### PR TITLE
Reset progress gauge smoothly

### DIFF
--- a/Assets/Scripts/InputsManager.cs
+++ b/Assets/Scripts/InputsManager.cs
@@ -316,6 +316,8 @@ public class InputsManager : MonoBehaviour
             StopCoroutine(passRoutine);
             passRoutine = null;
         }
+
+        passTurnUI?.ResetProgressSmooth();
     }
 
     private IEnumerator PassTurnRoutine()
@@ -326,6 +328,7 @@ public class InputsManager : MonoBehaviour
             if (!playerInputs.Battle.Back.IsPressed())
             {
                 passRoutine = null;
+                passTurnUI?.ResetProgressSmooth();
                 yield break;
             }
 

--- a/Assets/Scripts/PassTurnUI.cs
+++ b/Assets/Scripts/PassTurnUI.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using System.Collections;
 
 /// <summary>
 /// Affiche une jauge circulaire permettant de passer le tour.
@@ -12,6 +13,12 @@ public class PassTurnUI : MonoBehaviour
     [Header("UI Elements")]
     public Image progressImage;
     public TextMeshProUGUI label;
+
+    [Header("Settings")]
+    [Tooltip("Vitesse à laquelle la jauge revient à zéro lorsqu'aucune entrée n'est détectée.")]
+    public float resetSpeed = 2f;
+
+    private Coroutine resetRoutine;
 
     private void Awake()
     {
@@ -52,7 +59,33 @@ public class PassTurnUI : MonoBehaviour
     /// </summary>
     public void SetProgress(float t)
     {
+        if (resetRoutine != null)
+        {
+            StopCoroutine(resetRoutine);
+            resetRoutine = null;
+        }
         if (progressImage != null)
             progressImage.fillAmount = Mathf.Clamp01(t);
+    }
+
+    /// <summary>
+    /// Lance la diminution progressive de la jauge jusqu'à 0.
+    /// </summary>
+    public void ResetProgressSmooth()
+    {
+        if (resetRoutine != null)
+            StopCoroutine(resetRoutine);
+
+        resetRoutine = StartCoroutine(ResetRoutine());
+    }
+
+    private IEnumerator ResetRoutine()
+    {
+        while (progressImage != null && progressImage.fillAmount > 0f)
+        {
+            progressImage.fillAmount = Mathf.Max(0f, progressImage.fillAmount - Time.unscaledDeltaTime * resetSpeed);
+            yield return null;
+        }
+        resetRoutine = null;
     }
 }


### PR DESCRIPTION
## Summary
- add automatic smooth reset of the pass turn gauge
- trigger gauge reset when Back is released

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_686137084a3483259b330a1739055086