### PR TITLE
Fix enemy target choice and null reference

### DIFF
--- a/Assets/Scripts/AnimationEventsManager.cs
+++ b/Assets/Scripts/AnimationEventsManager.cs
@@ -18,16 +18,16 @@ public class AnimationEventsManager : MonoBehaviour
     {
         target = NewBattleManager.Instance?.currentTargetCharacter;
         move = NewBattleManager.Instance?.currentMove;
-        if (target != null)
+        if (target == null || move == null)
+            return;
+
+        if (target.isReadyToParry)
         {
-            if(target.isReadyToParry)
-            {
-                transform.parent.GetComponent<CharacterUnit>().TakeParry();
-            }
-            else
-            {
-                target.TakeDamage(move.power);
-            }                
+            transform.parent.GetComponent<CharacterUnit>().TakeParry();
+        }
+        else
+        {
+            target.TakeDamage(move.power);
         }
     }
 

--- a/Assets/Scripts/CharacterUnit.cs
+++ b/Assets/Scripts/CharacterUnit.cs
@@ -284,23 +284,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             return null;
         }
 
-        // Priorité 1 : cible avec le moins de PV
+        // Priorité : cible ayant infligé le plus de dégâts au cours du combat
+        var topDamageDealer = NewBattleManager.Instance.GetTopDamageDealer();
+        if (topDamageDealer != null)
+            return topDamageDealer;
+
+        // Sinon, cible avec le moins de PV
         var lowestHPUnit = squad.OrderBy(u => u.Data.currentHP).FirstOrDefault();
         if (lowestHPUnit != null)
             return lowestHPUnit;
 
-        // Priorité 2 : cible ayant infligé le plus de dégâts à cet ennemi (si tu as un système de suivi de dégâts)
-        // Exemple fictif : si tu avais un dictionnaire `Dictionary<CharacterUnit, float> damageReceivedFrom`
-        // Tu peux remplacer par ta propre logique de suivi.
-        /*
-        if (damageReceivedFrom.Count > 0)
-        {
-            var topAggro = damageReceivedFrom.OrderByDescending(kvp => kvp.Value).First().Key;
-            return topAggro;
-        }
-        */
-
-        return squad[Random.Range(0, squad.Count)]; // Fallback random
+        // Fallback aléatoire
+        return squad[Random.Range(0, squad.Count)];
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- fix `AnimationEventsManager.TryToDamage` when no move is defined
- track total damage dealt by squad units
- choose enemy target according to total damage dealt
- store current move when an enemy attacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68611e5c4a948325af2972862abfff6f