### PR TITLE
Remove item and squad management from GameData

### DIFF
--- a/Assets/GameDatas/GameData.asset
+++ b/Assets/GameDatas/GameData.asset
@@ -12,13 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 0}
   m_Name: GameData
   m_EditorClassIdentifier: Assembly-CSharp::GameData
-  allCharacters:
-  - {fileID: 11400000, guid: e1caa78650838d34ea2f6c2f1361a5f3, type: 2}
-  - {fileID: 11400000, guid: 12f79091fcc9dac468a0b815f88bf248, type: 2}
-  squadCharacters:
-  - {fileID: 11400000, guid: e1caa78650838d34ea2f6c2f1361a5f3, type: 2}
-  allItems: []
-  inventoryItems: []
-  defeatedEnemies: 
+  defeatedEnemies:
   squadLevel: 0
   squadXP: 0

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -5,15 +5,6 @@ using UnityEngine;
 public class InventoryManager : MonoBehaviour
 {
     public static InventoryManager Instance { get; private set; }
-
-        if (GameManager.Instance != null && GameManager.Instance.gameData != null)
-        {
-            allItems = GameManager.Instance.gameData.allItems;
-            inventoryItems = GameManager.Instance.gameData.inventoryItems;
-        }
-
-            GameManager.Instance.gameData.inventoryItems.Add(item);
-        GameManager.Instance.gameData.inventoryItems.Remove(item);
     [Header("Tous les items du jeu (à assigner dans l’inspecteur ou à charger dynamiquement)")]
     [SerializeField] private List<ItemData> allItems = new();
 

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -251,7 +251,7 @@ public class NewBattleManager : MonoBehaviour
         }
 
         // Seuls les trois premiers membres de la squad peuvent participer au combat
-        var squad = GameManager.Instance.gameData.squadCharacters;
+        var squad = SquadManager.Instance != null ? SquadManager.Instance.SquadCharacters : new List<CharacterData>();
         int maxSquadMembers = Mathf.Min(3, squad.Count);
         for (int i = 0; i < maxSquadMembers && i < playerSpawnPoints.Count; i++)
         {

--- a/Assets/Scripts/SquadManager.cs
+++ b/Assets/Scripts/SquadManager.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SquadManager : MonoBehaviour
+{
+    public static SquadManager Instance { get; private set; }
+
+    [SerializeField] private List<CharacterData> squadCharacters = new();
+
+    public IReadOnlyList<CharacterData> SquadCharacters => squadCharacters;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    public void SetSquad(List<CharacterData> characters)
+    {
+        squadCharacters = new List<CharacterData>(characters);
+    }
+
+    public void MoveCharacter(int fromIndex, int toIndex)
+    {
+        if (fromIndex < 0 || fromIndex >= squadCharacters.Count ||
+            toIndex < 0 || toIndex >= squadCharacters.Count ||
+            fromIndex == toIndex)
+            return;
+
+        CharacterData cd = squadCharacters[fromIndex];
+        squadCharacters.RemoveAt(fromIndex);
+        squadCharacters.Insert(toIndex, cd);
+    }
+}


### PR DESCRIPTION
## Summary
- retire la gestion des items et des personnages de `GameData`
- déplace la gestion de l'inventaire dans `InventoryManager`
- nouvelle classe `SquadManager` pour gérer l'ordre de la squad
- met à jour `NewBattleManager` pour utiliser `SquadManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d82e833c483258587f0e6c6aa17da