### PR TITLE
Fix target cursor destroyed after first battle

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -365,6 +365,9 @@ public class NewBattleManager : MonoBehaviour
         //3 Affecter currentTarget au premier ennemi de la liste
         SetDefaultCurrentTarget();
 
+        // S'assure que le curseur de cible existe pour ce nouveau combat
+        EnsureTargetCursor();
+
         //4 Réinitialise les ATB
         ResetAllATB();
 
@@ -1719,6 +1722,7 @@ public class NewBattleManager : MonoBehaviour
         if (targetCursor != null)
         {
             Destroy(targetCursor);
+            targetCursor = null;
         }
     }
     #endregion


### PR DESCRIPTION
## Summary
- recreate the target cursor when starting a new battle
- clear the cursor reference when resetting battle info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861231558948325835ae58f262a7db4