### PR TITLE
Fix pass turn UI fading

### DIFF
--- a/Assets/Scripts/PassTurnUI.cs
+++ b/Assets/Scripts/PassTurnUI.cs
@@ -73,7 +73,9 @@ public class PassTurnUI : MonoBehaviour
 
         while (elapsed < fadeDuration)
         {
-            elapsed += Time.deltaTime;
+            // Utilise unscaledDeltaTime pour ignorer le timeScale
+            // et assurer l'affichage même si le jeu est en pause
+            elapsed += Time.unscaledDeltaTime;
             canvasGroup.alpha = Mathf.Clamp01(elapsed / fadeDuration);
             yield return null;
         }


### PR DESCRIPTION
## Summary
- assure l'affichage de la jauge de passage de tour même si le temps est figé

## Testing
- `npm test` *(échoue : package.json manquant)*
- `pytest`
- `cargo test` *(échoue : `Cargo.toml` manquant)*
- `go test ./...` *(échoue : module go inexistant)*

------
https://chatgpt.com/codex/tasks/task_e_68612861b7bc832594fc16f696723b7c