### PR TITLE
Ajout d'un objet contre l'interception

### DIFF
--- a/Assets/Items/Item_AntiInterception.asset
+++ b/Assets/Items/Item_AntiInterception.asset
@@ -1,0 +1,54 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_AntiInterception
+  m_EditorClassIdentifier: 
+  itemID: AntiInterception
+  itemName: "Anti-Interception"
+  description: "Emp\xEAche la cible d'\xEAtre intercept\xE9e pendant un court laps de temps."
+  itemIcon: {fileID: 0}
+  effectValue: 10
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  itemTargetingAnimationName: UseItemPreparation_Start
+  effectType: 8
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 50
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 1
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  defaultTargetType: 3
+  targetTypes: 03000000
+  introVFXPrefab: {fileID: 0}
+  cameraPathPrefab: {fileID: 0}
+  beatPattern: []
+  currentCaster: {fileID: 0}
+  currentTarget: {fileID: 0}
+  cameraStartLocalPosition: {x: 0, y: 0, z: 0}
+  cameraStartLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraEndLocalPosition: {x: 0, y: 0, z: 0}
+  cameraEndLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraTransitionDuration: 0.5
+  notes: []
+  introAnimationClip: {fileID: 0}
+  animationClip: {fileID: 0}
+  visualEffect: {fileID: 0}
+  introClip: {fileID: 0}

--- a/Assets/Items/Item_AntiInterception.asset.meta
+++ b/Assets/Items/Item_AntiInterception.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63e0e6dd9f15483a986ad80869cc492d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -132,6 +132,10 @@ public class ItemData : ScriptableObject
                 }
                 break;
 
+            case ItemEffectType.PreventInterception:
+                InventoryManager.Instance?.ApplyInterceptionImmunity(target, Mathf.RoundToInt(buffDuration));
+                break;
+
             default:
                 Debug.LogWarning($"[ItemData] Type d'effet inconnu : {effectType}");
                 break;
@@ -139,7 +143,7 @@ public class ItemData : ScriptableObject
     }
 }
 
-public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange }
+public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange, PreventInterception }
 public enum BuffStatType { None, Strength, Defense, Initiative }
 public enum DebuffStatType { None, Strength, Defense, Initiative }
 public enum TimingBoostType { None, ParryWindow, DodgeWindow }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -41,6 +41,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
     private bool deathTriggered;
     public bool isReadyToParry;
+    [HideInInspector] public bool isInterceptionImmune = false;
+    [HideInInspector] public int interceptionImmunityTurns = 0;
 
     [Header("Récompenses de combat")]
     public List<ItemData> lootItems = new();

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -158,4 +158,12 @@ public class InventoryManager : MonoBehaviour
             _ => 0f,
         };
     }
+
+    public void ApplyInterceptionImmunity(CharacterUnit target, int turns)
+    {
+        if (target == null)
+            return;
+        target.isInterceptionImmune = true;
+        target.interceptionImmunityTurns = Mathf.Max(target.interceptionImmunityTurns, turns);
+    }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -667,7 +667,7 @@ public class NewBattleManager : MonoBehaviour
             yield break;
         }
 
-        if (move.interceptable)
+        if (move.interceptable && !enemy.isInterceptionImmune)
         {
             yield return TryPlayerInterception(enemy, target, move);
             if (interceptionSucceeded)
@@ -693,7 +693,7 @@ public class NewBattleManager : MonoBehaviour
             Debug.LogWarning("[ExecuteMoveOnTarget] Pas assez d'espace pour executer le mouvement.");
             yield break;
         }
-        if (move.interceptable)
+        if (move.interceptable && !caster.isInterceptionImmune)
         {
             var interceptor = CheckForInterception(caster, target, caster.Data.currentInterceptionRange);
             if (interceptor != null)
@@ -797,6 +797,8 @@ public class NewBattleManager : MonoBehaviour
 
     private CharacterUnit CheckForInterception(CharacterUnit caster, CharacterUnit target, float range)
     {
+        if (caster != null && caster.isInterceptionImmune)
+            return null;
         foreach (var unit in activeCharacterUnits)
         {
             if (unit == null || unit == caster || unit == target) continue;
@@ -814,6 +816,8 @@ public class NewBattleManager : MonoBehaviour
 
     private CharacterUnit FindPlayerInterceptor(CharacterUnit caster, CharacterUnit target, float range)
     {
+        if (caster != null && caster.isInterceptionImmune)
+            return null;
         CharacterUnit best = null;
         float bestChance = 0f;
         foreach (var unit in activeCharacterUnits)
@@ -837,6 +841,8 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator TryPlayerInterception(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)
     {
         interceptionSucceeded = false;
+        if (caster != null && caster.isInterceptionImmune)
+            yield break;
         var interceptor = FindPlayerInterceptor(caster, target, caster.Data.currentInterceptionRange);
         if (interceptor == null)
             yield break;
@@ -903,6 +909,13 @@ public class NewBattleManager : MonoBehaviour
         {
             Debug.Log($"[BattleTurnManager] Fin du tour de {currentCharacterUnit.name}");
             currentCharacterUnit.currentATB = 0f;
+
+            if (currentCharacterUnit.interceptionImmunityTurns > 0)
+            {
+                currentCharacterUnit.interceptionImmunityTurns--;
+                if (currentCharacterUnit.interceptionImmunityTurns <= 0)
+                    currentCharacterUnit.isInterceptionImmune = false;
+            }
 
             if (currentCharacterUnit.Data.characterType == CharacterType.SquadUnit && currentTurnDamage > maxTurnDamage)
             {


### PR DESCRIPTION
## Résumé
- ajoute une propriété `isInterceptionImmune` aux `CharacterUnit`
- permet à l'`InventoryManager` d'appliquer une immunité temporaire
- ajoute un nouveau type d'effet pour les items
- met à jour le `BattleManager` pour respecter l'immunité
- création de l'item `Item_AntiInterception`

## Tests
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_68619584d7188325ab60a780fc049d04