### PR TITLE
Implement move positioning check

### DIFF
--- a/Assets/MusicalMoves/MusicalMoveSO.cs
+++ b/Assets/MusicalMoves/MusicalMoveSO.cs
@@ -35,6 +35,9 @@ public class MusicalMoveSO : ScriptableObject
     public float castDistance;
     public bool stayInPlace = false;
 
+    [Header("Placement autour de la cible")]
+    public RelativePosition relativePosition = RelativePosition.Front;
+
     [Header("VFX")]
     public GameObject introVFXPrefab;
     public GameObject hitVFXPrefab;
@@ -53,3 +56,5 @@ public class MusicalMoveSO : ScriptableObject
 }
 
 public enum MusicalEffectType { Damage, Heal, Buff, Debuff }
+
+public enum RelativePosition { Front, Back, Left, Right }

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -463,6 +463,11 @@ public class NewBattleManager : MonoBehaviour
     {
         Debug.Log($"{caster} exécute le mouvement {move.moveName} sur {target}");
         ToggleMenuContainers(false, false, false);
+        if (!HasSpaceForMove(caster, target, move))
+        {
+            Debug.LogWarning("[ExecuteMoveOnTarget] Pas assez d'espace pour executer le mouvement.");
+            yield break;
+        }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
         move.ApplyEffect(target);
         currentCharacterUnit.currentATB = 0f;
@@ -471,6 +476,33 @@ public class NewBattleManager : MonoBehaviour
     public IEnumerator UseItemOnTarget(ItemData item, CharacterUnit caster, CharacterUnit target)
     {
         yield return null;
+    }
+
+    private bool HasSpaceForMove(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)
+    {
+        Vector3 direction = target.transform.forward;
+        switch (move.relativePosition)
+        {
+            case RelativePosition.Back:
+                direction = -target.transform.forward;
+                break;
+            case RelativePosition.Left:
+                direction = -target.transform.right;
+                break;
+            case RelativePosition.Right:
+                direction = target.transform.right;
+                break;
+        }
+
+        Vector3 destination = target.transform.position + direction * move.castDistance;
+        Collider[] hits = Physics.OverlapSphere(destination, 0.5f);
+        foreach (var h in hits)
+        {
+            CharacterUnit cu = h.GetComponentInParent<CharacterUnit>();
+            if (cu != null && cu != caster && cu != target)
+                return false;
+        }
+        return true;
     }
 
     public void EndTurn()

--- a/Assets/Scripts/RhythmQTEManager.cs
+++ b/Assets/Scripts/RhythmQTEManager.cs
@@ -100,7 +100,21 @@ public class RhythmQTEManager : MonoBehaviour
         float elapsed = 0f;
         float maxDuration = move.maxRunDuration;
 
-        Vector3 targetPosition = target.transform.position + target.transform.forward * move.castDistance;
+        Vector3 offsetDir = target.transform.forward;
+        switch (move.relativePosition)
+        {
+            case RelativePosition.Back:
+                offsetDir = -target.transform.forward;
+                break;
+            case RelativePosition.Left:
+                offsetDir = -target.transform.right;
+                break;
+            case RelativePosition.Right:
+                offsetDir = target.transform.right;
+                break;
+        }
+
+        Vector3 targetPosition = target.transform.position + offsetDir * move.castDistance;
 
         Animator animator = caster.GetComponentInChildren<Animator>();
         animator.Play(move.musicalMoveRunAnimationName);


### PR DESCRIPTION
## Summary
- add `relativePosition` and enum in `MusicalMoveSO`
- update `RhythmQTEManager.MoveTo` to move relative to target
- verify space before executing move in `NewBattleManager`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685af2ed17b08325b2c42c11f6b0064a