### PR TITLE
Fix camera handling conflicts

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -1401,6 +1401,12 @@ currentCharacterUnit.currentATB = 0f;
             }
         }
 
+        CameraController cc = CameraController.Instance;
+        if (cc != null && (cc.IsFollowingPath || cc.currentCameraState != CameraState.ResearchClosestCamPoint))
+        {
+            return; // Laisse la main au CameraController pour éviter les conflits
+        }
+
         if (isFollowingCurrentTarget && currentCharacterUnit != null && currentTargetCharacter != null)
         {
             Vector3 midPoint = (currentCharacterUnit.transform.position + currentTargetCharacter.transform.position) / 2f;


### PR DESCRIPTION
## Summary
- éviter le mouvement de la caméra du script NewBattleManager quand le CameraController contrôle déjà la caméra

## Testing
- `dotnet --version` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_685e5567b5a48325aaf4854b6ba550a6