### PR TITLE
Fix combat auto restart

### DIFF
--- a/Assets/Scripts/BattleTransitionManager.cs
+++ b/Assets/Scripts/BattleTransitionManager.cs
@@ -176,7 +176,7 @@ public class BattleTransitionManager : MonoBehaviour
         GameManager.Instance.ChangeGameState(GameState.Exploration);
 
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
-        playerDetection.ResetDetection();
+        playerDetection.ResetDetection(1f);
 
         battleRevealMask.SetActive(true);
         RectTransform maskRect = battleRevealMask.GetComponent<RectTransform>();

--- a/Assets/Scripts/PlayerDetection.cs
+++ b/Assets/Scripts/PlayerDetection.cs
@@ -125,13 +125,23 @@ public class PlayerDetection : MonoBehaviour
     /// Réinitialise tous les paramètres de détection aux valeurs de base,
     /// pour repartir proprement après un combat.
     /// </summary>
-    public void ResetDetection()
+    public void ResetDetection(float delay = 1f)
+    {
+        StartCoroutine(ResetDetectionRoutine(delay));
+    }
+
+    private IEnumerator ResetDetectionRoutine(float delay)
     {
         currentDetectionRadius = baseDetectionRadius;
-        detectionOn = true;
         battleEngaged = false;
         detectedEnemies.Clear();
+        detectionOn = false;
 
+        Debug.Log($"[PlayerDetection] Réinitialisation en cours, détection réactivée dans {delay} s.");
+
+        yield return new WaitForSeconds(delay);
+
+        detectionOn = true;
         Debug.Log("[PlayerDetection] Détection réinitialisée.");
     }
 


### PR DESCRIPTION
## Summary
- fix PlayerDetection reset to wait before re-enabling detection
- call new delayed reset when exiting battle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e41c8abc48325884b02ff4514ca19