### PR TITLE
Ajout du culling des décors

### DIFF
--- a/Assets/Scripts/Environment/DecorCullingManager.cs
+++ b/Assets/Scripts/Environment/DecorCullingManager.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using System.Collections.Generic;
+
+public class DecorCullingManager : MonoBehaviour
+{
+    public static DecorCullingManager Instance { get; private set; }
+    public static bool HasInstance => Instance != null;
+
+    [Tooltip("Marge de sécurité autour des décors (en mètres).")]
+    public float margin = 5f;
+
+    private readonly List<DecorCullingObject> objects = new();
+    private CullingGroup cullingGroup;
+    private BoundingSphere[] spheres = new BoundingSphere[0];
+    private Camera targetCamera;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        targetCamera = Camera.main;
+        cullingGroup = new CullingGroup();
+        cullingGroup.onStateChanged += OnStateChanged;
+        cullingGroup.targetCamera = targetCamera;
+    }
+
+    private void LateUpdate()
+    {
+        if (Camera.main != targetCamera)
+        {
+            targetCamera = Camera.main;
+            cullingGroup.targetCamera = targetCamera;
+        }
+    }
+
+    public void RegisterObject(DecorCullingObject obj)
+    {
+        if (!objects.Contains(obj))
+        {
+            objects.Add(obj);
+            UpdateSpheres();
+        }
+    }
+
+    public void UnregisterObject(DecorCullingObject obj)
+    {
+        int index = objects.IndexOf(obj);
+        if (index >= 0)
+        {
+            objects.RemoveAt(index);
+            UpdateSpheres();
+        }
+    }
+
+    private void UpdateSpheres()
+    {
+        spheres = new BoundingSphere[objects.Count];
+        for (int i = 0; i < objects.Count; i++)
+        {
+            spheres[i] = objects[i].GetSphere(margin);
+        }
+        cullingGroup.SetBoundingSpheres(spheres);
+        cullingGroup.SetBoundingSphereCount(objects.Count);
+    }
+
+    private void OnStateChanged(CullingGroupEvent evt)
+    {
+        bool visible = evt.isVisible;
+        objects[evt.index].SetVisible(visible);
+    }
+
+    private void OnDestroy()
+    {
+        cullingGroup.Dispose();
+    }
+}

--- a/Assets/Scripts/Environment/DecorCullingManager.cs.meta
+++ b/Assets/Scripts/Environment/DecorCullingManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53ef1fb6913f480eb2a137e5b194c602

--- a/Assets/Scripts/Environment/DecorCullingObject.cs
+++ b/Assets/Scripts/Environment/DecorCullingObject.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+
+[RequireComponent(typeof(Renderer))]
+public class DecorCullingObject : MonoBehaviour
+{
+    private Renderer[] renderers;
+    private Collider[] colliders;
+    private BoundingSphere baseSphere;
+
+    private void Awake()
+    {
+        renderers = GetComponentsInChildren<Renderer>(true);
+        colliders = GetComponentsInChildren<Collider>(true);
+
+        if (renderers.Length > 0)
+        {
+            Bounds bounds = renderers[0].bounds;
+            foreach (var r in renderers)
+                bounds.Encapsulate(r.bounds);
+            baseSphere = new BoundingSphere(bounds.center, bounds.extents.magnitude);
+        }
+        else
+        {
+            baseSphere = new BoundingSphere(transform.position, 1f);
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (DecorCullingManager.HasInstance)
+            DecorCullingManager.Instance.RegisterObject(this);
+    }
+
+    private void OnDisable()
+    {
+        if (DecorCullingManager.HasInstance)
+            DecorCullingManager.Instance.UnregisterObject(this);
+    }
+
+    public BoundingSphere GetSphere(float margin)
+    {
+        return new BoundingSphere(baseSphere.position, baseSphere.radius + margin);
+    }
+
+    public void SetVisible(bool visible)
+    {
+        foreach (var r in renderers)
+            r.enabled = visible;
+        foreach (var c in colliders)
+            c.enabled = visible;
+    }
+}

--- a/Assets/Scripts/Environment/DecorCullingObject.cs.meta
+++ b/Assets/Scripts/Environment/DecorCullingObject.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e899fd1abc6c4e31916cefc540373521


### PR DESCRIPTION
## Résumé
- ajout d'un `DecorCullingManager` qui s'occupe d'activer/désactiver les décors en fonction de la visibilité caméra
- ajout d'un `DecorCullingObject` à placer sur les décors concernés

## Tests
- `dotnet --version` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6860ec9a30108325ba3319bb364f76e1