### PR TITLE
Ajout du texte "Indisponible" pour les slots vides

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -1049,11 +1049,11 @@ public class NewBattleManager : MonoBehaviour
             var move = skillChoices[i];
             UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
         }
-        // Désactive les slots restants
+
+        // Indique les emplacements vides
         for (int j = skillChoices.Count; j < currentSkillsMenuSlots.Count; j++)
         {
-            if (currentSkillsMenuSlots[j].childCount > 0)
-                currentSkillsMenuSlots[j].GetChild(0).gameObject.SetActive(false);
+            UpdateButton(currentSkillsMenuSlots[j], "Indisponible", null);
         }
     }
 
@@ -1071,6 +1071,12 @@ public class NewBattleManager : MonoBehaviour
         {
             var item = itemChoices[i];
             UpdateButton(currentItemsMenuSlots[i], item.itemName, item.itemIcon);
+        }
+
+        // Indique les emplacements vides
+        for (int j = itemChoices.Count; j < currentItemsMenuSlots.Count; j++)
+        {
+            UpdateButton(currentItemsMenuSlots[j], "Indisponible", null);
         }
     }
 


### PR DESCRIPTION
## Résumé
- affiche "Indisponible" pour les emplacements de compétences et d'objets lorsqu'il n'y a rien à afficher

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ebdce1c1c83258e7d12fae09ca096