### PR TITLE
Maintien des HP entre combats

### DIFF
--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -56,7 +56,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         currentStability = Data.baseStability;
         currentVitality = Data.baseVitality;
         currentSagacity = Data.baseSagacity;
-        currentHP = Data.baseHP + currentVitality;
+        // Les HP doivent rester persistants entre les combats
+        if (Data.currentHP <= 0)
+            Data.currentHP = Data.baseHP + currentVitality;
+        currentHP = Data.currentHP;
         currentRage = Data.baseRage;
         currentInitiative = Data.baseInitiative;
         currentStrength = Data.baseStrength;


### PR DESCRIPTION
## Résumé
- préserve les HP actuels lors de l'initialisation d'une `CharacterUnit`
- réinitialise les autres statistiques comme avant

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e3ab83fe48325926e4150af3f4ffc