### PR TITLE
Ajout vibration barres et lien UI-Timeline

### DIFF
--- a/Assets/Scripts/FatigueBar.cs
+++ b/Assets/Scripts/FatigueBar.cs
@@ -6,8 +6,14 @@ using UnityEngine.UI;
 /// </summary>
 public class FatigueBar : MonoBehaviour
 {
-    [Header("Référence Slider")] 
+    [Header("Référence Slider")]
     public Slider slider;
+
+    [Header("Effet de tremblement")]
+    public float shakeDuration = 0.15f;
+    public float shakeMagnitude = 2f;
+
+    private Coroutine shakeRoutine;
 
     public void SetMaxValue(int max)
     {
@@ -21,6 +27,41 @@ public class FatigueBar : MonoBehaviour
     public void SetValue(int value)
     {
         if (slider != null)
+        {
             slider.value = value;
+
+            if (value >= slider.maxValue)
+                TriggerShake();
+        }
+    }
+
+    private void TriggerShake()
+    {
+        if (shakeRoutine != null)
+            StopCoroutine(shakeRoutine);
+
+        shakeRoutine = StartCoroutine(ShakeCoroutine());
+    }
+
+    private IEnumerator ShakeCoroutine()
+    {
+        RectTransform target = slider.GetComponent<RectTransform>();
+        if (target == null)
+            yield break;
+
+        Vector3 originalPos = target.localPosition;
+        float elapsed = 0f;
+
+        while (elapsed < shakeDuration)
+        {
+            float x = Random.Range(-shakeMagnitude, shakeMagnitude);
+            float y = Random.Range(-shakeMagnitude, shakeMagnitude);
+            target.localPosition = originalPos + new Vector3(x, y, 0f);
+            elapsed += Time.unscaledDeltaTime;
+            yield return null;
+        }
+
+        target.localPosition = originalPos;
+        shakeRoutine = null;
     }
 }

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -608,6 +608,16 @@ currentCharacterUnit.currentATB = 0f;
             var ui = slot.GetComponent<BattleTimelineUnit>();
             ui.Initialize(unit);
             timelineUIObjects.Add(ui);
+
+            // Attache l'UI personnalisée de l'unité à sa timeline
+            Transform customUI = unit.transform.Find("SquadUnit_UI");
+            if (customUI != null)
+            {
+                customUI.SetParent(slot.transform, worldPositionStays: false);
+                customUI.localPosition = Vector3.zero;
+                customUI.localRotation = Quaternion.identity;
+                customUI.localScale = Vector3.one;
+            }
         }
     }
 

--- a/Assets/Scripts/RageBar.cs
+++ b/Assets/Scripts/RageBar.cs
@@ -9,6 +9,12 @@ public class RageBar : MonoBehaviour
     [Header("Référence Slider")]
     public Slider slider;
 
+    [Header("Effet de tremblement")]
+    public float shakeDuration = 0.15f;
+    public float shakeMagnitude = 2f;
+
+    private Coroutine shakeRoutine;
+
     public void SetMaxValue(int max)
     {
         if (slider != null)
@@ -23,6 +29,39 @@ public class RageBar : MonoBehaviour
         if (slider != null)
         {
             slider.value = current;
+
+            if (current >= slider.maxValue)
+                TriggerShake();
         }
+    }
+
+    private void TriggerShake()
+    {
+        if (shakeRoutine != null)
+            StopCoroutine(shakeRoutine);
+
+        shakeRoutine = StartCoroutine(ShakeCoroutine());
+    }
+
+    private IEnumerator ShakeCoroutine()
+    {
+        RectTransform target = slider.GetComponent<RectTransform>();
+        if (target == null)
+            yield break;
+
+        Vector3 originalPos = target.localPosition;
+        float elapsed = 0f;
+
+        while (elapsed < shakeDuration)
+        {
+            float x = Random.Range(-shakeMagnitude, shakeMagnitude);
+            float y = Random.Range(-shakeMagnitude, shakeMagnitude);
+            target.localPosition = originalPos + new Vector3(x, y, 0f);
+            elapsed += Time.unscaledDeltaTime;
+            yield return null;
+        }
+
+        target.localPosition = originalPos;
+        shakeRoutine = null;
     }
 }


### PR DESCRIPTION
## Résumé
- fait trembler les FatigueBar et RageBar quand leur valeur atteint le maximum
- rattache les UI des personnages à leur élément de timeline lors de l'initialisation

## Tests
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_685d937628288325a7564a7e78b05755