### PR TITLE
Fix first strike camera release

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -1501,7 +1501,7 @@ currentCharacterUnit.currentATB = 0f;
     {
         ChangeBattleState(BattleState.FirstStrikeSequence);
         PlayFirstStrikeSequence(player);
-        yield return new WaitUntil(() => !CameraController.IsAnyPathPlaying);
+        yield return new WaitUntil(() => !firstStrikeCameraPath.IsPlaying);
         StartCoroutine(TurnLoop());
     }
 


### PR DESCRIPTION
## Summary
- ensure first-strike camera sequence waits for its own CameraPath completion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e64dfbe9083259e57742d69717dc4