### PR TITLE
Fix StartPathFollow calls

### DIFF
--- a/Assets/CameraPath.cs
+++ b/Assets/CameraPath.cs
@@ -320,7 +320,7 @@ public bool triggered;
 
         IsPlaying = true; // ✅ Marque comme en cours de suivi
         triggered = true; // ✅ Marque comme déclenché
-        controller.StartPathFollow(this, cameraTag, startPosition);
+        controller.StartPathFollow(this);
     }
 
     /// <summary>

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -417,8 +417,14 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator FirstStrikeSequenceRoutine(CharacterUnit unit)
     {
         ChangeBattleState(BattleState.FirstStrikeSequence);
-        Transform target = FindChildRecursive(unit, "spine_03");
-        CameraController.Instance.StartPathFollow(firstStrikeCameraPath, unit.transform, true, target, false);
+        Transform target = FindChildRecursive(unit.transform, "spine_03");
+        CameraController.Instance.StartPathFollow(
+            firstStrikeCameraPath,
+            unit.transform,
+            forceLook: true,
+            targetToLook: target,
+            alignImmediately: false
+        );
         yield return new WaitForSeconds(firstStrikeCameraPath.GetTotalDuration());
     }
 


### PR DESCRIPTION
## Summary
- utilise `unit.transform` au lieu de `unit` dans FirstStrikeSequenceRoutine
- appelle `StartPathFollow` avec paramètres nommés pour plus de clarté
- supprime les arguments obsolètes lors du lancement d'un `CameraPath`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e9a8fe3b083259db7be90a87ff3bb