### PR TITLE
Ajout d'une méthode StartPathFollow étendue

### DIFF
--- a/Assets/CameraPath.cs
+++ b/Assets/CameraPath.cs
@@ -260,6 +260,32 @@ public bool triggered;
         return total;
     }
 
+    /// <summary>
+    /// Retourne la position normalisée sur le chemin la plus proche du point donné.
+    /// </summary>
+    public float GetClosestPathPosition(Vector3 worldPos, int samples = 20)
+    {
+        if (points.Count < 2)
+            return 0f;
+
+        float bestT = 0f;
+        float bestDist = float.MaxValue;
+
+        for (int i = 0; i <= samples; i++)
+        {
+            float t = (float)i / samples;
+            Vector3 p = EvaluatePosition(t);
+            float dist = Vector3.Distance(worldPos, p);
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                bestT = t;
+            }
+        }
+
+        return bestT;
+    }
+
     #region Lecture de la séquence
     /// <summary>
     /// Lance la lecture de la trajectoire par la caméra associée.

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -32,6 +32,9 @@ public class CameraController : MonoBehaviour
     private float pathElapsedTime = 0f;
     private float pathTotalDuration = 0f;
 
+    private bool forceLookAt;
+    private Transform forcedLookTarget;
+
     [Header("Managed Cameras")]
     public CameraState currentCameraState = CameraState.ResearchClosestCamPoint; // ✅ Par défaut en recherche de point
     public List<Camera> managedCameras = new();
@@ -159,6 +162,11 @@ public class CameraController : MonoBehaviour
         Quaternion rot;
         currentCameraPath.EvaluatePath(pathPosition, out pos, out rot);
 
+        if (forceLookAt && forcedLookTarget != null)
+        {
+            rot = Quaternion.LookRotation(forcedLookTarget.position - pos);
+        }
+
         activeCamera.transform.position = Vector3.Lerp(activeCamera.transform.position, pos, followLerpSpeed * Time.deltaTime);
         activeCamera.transform.rotation = Quaternion.Slerp(activeCamera.transform.rotation, rot, rotateLerpSpeed * Time.deltaTime);
 
@@ -203,6 +211,23 @@ public class CameraController : MonoBehaviour
             activeCamera.transform.position = pos;
             activeCamera.transform.rotation = rot;
         }
+
+        forceLookAt = false;
+        forcedLookTarget = null;
+    }
+
+    public void StartPathFollow(CameraPath path, string cameraTag, Transform pathPositionTransform, bool forcelookAtTarget, Transform targetToLook, bool alignImmediately = false)
+    {
+        float startPos = 0f;
+        if (pathPositionTransform != null)
+        {
+            startPos = path.GetClosestPathPosition(pathPositionTransform.position);
+        }
+
+        StartPathFollow(path, cameraTag, startPos, alignImmediately);
+
+        forceLookAt = forcelookAtTarget;
+        forcedLookTarget = targetToLook;
     }
 
     public void StopPathFollow()
@@ -215,6 +240,8 @@ public class CameraController : MonoBehaviour
 
         isFollowingPath = false;
         activeCamera = null;
+        forceLookAt = false;
+        forcedLookTarget = null;
     }
 
     #endregion


### PR DESCRIPTION
## Résumé
- prise en charge d'un suivi de chemin démarré depuis un Transform
- ajout d'une option pour forcer le LookAt vers une cible
- logique correspondante dans `CameraController`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4cd270488325b472a95e79473794