### PR TITLE
Ajout d'items Sommeil et Réveil

### DIFF
--- a/Assets/Items/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_Reveil
+  m_EditorClassIdentifier:
+  itemID: Reveil
+  itemName: Reveil
+  description: "R\xE9veille une unit\xE9 endormie."
+  itemIcon: {fileID: 0}
+  effectValue: 0
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  itemTargetingAnimation: {fileID: 0}
+  effectType: 9
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 0
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  defaultTargetType: 0
+  targetTypes: 00000000
+  introVFXPrefab: {fileID: 0}
+  cameraPathPrefab: {fileID: 0}
+  sleepDuration: 0
+  beatPattern: []
+  currentCaster: {fileID: 0}
+  currentTarget: {fileID: 0}
+  cameraStartLocalPosition: {x: 0, y: 0, z: 0}
+  cameraStartLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraEndLocalPosition: {x: 0, y: 0, z: 0}
+  cameraEndLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraTransitionDuration: 0.5
+  notes: []
+  introAnimationClip: {fileID: 0}
+  animationClip: {fileID: 0}
+  visualEffect: {fileID: 0}
+  introClip: {fileID: 0}

--- a/Assets/Items/Item_Reveil.asset.meta
+++ b/Assets/Items/Item_Reveil.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3154918c32244feb139392e61fa426b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Items/Item_Sommeil.asset
+++ b/Assets/Items/Item_Sommeil.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_Sommeil
+  m_EditorClassIdentifier:
+  itemID: Sommeil
+  itemName: Sommeil
+  description: "Endort la cible pendant un court instant."
+  itemIcon: {fileID: 0}
+  effectValue: 0
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  itemTargetingAnimation: {fileID: 0}
+  effectType: 8
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 0
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  defaultTargetType: 0
+  targetTypes: 00000000
+  introVFXPrefab: {fileID: 0}
+  cameraPathPrefab: {fileID: 0}
+  sleepDuration: 2
+  beatPattern: []
+  currentCaster: {fileID: 0}
+  currentTarget: {fileID: 0}
+  cameraStartLocalPosition: {x: 0, y: 0, z: 0}
+  cameraStartLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraEndLocalPosition: {x: 0, y: 0, z: 0}
+  cameraEndLocalEulerAngles: {x: 0, y: 0, z: 0}
+  cameraTransitionDuration: 0.5
+  notes: []
+  introAnimationClip: {fileID: 0}
+  animationClip: {fileID: 0}
+  visualEffect: {fileID: 0}
+  introClip: {fileID: 0}

--- a/Assets/Items/Item_Sommeil.asset.meta
+++ b/Assets/Items/Item_Sommeil.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b582d2768704d61b5c209b344e414e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -52,6 +52,9 @@ public class ItemData : ScriptableObject
     [Tooltip("Trajectoire de caméra à instancier lors de l'utilisation de l'item")]
     public GameObject cameraPathPrefab;
 
+    [Header("Sleep Settings")]
+    public float sleepDuration = 2f;
+
     [Header("QTE Pattern")]
     public List<float> beatPattern;
 
@@ -132,6 +135,20 @@ public class ItemData : ScriptableObject
                 }
                 break;
 
+            case ItemEffectType.Sleep:
+                if (target != null && target.TryGetComponent<FatigueSystem>(out var sleepSystem))
+                {
+                    sleepSystem.Sleep(sleepDuration);
+                }
+                break;
+
+            case ItemEffectType.WakeUp:
+                if (target != null && target.TryGetComponent<FatigueSystem>(out var fs))
+                {
+                    fs.WakeUp();
+                }
+                break;
+
             default:
                 Debug.LogWarning($"[ItemData] Type d'effet inconnu : {effectType}");
                 break;
@@ -139,7 +156,7 @@ public class ItemData : ScriptableObject
     }
 }
 
-public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange }
+public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange, Sleep, WakeUp }
 public enum BuffStatType { None, Strength, Defense, Initiative }
 public enum DebuffStatType { None, Strength, Defense, Initiative }
 public enum TimingBoostType { None, ParryWindow, DodgeWindow }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -120,6 +120,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (hpBar != null) hpBar.SetValue(currentHP);
         DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
+        if (TryGetComponent<FatigueSystem>(out var fatigue))
+        {
+            fatigue.MarkDamagedWhileAsleep();
+        }
         if (Data != null && Data.gameplayType == GameplayType.Rage)
         {
             GetComponent<RageSystem>()?.AddRage(amount);

--- a/Assets/Scripts/MonoBehavioursUsed/FatigueSystem.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FatigueSystem.cs
@@ -10,11 +10,35 @@ public class FatigueSystem : MonoBehaviour
     public float asleepDuration = 2f;
     private bool isAsleep;
     private Coroutine routine;
+    private bool wasDamagedWhileAsleep;
     public bool IsAsleep => isAsleep;
+    public bool WasDamagedWhileAsleep => wasDamagedWhileAsleep;
 
     private void Awake()
     {
         unit = GetComponent<CharacterUnit>();
+    }
+
+    public void Sleep(float duration)
+    {
+        if (routine != null)
+            StopCoroutine(routine);
+        routine = StartCoroutine(SleepRoutine(duration));
+    }
+
+    public void WakeUp()
+    {
+        if (routine != null)
+            StopCoroutine(routine);
+        isAsleep = false;
+        wasDamagedWhileAsleep = false;
+        routine = null;
+    }
+
+    public void MarkDamagedWhileAsleep()
+    {
+        if (isAsleep)
+            wasDamagedWhileAsleep = true;
     }
 
     public void OnActionPerformed(float amount = 1f)
@@ -27,14 +51,15 @@ public class FatigueSystem : MonoBehaviour
             unit.customBar.SetValue(unit.currentFatigue);
         if (unit.currentFatigue >= unit.Data.maxFatigue && routine == null)
         {
-            routine = StartCoroutine(SleepRoutine());
+            routine = StartCoroutine(SleepRoutine(asleepDuration));
         }
     }
 
-    private IEnumerator SleepRoutine()
+    private IEnumerator SleepRoutine(float duration)
     {
         isAsleep = true;
-        yield return new WaitForSeconds(asleepDuration);
+        wasDamagedWhileAsleep = false;
+        yield return new WaitForSeconds(duration);
         unit.currentFatigue = unit.Data.baseFatigue;
         if (unit.customBar != null)
             unit.customBar.SetValue(unit.currentFatigue);

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -553,8 +553,15 @@ public class NewBattleManager : MonoBehaviour
         {
             if (unit.TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
             {
-                EndTurn();
-                yield break;
+                if (fatigue.WasDamagedWhileAsleep)
+                {
+                    fatigue.WakeUp();
+                }
+                else
+                {
+                    EndTurn();
+                    yield break;
+                }
             }
             isTurnResolving = true;
 


### PR DESCRIPTION
## Résumé
- ajoute la durée de sommeil dans `ItemData`
- supporte les effets `Sleep` et `WakeUp`
- les unités endormies sautent leur tour sauf si elles ont subi des dégâts
- les dégâts subis réveillent l'unité
- ajoute les items `Item_Sommeil` et `Item_Reveil`

## Tests
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686198f14e208325a189e7ff310e7f10