### PR TITLE
Implémente l'animation d'interception

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -716,6 +716,13 @@ public class NewBattleManager : MonoBehaviour
     {
         if (interceptor == null) yield break;
 
+        // Trigger the "intercepted" animation on the caster
+        var casterAnim = caster.GetComponentInChildren<Animator>();
+        if (casterAnim != null)
+        {
+            casterAnim.SetTrigger("intercepted");
+        }
+
         var move = interceptor.GetRandomMusicalAttack();
         if (move != null)
         {


### PR DESCRIPTION
## Résumé
- ajoute le déclenchement de l'animation `intercepted` sur l'unité interceptée
- l'animation est jouée au début de la routine d'interception
- la fin de tour est déjà gérée via `MusicalMoveRoutine`

## Tests
- `grep -n "SetTrigger" -R`

------
https://chatgpt.com/codex/tasks/task_e_6860129d22288325b422890464fa686b