### PR TITLE
Ajout de Thalia et système de fatigue

### DIFF
--- a/Assets/Characters/Thalia.meta
+++ b/Assets/Characters/Thalia.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe38deb3d2484bc4b0f96498a54bb648
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Characters/Thalia/CharacterModel_Thalia_World.prefab
+++ b/Assets/Characters/Thalia/CharacterModel_Thalia_World.prefab
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: CharacterModel_Thalia_World
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0

--- a/Assets/Characters/Thalia/CharacterModel_Thalia_World.prefab.meta
+++ b/Assets/Characters/Thalia/CharacterModel_Thalia_World.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9156fc4daf8647e1afa202ad3db84f16
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Characters/Thalia/CharacterUnit_Thalia_Battle.prefab
+++ b/Assets/Characters/Thalia/CharacterUnit_Thalia_Battle.prefab
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  m_Layer: 0
+  m_Name: CharacterUnit_Thalia_Battle
+  m_TagString: Player
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &3
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1a6243e99064a64aaf011821904e16f, type: 3}
+  Data: {fileID: 0}
+  hpBar: {fileID: 0}
+  mpBar: {fileID: 0}
+  fatigueBar: {fileID: 0}
+  characterType: 0
+  currentHP: 0
+  currentMP: 0
+  currentStrength: 0
+  currentDefense: 0
+  currentReflex: 0
+  currentMobility: 0
+  currentMusicalGauge: 0
+  currentInitiative: 0
+  currentATB: 0
+  ATBMax: 100
+  isReadyToParry: 0
+  currentFatigue: 0
+--- !u!114 &4
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8f44137d6b74cfbb03cb6f8edbfa897, type: 3}
+  asleepDuration: 2

--- a/Assets/Characters/Thalia/CharacterUnit_Thalia_Battle.prefab.meta
+++ b/Assets/Characters/Thalia/CharacterUnit_Thalia_Battle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 79414cd7f4f145ed9d97b030cefc89e3
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Characters/Thalia/Character_Thalia.asset
+++ b/Assets/Characters/Thalia/Character_Thalia.asset
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbc0c89b53ea7e246ba03cfe31f29194, type: 3}
+  m_Name: Character_Thalia
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterData
+  characterName: Thalia
+  portrait: {fileID: 0}
+  characterType: 0
+  characterWorldModel: {fileID: 1, guid: 9156fc4daf8647e1afa202ad3db84f16, type: 3}
+  characterBattleModel: {fileID: 1, guid: 79414cd7f4f145ed9d97b030cefc89e3, type: 3}
+  uiPrefab: {fileID: 1, guid: e75d5223a4c441a39a1a9c09594a746e, type: 3}
+  baseInitiative: 1
+  baseRange: 5
+  baseHP: 80
+  baseMP: 40
+  baseStrength: 1
+  baseDefense: 1
+  baseMusicalGauge: 0
+  baseFatigue: 0
+  maxFatigue: 3
+  battleIdleAnimationName: Idle
+  musicalAttacks:
+  - {fileID: 11400000, guid: aa3a8aa7524d80e48b7cbfff02d64f32, type: 2}
+  currentInitiative: 1
+  currentRange: 0
+  currentHP: 80
+  currentMP: 40
+  currentStrength: 1
+  currentDefense: 1
+  isPlayerControlled: 1
+  hitSound: {fileID: 0}
+  hitEffect: {fileID: 0}
+  deathEffect: {fileID: 0}
+  owner: {fileID: 0}

--- a/Assets/Characters/Thalia/Character_Thalia.asset.meta
+++ b/Assets/Characters/Thalia/Character_Thalia.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd365be125cd443b82bfec8b6d4e0841
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Characters/Thalia/Thalia_UI.prefab
+++ b/Assets/Characters/Thalia/Thalia_UI.prefab
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  - component: {fileID: 4}
+  m_Layer: 5
+  m_Name: Thalia_UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_CullTransparentMesh: 1
+--- !u!114 &4
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e128988629e741849428d924de227e6b, type: 3}
+  slider: {fileID: 0}

--- a/Assets/Characters/Thalia/Thalia_UI.prefab.meta
+++ b/Assets/Characters/Thalia/Thalia_UI.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e75d5223a4c441a39a1a9c09594a746e
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CharacterData.cs
+++ b/Assets/Scripts/CharacterData.cs
@@ -24,6 +24,8 @@ public class CharacterData : ScriptableObject, ITargetable
     public int baseStrength;
     public int baseDefense;
     public int baseMusicalGauge;
+    public int baseFatigue;
+    public int maxFatigue;
     public int baseReflex;
     public float baseMobility;
 

--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -10,6 +10,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     [Header("UI Components")]
     public HPBar hpBar;
     public MPBar mpBar;
+    public FatigueBar fatigueBar;
 
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
@@ -26,6 +27,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentMobility;
 
     public int currentMusicalGauge;
+    public int currentFatigue;
 
     // Gestion de l'initiative
     public int currentInitiative;
@@ -51,6 +53,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         currentReflex = Data.baseReflex;
         currentMobility = Data.baseMobility;
         currentMusicalGauge = Data.baseMusicalGauge;
+        currentFatigue = Data.baseFatigue;
 
         spriteRenderer = GetComponent<SpriteRenderer>();
         audioSource = GetComponent<AudioSource>();
@@ -80,6 +83,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         {
             mpBar.SetMaxValue(Data.baseMP);
             mpBar.SetValue(Data.currentMP);
+        }
+        if (fatigueBar != null)
+        {
+            fatigueBar.SetMaxValue(Data.maxFatigue);
+            fatigueBar.SetValue(currentFatigue);
         }
 
         // Instanciation de l’UI personnalisée

--- a/Assets/Scripts/FatigueBar.cs
+++ b/Assets/Scripts/FatigueBar.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Composant UI pour afficher la barre de fatigue d'une unité.
+/// </summary>
+public class FatigueBar : MonoBehaviour
+{
+    [Header("Référence Slider")] 
+    public Slider slider;
+
+    public void SetMaxValue(int max)
+    {
+        if (slider != null)
+        {
+            slider.maxValue = max;
+            slider.value = 0;
+        }
+    }
+
+    public void SetValue(int value)
+    {
+        if (slider != null)
+            slider.value = value;
+    }
+}

--- a/Assets/Scripts/FatigueBar.cs.meta
+++ b/Assets/Scripts/FatigueBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e128988629e741849428d924de227e6b

--- a/Assets/Scripts/FatigueSystem.cs
+++ b/Assets/Scripts/FatigueSystem.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Gère la fatigue d'une unité. Lorsque la fatigue atteint un seuil, l'unité s'endort temporairement.
+/// </summary>
+public class FatigueSystem : MonoBehaviour
+{
+    private CharacterUnit unit;
+    public float asleepDuration = 2f;
+    private bool isAsleep;
+    private Coroutine routine;
+    public bool IsAsleep => isAsleep;
+
+    private void Awake()
+    {
+        unit = GetComponent<CharacterUnit>();
+    }
+
+    public void OnActionPerformed()
+    {
+        if (unit == null) return;
+        unit.currentFatigue++;
+        if (unit.fatigueBar != null)
+            unit.fatigueBar.SetValue(unit.currentFatigue);
+        if (unit.currentFatigue >= unit.Data.maxFatigue && routine == null)
+        {
+            routine = StartCoroutine(SleepRoutine());
+        }
+    }
+
+    private IEnumerator SleepRoutine()
+    {
+        isAsleep = true;
+        yield return new WaitForSeconds(asleepDuration);
+        unit.currentFatigue = unit.Data.baseFatigue;
+        if (unit.fatigueBar != null)
+            unit.fatigueBar.SetValue(unit.currentFatigue);
+        isAsleep = false;
+        routine = null;
+    }
+}

--- a/Assets/Scripts/FatigueSystem.cs.meta
+++ b/Assets/Scripts/FatigueSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8f44137d6b74cfbb03cb6f8edbfa897

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -403,6 +403,11 @@ public class NewBattleManager : MonoBehaviour
     {
         if (currentBattleState != BattleState.VictoryScreen_Await && currentBattleState != BattleState.VictoryScreen_CanContinue && currentBattleState != BattleState.GameOverScreen_Await && currentBattleState != BattleState.GameOverScreen_CanContinue)
         {
+            if (unit.TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
+            {
+                EndTurn();
+                yield break;
+            }
             isTurnResolving = true;
 
             // 1) On stocke l’unité qui jouait juste avant (champ de classe)
@@ -470,11 +475,15 @@ public class NewBattleManager : MonoBehaviour
         }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
         move.ApplyEffect(target);
+        caster.GetComponent<FatigueSystem>()?.OnActionPerformed();
         currentCharacterUnit.currentATB = 0f;
     }
 
     public IEnumerator UseItemOnTarget(ItemData item, CharacterUnit caster, CharacterUnit target)
     {
+        InventoryManager.Instance.UseItem(item, target);
+        caster.GetComponent<FatigueSystem>()?.OnActionPerformed();
+        currentCharacterUnit.currentATB = 0f;
         yield return null;
     }
 


### PR DESCRIPTION
## Résumé
- extension de `CharacterData` avec baseFatigue et maxFatigue
- ajout de `currentFatigue` et d'une `FatigueBar` dans `CharacterUnit`
- nouveau `FatigueSystem` gérant la fatigue et l'état d'endormissement
- gestion de la fatigue dans `NewBattleManager`
- ajout des assets et prefabs pour Thalia

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_685c4e9bb318832589c9a9f05af1a6a4