### PR TITLE
Ajout d’un item augmentant la portée

### DIFF
--- a/Assets/Items/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee.asset
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_LonguePortee
+  m_EditorClassIdentifier:
+  itemID: LonguePortee
+  itemName: Longue Portée
+  description: Augmente la portée du lanceur de 10 pour ce tour.
+  icon: {fileID: 0}
+  effectValue: 10
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  effectType: 6
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 0
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  targetType: 3
+  introVFXPrefab: {fileID: 0}
+  beatPattern: []
+  currentCaster: {fileID: 0}
+  currentTarget: {fileID: 0}
+  cameraStartLocalPosition: {x: 0, y: 0, z: 0}
+  cameraStartLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraEndLocalPosition: {x: 0, y: 0, z: 0}
+  cameraEndLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraTransitionDuration: 0.5
+  notes: []
+  introAnimationClip: {fileID: 0}
+  animationClip: {fileID: 0}
+  visualEffect: {fileID: 0}
+  introClip: {fileID: 0}

--- a/Assets/Items/Item_LonguePortee.asset.meta
+++ b/Assets/Items/Item_LonguePortee.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd8086605fb14e81a0e94c639309929f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Prefabs/InventoryManager.prefab
+++ b/Assets/Prefabs/InventoryManager.prefab
@@ -48,4 +48,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 2e35fef8567f44b4680de59e308b73b5, type: 2}
   - {fileID: 11400000, guid: 55e936b19947e8d4bb0f7743a5bdd51b, type: 2}
   - {fileID: 11400000, guid: 167dce701cc3ff548b8cf7cec4b9adfe, type: 2}
-  inventoryItems: []
+  - {fileID: 11400000, guid: fd8086605fb14e81a0e94c639309929f, type: 2}
+  inventoryItems:
+  - {fileID: 11400000, guid: fd8086605fb14e81a0e94c639309929f, type: 2}

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -88,27 +88,34 @@ public class ItemData : ScriptableObject
         switch (effectType)
         {
             case ItemEffectType.Heal:
-                
+
                 break;
 
             case ItemEffectType.Revive:
-                
+
                 break;
 
             case ItemEffectType.Buff:
-                
+
                 break;
 
             case ItemEffectType.Debuff:
-               
+
                 break;
 
             case ItemEffectType.BoostTiming:
-                
+
                 break;
 
             case ItemEffectType.Damage:
-                
+
+                break;
+
+            case ItemEffectType.IncreaseRange:
+                if (target != null)
+                {
+                    target.Data.currentRange += effectValue;
+                }
                 break;
 
             default:
@@ -118,7 +125,7 @@ public class ItemData : ScriptableObject
     }
 }
 
-public enum ItemEffectType { Heal, Revive, Buff, Debuff, BoostTiming, Damage }
+public enum ItemEffectType { Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange }
 public enum BuffStatType { Strength, Defense, Initiative }
 public enum DebuffStatType { Strength, Defense, Initiative }
 public enum TimingBoostType { ParryWindow, DodgeWindow }


### PR DESCRIPTION
## Résumé
- ajout d'un objet `Item_LonguePortee` permettant d'augmenter la portée du lanceur
- mise à jour du script `ItemData` pour gérer un nouvel effet `IncreaseRange`
- ajout de l'objet dans le prefab `InventoryManager` parmi les items disponibles et obtenus par la squad

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68614a320b408325b409e9e66e910587