### PR TITLE
Refactor DamagePopup system

### DIFF
--- a/Assets/DamagePopupManager.cs
+++ b/Assets/DamagePopupManager.cs
@@ -2,15 +2,30 @@ using UnityEngine;
 
 public class DamagePopupManager : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    public static DamagePopupManager Instance { get; private set; }
+
+    [SerializeField] private DamagePopup damagePopupPrefab;
+
+    void Awake()
     {
-        
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
     }
 
-    // Update is called once per frame
-    void Update()
+    public void ShowDamage(Vector3 position, int amount)
     {
-        
+        if (damagePopupPrefab == null)
+        {
+            Debug.LogWarning("[DamagePopupManager] Prefab manquant.");
+            return;
+        }
+
+        DamagePopup popup = Instantiate(damagePopupPrefab, position, Quaternion.identity, transform);
+        popup.Initialize(amount);
     }
 }

--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -118,7 +118,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
-        DamagePopup.Show(transform.position, Mathf.RoundToInt(amount));
+        DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
         if (Data != null && Data.gameplayType == GameplayType.Rage)
         {

--- a/Assets/Scripts/DamagePopup.cs
+++ b/Assets/Scripts/DamagePopup.cs
@@ -15,23 +15,6 @@ public class DamagePopup : MonoBehaviour
     private Camera mainCam;
     private CanvasGroup canvasGroup;
 
-    private static DamagePopup popupPrefab;
-
-    public static void Show(Vector3 position, int amount)
-    {
-        if (popupPrefab == null)
-            popupPrefab = Resources.Load<DamagePopup>("DamagePopup");
-
-        if (popupPrefab == null)
-        {
-            Debug.LogError("DamagePopup prefab introuvable dans un dossier Resources.");
-            return;
-        }
-
-        DamagePopup instance = Instantiate(popupPrefab, position, Quaternion.identity);
-        instance.Initialize(amount);
-    }
-
     public void Initialize(int amount)
     {
         textMesh.text = amount.ToString();


### PR DESCRIPTION
## Summary
- réécriture complète de `DamagePopupManager` pour gérer le prefab et l'affichage
- simplification de `DamagePopup` qui ne sert plus qu'à l'animation
- appel au manager depuis `CharacterUnit` lors de la prise de dégâts

## Testing
- `dotnet test` *(échoue : `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860fd4a99e483259b87cb4d8fe1f4fa