### PR TITLE
Fix timing for item targeting animation

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -140,6 +140,10 @@ public class InputsManager : MonoBehaviour
                 return;
             }
 
+            if (bm.currentItem != null && bm.currentItem.itemTargetingAnimation != null)
+                bm.currentCharacterUnit.GetComponentInChildren<Animator>()
+                    .Play(bm.currentItem.itemTargetingAnimation.name);
+
             bm.ChangeBattleState(BattleState.SquadUnit_UseItem);
             bm.StartCoroutine(bm.UseItemOnTarget(bm.currentItem, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);


### PR DESCRIPTION
## Summary
- rejoue l'animation de ciblage des objets juste avant la validation de la cible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68616e1f45288325aca62436844487c5