### PR TITLE
Fix Time.timeScale negative bug

### DIFF
--- a/Assets/Scripts/BattleTransitionManager.cs
+++ b/Assets/Scripts/BattleTransitionManager.cs
@@ -242,9 +242,11 @@ public class BattleTransitionManager : MonoBehaviour
 
         while (Time.timeScale - to > epsilon)
         {
-            Time.timeScale -= Time.unscaledDeltaTime * speed;
-            if (Time.timeScale <= to + epsilon)
-                Time.timeScale = to;
+            float newScale = Time.timeScale - Time.unscaledDeltaTime * speed;
+            if (newScale <= to + epsilon)
+                newScale = to;
+            // Empêche toute valeur négative due au calcul
+            Time.timeScale = Mathf.Max(0f, newScale);
 
             yield return new WaitForEndOfFrame();
         }


### PR DESCRIPTION
## Summary
- évite d'assigner une valeur négative à `Time.timeScale`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d9bc4c6e88325940c4c780e8bb8d5