### PR TITLE
Fusionner TargetType en AvailableTargetType

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -42,9 +42,9 @@ public class ItemData : ScriptableObject
     public float timingDuration;
 
     [Header("Ciblage")]
-    public TargetType targetType = TargetType.SingleAlly;
-    public TargetType defaultTargetType = TargetType.SingleAlly;
-    public List<TargetType> availableTargetTypes = new List<TargetType>() { TargetType.SingleAlly };
+    public AvailableTargetType targetType = AvailableTargetType.SingleAlly;
+    public AvailableTargetType defaultTargetType = AvailableTargetType.SingleAlly;
+    public List<AvailableTargetType> availableTargetTypes = new List<AvailableTargetType>() { AvailableTargetType.SingleAlly };
 
     [Header("VFX")]
     public GameObject introVFXPrefab;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -24,9 +24,9 @@ public class MusicalMoveSO : ScriptableObject
     public float fatigueCost = 1;
 
     [Header("Ciblage")]
-    public TargetType targetType = TargetType.SingleEnemy;
-    public TargetType defaultTargetType = TargetType.SingleEnemy;
-    public List<TargetType> availableTargetTypes = new List<TargetType>() { TargetType.SingleEnemy };
+    public AvailableTargetType targetType = AvailableTargetType.SingleEnemy;
+    public AvailableTargetType defaultTargetType = AvailableTargetType.SingleEnemy;
+    public List<AvailableTargetType> availableTargetTypes = new List<AvailableTargetType>() { AvailableTargetType.SingleEnemy };
 
     [Header("Effet appliqué")]
     public MusicalEffectType effectType = MusicalEffectType.Damage;

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -346,21 +346,21 @@ public class InputsManager : MonoBehaviour
         NewBattleManager bm = NewBattleManager.Instance;
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad)
         {
-            TargetType desired = TargetType.SingleEnemy;
+            AvailableTargetType desired = AvailableTargetType.SingleEnemy;
             if (bm.currentMove != null)
             {
-                if (bm.currentMove.availableTargetTypes.Contains(TargetType.SingleEnemy))
-                    desired = TargetType.SingleEnemy;
-                else if (bm.currentMove.availableTargetTypes.Contains(TargetType.AllEnemies))
-                    desired = TargetType.AllEnemies;
+                if (bm.currentMove.availableTargetTypes.Contains(AvailableTargetType.SingleEnemy))
+                    desired = AvailableTargetType.SingleEnemy;
+                else if (bm.currentMove.availableTargetTypes.Contains(AvailableTargetType.AllEnemies))
+                    desired = AvailableTargetType.AllEnemies;
                 bm.currentMove.targetType = desired;
             }
             if (bm.currentItem != null)
             {
-                if (bm.currentItem.availableTargetTypes.Contains(TargetType.SingleEnemy))
-                    desired = TargetType.SingleEnemy;
-                else if (bm.currentItem.availableTargetTypes.Contains(TargetType.AllEnemies))
-                    desired = TargetType.AllEnemies;
+                if (bm.currentItem.availableTargetTypes.Contains(AvailableTargetType.SingleEnemy))
+                    desired = AvailableTargetType.SingleEnemy;
+                else if (bm.currentItem.availableTargetTypes.Contains(AvailableTargetType.AllEnemies))
+                    desired = AvailableTargetType.AllEnemies;
                 bm.currentItem.targetType = desired;
             }
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
@@ -373,21 +373,21 @@ public class InputsManager : MonoBehaviour
         NewBattleManager bm = NewBattleManager.Instance;
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies)
         {
-            TargetType desired = TargetType.SingleAlly;
+            AvailableTargetType desired = AvailableTargetType.SingleAlly;
             if (bm.currentMove != null)
             {
-                if (bm.currentMove.availableTargetTypes.Contains(TargetType.SingleAlly))
-                    desired = TargetType.SingleAlly;
-                else if (bm.currentMove.availableTargetTypes.Contains(TargetType.AllAllies))
-                    desired = TargetType.AllAllies;
+                if (bm.currentMove.availableTargetTypes.Contains(AvailableTargetType.SingleAlly))
+                    desired = AvailableTargetType.SingleAlly;
+                else if (bm.currentMove.availableTargetTypes.Contains(AvailableTargetType.AllAllies))
+                    desired = AvailableTargetType.AllAllies;
                 bm.currentMove.targetType = desired;
             }
             if (bm.currentItem != null)
             {
-                if (bm.currentItem.availableTargetTypes.Contains(TargetType.SingleAlly))
-                    desired = TargetType.SingleAlly;
-                else if (bm.currentItem.availableTargetTypes.Contains(TargetType.AllAllies))
-                    desired = TargetType.AllAllies;
+                if (bm.currentItem.availableTargetTypes.Contains(AvailableTargetType.SingleAlly))
+                    desired = AvailableTargetType.SingleAlly;
+                else if (bm.currentItem.availableTargetTypes.Contains(AvailableTargetType.AllAllies))
+                    desired = AvailableTargetType.AllAllies;
                 bm.currentItem.targetType = desired;
             }
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -8,8 +8,8 @@ using UnityEngine.InputSystem;
 using TMPro;
 using UnityEngine.Playables;
 
-#region TargetType
-public enum TargetType
+#region AvailableTargetType
+public enum AvailableTargetType
 {
     Self,
     SingleEnemy,
@@ -1401,15 +1401,15 @@ public class NewBattleManager : MonoBehaviour
         if (!isSkillTargeting && !isItemTargeting)
             return;
 
-        TargetType type = isSkillTargeting ? currentMove.targetType : currentItem.targetType;
+        AvailableTargetType type = isSkillTargeting ? currentMove.targetType : currentItem.targetType;
 
-        if (type == TargetType.Self)
+        if (type == AvailableTargetType.Self)
         {
             currentTargetCharacter = currentCharacterUnit;
             return;
         }
 
-        bool targetEnemies = type == TargetType.SingleEnemy || type == TargetType.AllEnemies;
+        bool targetEnemies = type == AvailableTargetType.SingleEnemy || type == AvailableTargetType.AllEnemies;
         CharacterType requiredType = targetEnemies ? CharacterType.EnemyUnit : CharacterType.SquadUnit;
 
         filteredUnits = activeCharacterUnits
@@ -1516,13 +1516,13 @@ public class NewBattleManager : MonoBehaviour
         move.targetType = move.defaultTargetType;
         switch (move.defaultTargetType)
         {
-            case TargetType.Self:
+            case AvailableTargetType.Self:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForSkill);
                 currentTargetCharacter = currentCharacterUnit;
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.SingleEnemy:
+            case AvailableTargetType.SingleEnemy:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill);
 
                 currentTargetCharacter = activeCharacterUnits
@@ -1530,7 +1530,7 @@ public class NewBattleManager : MonoBehaviour
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.AllEnemies:
+            case AvailableTargetType.AllEnemies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
 
                 currentTargetCharacter = activeCharacterUnits
@@ -1539,7 +1539,7 @@ public class NewBattleManager : MonoBehaviour
                 break;
                 break;
 
-            case TargetType.SingleAlly:
+            case AvailableTargetType.SingleAlly:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForSkill);
                 break;
 
@@ -1548,7 +1548,7 @@ public class NewBattleManager : MonoBehaviour
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.AllAllies:
+            case AvailableTargetType.AllAllies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
 
                 currentTargetCharacter = activeCharacterUnits
@@ -1569,13 +1569,13 @@ public class NewBattleManager : MonoBehaviour
         item.targetType = item.defaultTargetType;
         switch (item.defaultTargetType)
         {
-            case TargetType.Self:
+            case AvailableTargetType.Self:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForItem);
                 currentTargetCharacter = currentCharacterUnit;
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.SingleEnemy:
+            case AvailableTargetType.SingleEnemy:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem);
 
                 currentTargetCharacter = activeCharacterUnits
@@ -1583,21 +1583,21 @@ public class NewBattleManager : MonoBehaviour
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.AllEnemies:
+            case AvailableTargetType.AllEnemies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.SingleAlly:
+            case AvailableTargetType.SingleAlly:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForItem);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
                 currentTargetIndex = 0;
                 break;
 
-            case TargetType.AllAllies:
+            case AvailableTargetType.AllAllies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);


### PR DESCRIPTION
## Summary
- renommer l'enum `TargetType` en `AvailableTargetType`
- adapter `ItemData`, `MusicalMoveSO`, `InputsManager` et `NewBattleManager`

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_6861506498fc8325be25ac383531fd19