### PR TITLE
Ajoute CameraPath sur moves et items

### DIFF
--- a/Assets/MusicalMoves/MusicalMoveSO.cs
+++ b/Assets/MusicalMoves/MusicalMoveSO.cs
@@ -48,6 +48,10 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("VFX joué au point d'arrivée de la téléportation")]
     public GameObject teleportEndVFXPrefab;
 
+    [Header("Camera")]
+    [Tooltip("Trajectoire de caméra à instancier lors de l'utilisation du move")]
+    public GameObject cameraPathPrefab;
+
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {
         float finalValue = effectValue;

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -73,6 +73,24 @@ public class InventoryManager : MonoBehaviour
         }
 
         Debug.Log($"[Inventory] Utilisation de l'objet : {item.itemName} sur {target.Data.characterName}");
+
+        if (item.cameraPathPrefab != null && target != null
+            && NewBattleManager.Instance != null
+            && NewBattleManager.Instance.currentBattleState != BattleState.None)
+        {
+            GameObject pathGO = Instantiate(item.cameraPathPrefab, target.transform.position, target.transform.rotation, target.transform);
+            CameraPath camPath = pathGO.GetComponent<CameraPath>();
+            if (camPath != null)
+            {
+                CameraController.Instance.StartPathFollow(camPath, target, alignImmediately: false);
+                Destroy(pathGO, camPath.GetTotalDuration() + 0.5f);
+            }
+            else
+            {
+                Debug.LogWarning("[InventoryManager] CameraPath component manquant sur le prefab de l'item.");
+            }
+        }
+
         item.ApplyEffect(target);
         inventoryItems.Remove(item);
     }

--- a/Assets/Scripts/ItemData.cs
+++ b/Assets/Scripts/ItemData.cs
@@ -48,6 +48,10 @@ public class ItemData : ScriptableObject
     [Header("VFX")]
     public GameObject introVFXPrefab;
 
+    [Header("Camera")]
+    [Tooltip("Trajectoire de caméra à instancier lors de l'utilisation de l'item")]
+    public GameObject cameraPathPrefab;
+
     [Header("QTE Pattern")]
     public List<float> beatPattern;
 

--- a/Assets/Scripts/RhythmQTEManager.cs
+++ b/Assets/Scripts/RhythmQTEManager.cs
@@ -59,6 +59,21 @@ public class RhythmQTEManager : MonoBehaviour
         Debug.Log("Début de la séquence du MusicalMove: " + move + " de " + caster.name);
         isActive = true;
 
+        if (move.cameraPathPrefab != null && target != null)
+        {
+            GameObject pathGO = Instantiate(move.cameraPathPrefab, target.transform.position, target.transform.rotation, target.transform);
+            CameraPath camPath = pathGO.GetComponent<CameraPath>();
+            if (camPath != null)
+            {
+                CameraController.Instance.StartPathFollow(camPath, target, alignImmediately: false);
+                Destroy(pathGO, camPath.GetTotalDuration() + 0.5f);
+            }
+            else
+            {
+                Debug.LogWarning("[RhythmQTEManager] CameraPath component manquant sur le prefab du move.");
+            }
+        }
+
         if (move.musicalMoveIntroAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveIntroAnimationNames, caster);


### PR DESCRIPTION
## Résumé
- ajoute un champ `cameraPathPrefab` aux ScriptableObjects de moves et d'items
- déclenche automatiquement le CameraPath lors de l'utilisation d'un move ou d'un item
- désactive le CameraPath pour les items hors combat

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68604e57c28c8325a5c57211d83fc980