### PR TITLE
Fix camera state after first strike sequence

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -472,15 +472,15 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
-        if (characterUnit.Data.characterType == CharacterType.SquadUnit)
-            ChangeBattleState(BattleState.SquadUnit_MainMenu);
-        else if (characterUnit.Data.characterType == CharacterType.EnemyUnit)
-            ChangeBattleState(BattleState.EnemyUnit_Reflexion);
-
         if (currentCharacterUnit != null)
             ToggleMenuContainers(false, false, false);
 
         ChangeCurrentCharacterUnit(characterUnit);
+
+        if (characterUnit.Data.characterType == CharacterType.SquadUnit)
+            ChangeBattleState(BattleState.SquadUnit_MainMenu);
+        else if (characterUnit.Data.characterType == CharacterType.EnemyUnit)
+            ChangeBattleState(BattleState.EnemyUnit_Reflexion);
 
         SetupCurrentUnitMenus(); // prépare les panels de l’unité
         ShowMainMenu(); // montre le menu principal


### PR DESCRIPTION
## Summary
- fix `StartSquadUnitTurn` order so current unit is set before updating state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e9df3f3a883259b29db39a8fdabc6