### PR TITLE
Add world-space damage popup

### DIFF
--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -118,6 +118,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
+        DamagePopup.Show(transform.position, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
         if (Data != null && Data.gameplayType == GameplayType.Rage)
         {

--- a/Assets/Scripts/DamagePopup.cs
+++ b/Assets/Scripts/DamagePopup.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using TMPro;
+
+public class DamagePopup : MonoBehaviour
+{
+    public float floatSpeed = 1f;
+    public float duration = 1.5f;
+    public Color textColor = Color.red;
+
+    private TextMeshProUGUI text;
+    private CanvasGroup canvasGroup;
+    private float elapsed;
+
+    public static void Show(Vector3 worldPosition, int amount)
+    {
+        var obj = new GameObject("DamagePopup");
+        obj.transform.position = worldPosition;
+
+        var canvas = obj.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.WorldSpace;
+        var camObj = GameObject.FindGameObjectWithTag("BattleCamera");
+        if (camObj != null)
+            canvas.worldCamera = camObj.GetComponent<Camera>();
+
+        obj.AddComponent<CanvasRenderer>();
+        var group = obj.AddComponent<CanvasGroup>();
+
+        var textObj = new GameObject("Text");
+        textObj.transform.SetParent(obj.transform, false);
+        var tmp = textObj.AddComponent<TextMeshProUGUI>();
+        tmp.text = amount.ToString();
+        tmp.alignment = TextAlignmentOptions.Center;
+        tmp.fontSize = 40;
+
+        var popup = obj.AddComponent<DamagePopup>();
+        popup.text = tmp;
+        popup.canvasGroup = group;
+    }
+
+    private void Update()
+    {
+        transform.position += Vector3.up * floatSpeed * Time.deltaTime;
+        elapsed += Time.deltaTime;
+        if (elapsed >= duration)
+        {
+            canvasGroup.alpha = Mathf.Lerp(1f, 0f, (elapsed - duration) / duration);
+            if (canvasGroup.alpha <= 0f)
+                Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/DamagePopup.cs.meta
+++ b/Assets/Scripts/DamagePopup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29b1142401555cc26885f9faa72e09c6


### PR DESCRIPTION
## Summary
- add `DamagePopup` script to display floating damage text under the BattleCamera
- show a damage popup when `CharacterUnit` takes damage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860f161725c8325b22d2d7fda30774b