### PR TITLE
Ajout du système d'interception

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -34,6 +34,8 @@ public class MusicalMoveSO : ScriptableObject
     public float moveSpeed = 20f;
     public float castDistance;
     public bool stayInPlace = false;
+    [Tooltip("Si faux, le move ne peut pas être intercepté")]
+    public bool interceptable = true;
 
     [Header("Placement autour de la cible")]
     public RelativePosition relativePosition = RelativePosition.Front;

--- a/Assets/Scripts/MonoBehavioursUsed/InterceptionSignal.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InterceptionSignal.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+/// <summary>
+/// Affiche un signal visuel indiquant qu'une interception est possible.
+/// </summary>
+public class InterceptionSignal : MonoBehaviour
+{
+    public Image progressImage;
+    public float duration = 1f;
+
+    private Coroutine fillRoutine;
+
+    public void StartSignal(float d)
+    {
+        duration = d;
+        if (progressImage != null)
+            progressImage.fillAmount = 0f;
+        if (fillRoutine != null)
+            StopCoroutine(fillRoutine);
+        fillRoutine = StartCoroutine(FillRoutine());
+    }
+
+    private IEnumerator FillRoutine()
+    {
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            elapsed += Time.unscaledDeltaTime;
+            if (progressImage != null)
+                progressImage.fillAmount = elapsed / duration;
+            yield return null;
+        }
+        Destroy(gameObject);
+    }
+
+    public void StopSignal()
+    {
+        if (fillRoutine != null)
+            StopCoroutine(fillRoutine);
+        Destroy(gameObject);
+    }
+}


### PR DESCRIPTION
## Résumé
- ajout d'un booléen `interceptable` dans `MusicalMoveSO`
- ajout du script `InterceptionSignal` pour l'affichage d'une fenêtre d'interception
- prise en charge d'un prefab `interceptionSignalPrefab` dans `NewBattleManager`
- interception possible lors du tour d'un ennemi avec entrée `leftShoulder`
- protection des attaques non interceptables dans `ExecuteMoveOnTarget`

## Tests
- `npm test` *(échoue: package.json absent)*
- `pytest` *(0 tests exécutés)*

------
https://chatgpt.com/codex/tasks/task_e_686147f11eb4832592c9e0a1afc1190a