### PR TITLE
Mise à jour du FirstStrikeEffect

### DIFF
--- a/Assets/Scripts/FirstStrikeEffect.cs
+++ b/Assets/Scripts/FirstStrikeEffect.cs
@@ -40,6 +40,6 @@ public class FirstStrikeEffect : MonoBehaviour
         transform.position += Vector3.left * speed * Time.unscaledDeltaTime;
 
         if (transform.position.x <= endX)
-            Destroy(gameObject);
+            gameObject.SetActive(false);
     }
 }

--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -77,6 +77,7 @@ public class NewBattleManager : MonoBehaviour
 
     [Header("Début de combat")]
     [SerializeField] private CameraPath firstStrikeCameraPath;
+    [SerializeField] private GameObject firstStrikeEffect;
 
     [Header("Fin de combat")]
     public GameObject victoryScreen;
@@ -419,6 +420,12 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator FirstStrikeSequenceRoutine(CharacterUnit unit)
     {
         ChangeBattleState(BattleState.FirstStrikeSequence);
+        if (firstStrikeEffect == null)
+            firstStrikeEffect = GameObject.Find("FirstStrikeEffect");
+        if (firstStrikeEffect != null)
+            firstStrikeEffect.SetActive(true);
+        else
+            Debug.LogWarning("[BattleTurnManager] FirstStrikeEffect introuvable.");
         Transform target = FindChildRecursive(unit.transform, "spine_03");
         Transform position = FindChildRecursive(unit.transform, "spine_03");
         CameraController.Instance.StartPathFollow(


### PR DESCRIPTION
## Résumé
- désactive l'objet `FirstStrikeEffect` au lieu de le détruire
- active `FirstStrikeEffect` lors du lancement de la caméra `FirstStrike`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ed996074c8325bd41f9ea77f836ca