### PR TITLE
Correctif CanvasGroup pour PassTurnUI

### DIFF
--- a/Assets/Scripts/PassTurnUI.cs
+++ b/Assets/Scripts/PassTurnUI.cs
@@ -20,6 +20,9 @@ public class PassTurnUI : MonoBehaviour
 
     private void Awake()
     {
+        if (canvasGroup == null)
+            canvasGroup = GetComponent<CanvasGroup>();
+
         if (canvasGroup != null)
             canvasGroup.alpha = 0f;
     }


### PR DESCRIPTION
## Résumé
- obtention automatique du `CanvasGroup` dans `PassTurnUI` si la référence n'est pas renseignée

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686129d571408325bcbdd97246167981