### PR TITLE
Gestion prioritaire des CameraPath

### DIFF
--- a/Assets/EventSignalReceiver.cs
+++ b/Assets/EventSignalReceiver.cs
@@ -11,7 +11,7 @@ public class EventSignalReceiver : MonoBehaviour
 
     private void Start()
     {
-        // Cache le joueur pour Èviter le Find() en boucle
+        // Cache le joueur pour √©viter le Find() en boucle
         GameObject player = GameObject.FindGameObjectWithTag("Player");
         if (player != null)
         {
@@ -23,7 +23,7 @@ public class EventSignalReceiver : MonoBehaviour
     {
         if (playerTransform != null && moveDirection != Vector3.zero)
         {
-            // DÈplace dans l'espace local du joueur (avant, arriËre, cÙtÈ)
+            // D√©place dans l'espace local du joueur (avant, arri√®re, c√¥t√©)
             Vector3 localMove = playerTransform.TransformDirection(moveDirection);
             playerTransform.position += localMove * moveSpeed * Time.deltaTime;
         }
@@ -61,6 +61,11 @@ public class EventSignalReceiver : MonoBehaviour
             Debug.LogWarning("[EventSignalReceiver] CameraPath non fourni !");
             return;
         }
+        if (CameraController.IsAnyPathPlaying)
+        {
+            Debug.Log("[EventSignalReceiver] CameraPath d√©j√† en cours - s√©quence ignor√©e.");
+            return;
+        }
 
         CameraController.Instance.StartPathFollow(path, path.cameraTag);
     }
@@ -76,12 +81,12 @@ public class EventSignalReceiver : MonoBehaviour
             }
             else
             {
-                Debug.LogWarning("[EventSignalReceiver] PlayerDetection non trouvÈ sur le joueur !");
+                Debug.LogWarning("[EventSignalReceiver] PlayerDetection non trouv√© sur le joueur !");
             }
         }
         else
         {
-            Debug.LogWarning("[EventSignalReceiver] Joueur non trouvÈ !");
+            Debug.LogWarning("[EventSignalReceiver] Joueur non trouv√© !");
         }
     }
 }

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -14,6 +14,12 @@ public class CameraController : MonoBehaviour
 {
     public static CameraController Instance { get; private set; }
 
+    /// <summary>
+    /// Indique si un CameraPath est actuellement suivi.
+    /// Permet aux autres scripts de connaître la priorité caméra.
+    /// </summary>
+    public static bool IsAnyPathPlaying => Instance != null && Instance.isFollowingPath;
+
     private Coroutine currentTransition;
 
     [Header("Orbit Settings")]
@@ -181,6 +187,12 @@ public class CameraController : MonoBehaviour
     /// </summary>
     public void StartPathFollow(CameraPath path, string cameraTag, float startPosition = 0f, bool alignImmediately = true)
     {
+        if (isFollowingPath)
+        {
+            Debug.Log("[CameraController] CameraPath déjà en cours, appel ignoré.");
+            return;
+        }
+
         StopOrbit();
 
         Camera cam = FindCameraByTag(cameraTag);
@@ -252,6 +264,12 @@ public class CameraController : MonoBehaviour
     /// </summary>
     public void OrbitAround(string cameraTag, Transform target, float distance = 5f, float speed = 30f, bool x = false, bool y = true, bool z = false)
     {
+        if (isFollowingPath)
+        {
+            Debug.Log("[CameraController] CameraPath en cours - OrbitAround ignoré.");
+            return;
+        }
+
         StopOrbit();
         StopPathFollow();
 
@@ -328,6 +346,12 @@ public class CameraController : MonoBehaviour
     /// </summary>
     public Coroutine SetCameraTarget(string positionName, string lookAtName, float transitionSpeed = 2f)
     {
+        if (isFollowingPath)
+        {
+            Debug.Log("[CameraController] CameraPath en cours - SetCameraTarget ignoré.");
+            return null;
+        }
+
         StopOrbit();
         StopPathFollow();
 
@@ -379,6 +403,12 @@ public class CameraController : MonoBehaviour
     /// </summary>
     public void ForceCam()
     {
+        if (isFollowingPath)
+        {
+            Debug.Log("[CameraController] CameraPath en cours - ForceCam ignoré.");
+            return;
+        }
+
         StopOrbit();
         StopPathFollow();
 

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -1477,6 +1477,11 @@ currentCharacterUnit.currentATB = 0f;
             Debug.LogError("[FirstStrike] CameraController manquant pour la caméra de combat !");
             return;
         }
+        if (CameraController.IsAnyPathPlaying)
+        {
+            Debug.Log("[FirstStrike] CameraPath déjà en cours - intro ignorée.");
+            return;
+        }
 
         firstStrikeCameraPath.IsPlaying = true;
         firstStrikeCameraPath.triggered = true;


### PR DESCRIPTION
## Summary
- expose `IsAnyPathPlaying` dans `CameraController`
- ignore les demandes de `StartPathFollow` si un chemin est déjà en cours
- empêchez `OrbitAround`, `SetCameraTarget` et `ForceCam` d'interrompre un `CameraPath`
- vérifiez l'état global dans `EventSignalReceiver` et `NewBattleManager`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685e574a5b788325acb07a314d0fe15c