### PR TITLE
Amélioration de la logique d'utilisation des objets

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -730,8 +730,12 @@ public class NewBattleManager : MonoBehaviour
             RegisterDamage(caster, item.effectValue);
         }
         caster.GetComponent<FatigueSystem>()?.OnActionPerformed();
-        currentCharacterUnit.currentATB = 0f;
+        // L'utilisation d'un objet ne met plus fin immédiatement au tour
+        // On laisse l'ATB inchangé pour permettre l'exécution d'un mouvement ensuite
         yield return null;
+
+        // Retour au menu principal pour choisir une autre action
+        ShowMainMenu();
     }
 
     private bool HasSpaceForMove(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)


### PR DESCRIPTION
## Résumé
- un objet n'interrompt plus immédiatement le tour
- retour au menu principal après utilisation d'un objet

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861605a8004832588285ae330f538ec