### PR TITLE
Bugfix: ensure BattleCamera moves to MainMenu position

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -478,6 +478,11 @@ public class NewBattleManager : MonoBehaviour
 
         ChangeCurrentCharacterUnit(characterUnit);
 
+        // S'assure que la BattleCamera peut se déplacer librement
+        CameraController cc = CameraController.Instance;
+        if (cc != null && cc.currentWorldCameraState != WorldCameraState.ResearchClosestCamPoint)
+            cc.ReleaseCam();
+
         if (characterUnit.Data.characterType == CharacterType.SquadUnit)
             ChangeBattleState(BattleState.SquadUnit_MainMenu);
         else if (characterUnit.Data.characterType == CharacterType.EnemyUnit)


### PR DESCRIPTION
## Summary
- release forced camera states when a player's turn begins so battle camera can reposition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ea1f095b483258035385f37a5e6a1