### PR TITLE
Ajout vérification de portée

### DIFF
--- a/Assets/Scripts/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/ActionUIDisplayManager.cs
@@ -90,6 +90,11 @@ public class ActionUIDisplayManager : MonoBehaviour
         ShowMessage("Appuyez en rythme !");
     }
 
+    public void DisplayInstruction_TargetTooFar()
+    {
+        ShowMessage("Cible trop éloignée");
+    }
+
     private void ShowMessage(string message)
     {
         if (currentDisplayRoutine != null)

--- a/Assets/Scripts/InputsManager.cs
+++ b/Assets/Scripts/InputsManager.cs
@@ -107,12 +107,22 @@ public class InputsManager : MonoBehaviour
         NewBattleManager bm = NewBattleManager.Instance;
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill)
         {
+            if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentMove))
+            {
+                ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
+                return;
+            }
             bm.ChangeBattleState(BattleState.SquadUnit_PerformingMusicalMove);
             bm.StartCoroutine(bm.ExecuteMoveOnTarget(bm.currentMove, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem)
         {
+            if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentItem))
+            {
+                ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
+                return;
+            }
             bm.ChangeBattleState(BattleState.SquadUnit_UseItem);
             bm.StartCoroutine(bm.UseItemOnTarget(bm.currentItem, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);


### PR DESCRIPTION
## Summary
- affiche un message "Cible trop éloignée" si la cible est hors de portée
- empêche le lancement d'une action ou d'un objet quand la portée est insuffisante

## Testing
- `dotnet --version` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68600a880638832585599acf3d9e747d