### PR TITLE
Mise à jour orientation des unités

### DIFF
--- a/Assets/Scripts/RhythmQTEManager.cs
+++ b/Assets/Scripts/RhythmQTEManager.cs
@@ -143,17 +143,17 @@ public class RhythmQTEManager : MonoBehaviour
             if (move.teleportEndVFXPrefab != null)
                 Instantiate(move.teleportEndVFXPrefab, teleportTargetPosition, Quaternion.identity);
 
-            if (move.stayFaceToTarget && target != null)
-            {
-                Vector3 lookDirection = (target.transform.position - caster.transform.position).normalized;
-                if (lookDirection != Vector3.zero)
-                    caster.transform.forward = lookDirection;
-            }
-            else
-            {
-                if (teleportOffsetDir != Vector3.zero)
-                    caster.transform.forward = teleportOffsetDir;
-            }
+            Vector3 lookDir = Vector3.zero;
+            if (target != null)
+                lookDir = (target.transform.position - caster.transform.position).normalized;
+
+
+            if (lookDir != Vector3.zero)
+                caster.transform.forward = lookDir;
+            else if (teleportOffsetDir != Vector3.zero)
+                caster.transform.forward = teleportOffsetDir;
+
+            NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
 
             yield return null;
             Debug.Log("Fin du déplacement de " + caster.name);
@@ -219,6 +219,7 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         Debug.Log("Fin du déplacement de " + caster.name);
+        NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
     }
 
     private IEnumerator ReturnToInitialPosition(MusicalMoveSO move, CharacterUnit caster, CharacterUnit target)
@@ -292,6 +293,7 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         Debug.Log("Le caster a terminé son retour.");
+        NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
     }
 
     IEnumerator PlayMoveAnimations(string[] animationClips, CharacterUnit caster)


### PR DESCRIPTION
## Résumé
- ajoute `OrientUnitTowardClosestOpponent` et `OrientAllUnitsTowardClosestOpponent`
- oriente les unités vers l'ennemi le plus proche ou la cible prioritaire
- applique cette logique lors des tours et après les `MusicalMove`
- ajuste la téléportation pour que le caster regarde sa cible

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68613d6ed5d883259a5c21a29578c9f1