### PR TITLE
Correction du type de statistique

### DIFF
--- a/Assets/Scripts/CharacterData.cs
+++ b/Assets/Scripts/CharacterData.cs
@@ -31,7 +31,7 @@ public class CharacterData : ScriptableObject, ITargetable
     public float rageDamageMultiplier = 0.1f;
     public int baseReflex;
     public float baseMobility;
-    public float baseVitality;
+    public int baseVitality;
     public int basePower;
     public int baseStability;
     public int baseSagacity;


### PR DESCRIPTION
## Résumé
- corrige `baseVitality` pour qu'il utilise `int`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c5f8bbde48325b102ef78cfc83d50