### PR TITLE
Ajout FirstStrikeEffect

### DIFF
--- a/Assets/Prefabs/FirstStrikeEffect.prefab
+++ b/Assets/Prefabs/FirstStrikeEffect.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  m_Layer: 0
+  m_Name: FirstStrikeEffect
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 100010}
+  - {fileID: 100020}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1e3f9c79b2a4de5bce1c74a1f95788b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1 &100009
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100010}
+  m_Layer: 0
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100010
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100009}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 100001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &100019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100020}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100020
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100019}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 100001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/FirstStrikeEffect.prefab.meta
+++ b/Assets/Prefabs/FirstStrikeEffect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1b4e5c63c6bd40e088ef5c2e3c765d3b
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/FirstStrikeEffect.cs
+++ b/Assets/Scripts/FirstStrikeEffect.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Fait apparaitre un effet "First Strike" depuis la droite de l'écran,
+/// applique un ralenti puis le fait disparaître vers la gauche.
+/// </summary>
+public class FirstStrikeEffect : MonoBehaviour
+{
+    [Header("Déplacement")]
+    public float startX = 2000f;
+    public float endX = -2000f;
+    public float speed = 1000f;
+
+    [Header("Ralenti")]
+    public float slowMotionScale = 0.3f;
+    public float slowMotionDuration = 0.5f;
+
+    private float initialTimeScale;
+
+    private void OnEnable()
+    {
+        Vector3 pos = transform.position;
+        pos.x = startX;
+        transform.position = pos;
+
+        initialTimeScale = Time.timeScale;
+        StartCoroutine(SlowMotion());
+    }
+
+    private IEnumerator SlowMotion()
+    {
+        Time.timeScale = slowMotionScale;
+        yield return new WaitForSecondsRealtime(slowMotionDuration);
+        Time.timeScale = initialTimeScale;
+    }
+
+    private void Update()
+    {
+        transform.position += Vector3.left * speed * Time.unscaledDeltaTime;
+
+        if (transform.position.x <= endX)
+            Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/FirstStrikeEffect.cs.meta
+++ b/Assets/Scripts/FirstStrikeEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1e3f9c79b2a4de5bce1c74a1f95788b


### PR DESCRIPTION
## Résumé
- ajoute un script `FirstStrikeEffect` pilotant l'apparition depuis la droite, un court ralenti puis la disparition vers la gauche
- crée le prefab `FirstStrikeEffect` avec les GameObjects `Background` et `Text`

## Tests
- aucune suite de tests fournie dans le dépôt

------
https://chatgpt.com/codex/tasks/task_e_685ed4fbf0c48325a1c76d2e6ac8a766