### PR TITLE
Fix item targeting without new property

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -361,7 +361,7 @@ public class InputsManager : MonoBehaviour
                     desired = TargetType.SingleEnemy;
                 else if (bm.currentItem.targetTypes.Contains(TargetType.AllEnemies))
                     desired = TargetType.AllEnemies;
-                bm.currentItem.targetType = desired;
+                bm.currentItemTargetType = desired;
             }
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
 
@@ -388,7 +388,7 @@ public class InputsManager : MonoBehaviour
                     desired = TargetType.SingleAlly;
                 else if (bm.currentItem.targetTypes.Contains(TargetType.AllAllies))
                     desired = TargetType.AllAllies;
-                bm.currentItem.targetType = desired;
+                bm.currentItemTargetType = desired;
             }
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -151,6 +151,7 @@ public class NewBattleManager : MonoBehaviour
     [HideInInspector] public List<ItemData> itemChoices = new List<ItemData>();
     [HideInInspector] public MusicalMoveSO currentMove;
     [HideInInspector] public ItemData currentItem;
+    [HideInInspector] public TargetType currentItemTargetType;
     public int currentMenuIndex;
     // Sélection nulle pour remplir les emplacements vides
     public MusicalMoveSO emptyMove;
@@ -1401,7 +1402,7 @@ public class NewBattleManager : MonoBehaviour
         if (!isSkillTargeting && !isItemTargeting)
             return;
 
-        TargetType type = isSkillTargeting ? currentMove.targetType : currentItem.targetType;
+        TargetType type = isSkillTargeting ? currentMove.targetType : currentItemTargetType;
 
         if (type == TargetType.Self)
         {
@@ -1566,7 +1567,7 @@ public class NewBattleManager : MonoBehaviour
     public void HandleTargetSelection(ItemData item)
     {
         currentItem = item;
-        item.targetType = item.defaultTargetType;
+        currentItemTargetType = item.defaultTargetType;
         switch (item.defaultTargetType)
         {
             case TargetType.Self:


### PR DESCRIPTION
## Summary
- supprime la propriété `targetType` de `ItemData`
- introduit `currentItemTargetType` dans `NewBattleManager`
- adapte la navigation de sélection de cibles pour les items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686157f05cbc8325ba07bf97e4184165