### PR TITLE
Ajout SaveAndLoadManager

### DIFF
--- a/Assets/OrganizedScripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/OrganizedScripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -203,6 +203,11 @@ public class BattleTransitionManager : MonoBehaviour
 
         battleIntroPath.triggered = false;
 
+        if (Application.isPlaying && !Application.isEditor && SaveAndLoadManager.Instance != null)
+        {
+            SaveAndLoadManager.Instance.AutoSave();
+        }
+
         //yield return FadeToTransparent(1f);
     }
 

--- a/Assets/OrganizedScripts/MonoBehavioursUsed/SaveAndLoadManager.cs
+++ b/Assets/OrganizedScripts/MonoBehavioursUsed/SaveAndLoadManager.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+public class SaveAndLoadManager : MonoBehaviour
+{
+    public static SaveAndLoadManager Instance { get; private set; }
+
+    private string saveDirectory;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        saveDirectory = Path.Combine(Application.persistentDataPath, "Saves");
+        if (!Directory.Exists(saveDirectory))
+            Directory.CreateDirectory(saveDirectory);
+    }
+
+    public IEnumerable<string> GetAllSaveNames()
+    {
+        if (!Directory.Exists(saveDirectory))
+            yield break;
+
+        foreach (var file in Directory.GetFiles(saveDirectory, "*.json"))
+            yield return Path.GetFileNameWithoutExtension(file);
+    }
+
+    public void SaveGame(string saveName, bool confirmOverwrite = true)
+    {
+        if (GameManager.Instance == null)
+        {
+            Debug.LogError("[SaveAndLoadManager] GameManager introuvable.");
+            return;
+        }
+
+        string relativePath = Path.Combine("Saves", saveName + ".json");
+        string fullPath = Path.Combine(Application.persistentDataPath, relativePath);
+
+        if (File.Exists(fullPath) && confirmOverwrite && InfoBoxManager.Instance != null)
+        {
+            StartCoroutine(SaveWithConfirmation(relativePath));
+        }
+        else
+        {
+            GameManager.Instance.gameData.SaveToFile(relativePath);
+        }
+    }
+
+    private IEnumerator SaveWithConfirmation(string relativePath)
+    {
+        InfoBoxManager.Instance.OpenInfoBox("Sauvegarde", "Écraser la sauvegarde existante ?", null);
+        while (!InfoBoxManager.Instance.choix.HasValue)
+            yield return null;
+
+        if (InfoBoxManager.Instance.choix.Value)
+            GameManager.Instance.gameData.SaveToFile(relativePath);
+    }
+
+    public void LoadGame(string saveName)
+    {
+        if (GameManager.Instance == null)
+        {
+            Debug.LogError("[SaveAndLoadManager] GameManager introuvable.");
+            return;
+        }
+
+        string relativePath = Path.Combine("Saves", saveName + ".json");
+        GameManager.Instance.gameData.LoadFromFile(relativePath);
+    }
+
+    public void AutoSave()
+    {
+        if (GameManager.Instance == null)
+            return;
+
+        string name = "autosave_" + DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        GameManager.Instance.gameData.SaveToFile(Path.Combine("Saves", name + ".json"));
+    }
+}

--- a/Assets/OrganizedScripts/MonoBehavioursUsed/SaveAndLoadManager.cs.meta
+++ b/Assets/OrganizedScripts/MonoBehavioursUsed/SaveAndLoadManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9af1e5ebc95746d1b155697927a57b67

--- a/Assets/Prefabs/SaveAndLoadManager.prefab
+++ b/Assets/Prefabs/SaveAndLoadManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5962896430240256447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4404889274593097036}
+  - component: {fileID: 6244274720720144901}
+  m_Layer: 0
+  m_Name: SaveAndLoadManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4404889274593097036
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5962896430240256447}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6244274720720144901
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5962896430240256447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af1e5ebc95746d1b155697927a57b67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/SaveAndLoadManager.prefab.meta
+++ b/Assets/Prefabs/SaveAndLoadManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de8e75e6fb964053b92bb793b21f333c
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Résumé
- nouveau script `SaveAndLoadManager` permettant plusieurs sauvegardes
- prefab associé `SaveAndLoadManager`
- appel de l'auto‑sauvegarde à la fin d'un combat

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6861429d2564832583a6bcb0de6ee1e3