### PR TITLE
Ajout du système de rage pour Lucian

### DIFF
--- a/Assets/Characters/Lucian/CharacterUnit_Lucian_Battle.prefab
+++ b/Assets/Characters/Lucian/CharacterUnit_Lucian_Battle.prefab
@@ -146,6 +146,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5387018186125168565}
   - component: {fileID: 2868098831747274196}
+  - component: {fileID: 6769647812387645000}
   m_Layer: 6
   m_Name: CharacterUnit_Lucian_Battle
   m_TagString: Player
@@ -185,6 +186,7 @@ MonoBehaviour:
   Data: {fileID: 0}
   hpBar: {fileID: 0}
   mpBar: {fileID: 0}
+  rageBar: {fileID: 0}
   characterType: 0
   currentHP: 0
   currentMP: 0
@@ -195,6 +197,18 @@ MonoBehaviour:
   currentATB: 0
   ATBMax: 100
   isReadyToParry: 0
+--- !u!114 &6769647812387645000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901204007372340786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2489b6fdd4b4a97ba03c619498bec01, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &3325568263149963469
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Characters/Lucian/Character_Lucian.asset
+++ b/Assets/Characters/Lucian/Character_Lucian.asset
@@ -25,6 +25,9 @@ MonoBehaviour:
   baseStrength: 1
   baseDefense: 1
   baseMusicalGauge: 0
+  baseRage: 0
+  maxRage: 100
+  rageDamageMultiplier: 0.1
   battleIdleAnimationName: Idle
   musicalAttacks:
   - {fileID: 11400000, guid: aa3a8aa7524d80e48b7cbfff02d64f32, type: 2}
@@ -36,6 +39,7 @@ MonoBehaviour:
   currentStrength: 1
   currentDefense: 1
   isPlayerControlled: 1
+  currentRage: 0
   hitSound: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Scripts/CharacterData.cs
+++ b/Assets/Scripts/CharacterData.cs
@@ -24,6 +24,9 @@ public class CharacterData : ScriptableObject, ITargetable
     public int baseStrength;
     public int baseDefense;
     public int baseMusicalGauge;
+    public int baseRage;
+    public int maxRage;
+    public float rageDamageMultiplier = 0.1f;
     public int baseReflex;
     public float baseMobility;
 
@@ -49,6 +52,7 @@ public class CharacterData : ScriptableObject, ITargetable
 
     public float currentReflex;
     public float currentMobility;
+    public int currentRage;
     // Ajoute une référence au GameObject source
     public MonoBehaviour owner;
 
@@ -60,6 +64,7 @@ public class CharacterData : ScriptableObject, ITargetable
         currentMP = baseMP;
         currentStrength = baseStrength;
         currentDefense = baseDefense;
+        currentRage = baseRage;
     }
 
     public Transform GetTransform()

--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -10,6 +10,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     [Header("UI Components")]
     public HPBar hpBar;
     public MPBar mpBar;
+    public RageBar rageBar;
 
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
@@ -19,6 +20,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
     public int currentHP;
     public int currentMP;
+    public int currentRage;
 
     public int currentStrength;
     public int currentDefense;
@@ -45,6 +47,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         // Initialisation des stats
         currentHP = Data.baseHP;
         currentMP = Data.baseMP;
+        currentRage = Data.baseRage;
         currentInitiative = Data.baseInitiative;
         currentStrength = Data.baseStrength;
         currentDefense = Data.baseDefense;
@@ -81,6 +84,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             mpBar.SetMaxValue(Data.baseMP);
             mpBar.SetValue(Data.currentMP);
         }
+        if (rageBar != null)
+        {
+            rageBar.SetMaxValue(Data.maxRage);
+            rageBar.SetValue(currentRage);
+        }
 
         // Instanciation de l’UI personnalisée
         if (Data.uiPrefab != null && Data.characterType == CharacterType.SquadUnit)
@@ -109,6 +117,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
         PlayDamageFeedback();
+        GetComponent<RageSystem>()?.AddRage(amount);
     }
 
     public void TakeParry()

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -470,6 +470,15 @@ public class NewBattleManager : MonoBehaviour
         }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
         move.ApplyEffect(target);
+        var rage = caster.GetComponent<RageSystem>();
+        if (rage != null && move.effectType == MusicalEffectType.Damage)
+        {
+            int bonus = rage.CalculateBonusDamage();
+            if (bonus > 0)
+            {
+                target.TakeDamage(bonus);
+            }
+        }
         currentCharacterUnit.currentATB = 0f;
     }
 

--- a/Assets/Scripts/RageBar.cs
+++ b/Assets/Scripts/RageBar.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Composant UI pour afficher la barre de rage d'une unité.
+/// </summary>
+public class RageBar : MonoBehaviour
+{
+    [Header("Référence Slider")]
+    public Slider slider;
+
+    public void SetMaxValue(int max)
+    {
+        if (slider != null)
+        {
+            slider.maxValue = max;
+            slider.value = max;
+        }
+    }
+
+    public void SetValue(int current)
+    {
+        if (slider != null)
+        {
+            slider.value = current;
+        }
+    }
+}

--- a/Assets/Scripts/RageBar.cs.meta
+++ b/Assets/Scripts/RageBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cd66fb8980644499bc0453a8a55e502

--- a/Assets/Scripts/RageSystem.cs
+++ b/Assets/Scripts/RageSystem.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CharacterUnit))]
+public class RageSystem : MonoBehaviour
+{
+    private CharacterUnit unit;
+
+    private void Awake()
+    {
+        unit = GetComponent<CharacterUnit>();
+    }
+
+    public void AddRage(int damage)
+    {
+        if (unit == null || unit.Data == null) return;
+        unit.currentRage = Mathf.Clamp(unit.currentRage + damage, unit.Data.baseRage, unit.Data.maxRage);
+        if (unit.rageBar != null)
+            unit.rageBar.SetValue(unit.currentRage);
+    }
+
+    public int CalculateBonusDamage()
+    {
+        if (unit == null || unit.Data == null) return 0;
+        return Mathf.RoundToInt(unit.currentRage * unit.Data.rageDamageMultiplier);
+    }
+}

--- a/Assets/Scripts/RageSystem.cs.meta
+++ b/Assets/Scripts/RageSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b2489b6fdd4b4a97ba03c619498bec01


### PR DESCRIPTION
## Résumé
- extension de `CharacterData` avec de nouveaux champs liés à la rage
- ajout de `currentRage` et d'une `RageBar` dans `CharacterUnit`
- nouveau composant `RageSystem` gérant l'augmentation de la rage et le bonus de dégâts
- prise en compte du bonus de rage dans `NewBattleManager`
- mise à jour des données et du prefab de Lucian

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c4e9b6618832593c974243d097a72