### PR TITLE
Cache le menu principal après le passage de tour

### DIFF
--- a/Assets/Scripts/NewBattleManager.cs
+++ b/Assets/Scripts/NewBattleManager.cs
@@ -828,6 +828,8 @@ public class NewBattleManager : MonoBehaviour
         }
 
         ChangeBattleState(BattleState.EndTurn);
+        // Cache tous les menus à la fin du tour
+        ToggleMenuContainers(false, false, false);
         UpdateTimelineHighlight(null);
         isTurnResolving = false;
         HandleEndOfBattle();


### PR DESCRIPTION
## Summary
- cache tous les panneaux de menu lors de la fin de tour afin que le MainMenu disparaisse après un passage de tour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68613bd4383883258cf18ad3e31dee46