### PR TITLE
Fix first strike camera path position

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -1467,6 +1467,10 @@ currentCharacterUnit.currentATB = 0f;
         if (player == null || firstStrikeCameraPath == null)
             return;
 
+        // Positionne le GameObject du CameraPath sur l'unité qui initie le combat
+        firstStrikeCameraPath.transform.position = player.transform.position;
+        firstStrikeTransform = player.transform;
+
         foreach (var point in firstStrikeCameraPath.points)
         {
             if (point.useLookAt)


### PR DESCRIPTION
## Summary
- place the first strike camera path on the first player before launching the sequence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e72ad84b083259d47a07f4e1832da