### PR TITLE
Correction de compilation : ajout de targetType à ItemData

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -42,6 +42,7 @@ public class ItemData : ScriptableObject
     public float timingDuration;
 
     [Header("Ciblage")]
+    public TargetType targetType = TargetType.SingleAlly;
     public TargetType defaultTargetType = TargetType.SingleAlly;
     public List<TargetType> availableTargetTypes = new List<TargetType>() { TargetType.SingleAlly };
 


### PR DESCRIPTION
## Résumé
- ajout de la propriété `targetType` dans `ItemData`

Cette modification résout les erreurs CS1061 indiquant que `ItemData` ne possédait pas le champ `targetType`.

## Tests
- pas de tests automatiques fournis

------
https://chatgpt.com/codex/tasks/task_e_686156dee8188325986146b66d376d9c