### PR TITLE
Add rage & fatigue gameplay logic

### DIFF
--- a/Assets/MusicalMoves/MusicalMoveSO.cs
+++ b/Assets/MusicalMoves/MusicalMoveSO.cs
@@ -57,10 +57,9 @@ public class MusicalMoveSO : ScriptableObject
             target.Heal(finalValue);
         }
 
-        if(caster.Data.gameplayType == GameplayType.Fatigue)
+        if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
-            Debug.Log($"Applying fatigue effect: {finalValue} to {caster.name}");
-            caster.currentRage += finalValue;
+            caster.GetComponent<FatigueSystem>()?.OnActionPerformed(fatigueCost);
         }
     }
 }

--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -116,7 +116,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         Data.currentHP = currentHP;
         if (hpBar != null) hpBar.SetValue(currentHP);
         PlayDamageFeedback();
-        GetComponent<RageSystem>()?.AddRage(amount);
+        if (Data != null && Data.gameplayType == GameplayType.Rage)
+        {
+            GetComponent<RageSystem>()?.AddRage(amount);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/FatigueSystem.cs
+++ b/Assets/Scripts/FatigueSystem.cs
@@ -17,10 +17,12 @@ public class FatigueSystem : MonoBehaviour
         unit = GetComponent<CharacterUnit>();
     }
 
-    public void OnActionPerformed()
+    public void OnActionPerformed(float amount = 1f)
     {
-        if (unit == null) return;
-        unit.currentFatigue++;
+        if (unit == null || unit.Data == null) return;
+        if (unit.Data.gameplayType != GameplayType.Fatigue) return;
+
+        unit.currentFatigue = Mathf.Clamp(unit.currentFatigue + amount, unit.Data.baseFatigue, unit.Data.maxFatigue);
         if (unit.customBar != null)
             unit.customBar.SetValue(unit.currentFatigue);
         if (unit.currentFatigue >= unit.Data.maxFatigue && routine == null)

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -499,7 +499,6 @@ public class NewBattleManager : MonoBehaviour
             yield break;
         }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
-        caster.GetComponent<FatigueSystem>()?.OnActionPerformed();
         move.ApplyEffect(caster, target);
 
         // Ajout du système de rage manuellement


### PR DESCRIPTION
## Summary
- check gameplay type before adding rage
- track fatigue via FatigueSystem with optional amount
- apply fatigue cost when a move is executed
- avoid duplicate fatigue handling

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685db3d2ede08325a5e7c05c8de9d115