### PR TITLE
Ajout d'un effet de Sommeil et objets associés

### DIFF
--- a/Assets/Items/Item_Endormissement.asset
+++ b/Assets/Items/Item_Endormissement.asset
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_Endormissement
+  m_EditorClassIdentifier:
+  itemID: Endormissement
+  itemName: Endormissement
+  description: "Endort la cible jusqu\xE0 ce qu'elle subisse des d\xE9g\xE2ts."
+  itemIcon: {fileID: 0}
+  effectValue: 0
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  itemTargetingAnimationName: UseItemPreparation_Start
+  effectType: 10
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 50
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  defaultTargetType: 1
+  targetTypes: 0100000003000000
+  introVFXPrefab: {fileID: 0}

--- a/Assets/Items/Item_Endormissement.asset.meta
+++ b/Assets/Items/Item_Endormissement.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24fb197471a64498ae149186e17ba68b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Items/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil.asset
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 133a8786c2756524a9bd962bbc0f1ff8, type: 3}
+  m_Name: Item_Reveil
+  m_EditorClassIdentifier:
+  itemID: Reveil
+  itemName: Reveil
+  description: "R\xE9veille une unit\xE9 endormie."
+  itemIcon: {fileID: 0}
+  effectValue: 0
+  isUsableInBattle: 1
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  itemTargetingAnimationName: UseItemPreparation_Start
+  effectType: 11
+  healAmount: 0
+  healIsPercentage: 0
+  revivePercentage: 50
+  buffStat: 0
+  debuffStat: 0
+  buffAmount: 0
+  debuffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  timingType: 0
+  timingBoostAmount: 0
+  timingDuration: 0
+  defaultTargetType: 3
+  targetTypes: 03000000
+  introVFXPrefab: {fileID: 0}

--- a/Assets/Items/Item_Reveil.asset.meta
+++ b/Assets/Items/Item_Reveil.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 17bb4e65d90a4d1c95dba757ed59cb0f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -141,6 +141,14 @@ public class ItemData : ScriptableObject
                 InventoryManager.Instance?.ExtendEffectDurations(target, Mathf.RoundToInt(buffDuration));
                 break;
 
+            case ItemEffectType.Sleep:
+                InventoryManager.Instance?.ApplySleep(target);
+                break;
+
+            case ItemEffectType.WakeUp:
+                InventoryManager.Instance?.RemoveSleep(target);
+                break;
+
             default:
                 Debug.LogWarning($"[ItemData] Type d'effet inconnu : {effectType}");
                 break;
@@ -148,7 +156,7 @@ public class ItemData : ScriptableObject
     }
 }
 
-public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange, PreventInterception, ExtendEffects }
+public enum ItemEffectType { None, Heal, Revive, Buff, Debuff, BoostTiming, Damage, IncreaseRange, PreventInterception, ExtendEffects, Sleep, WakeUp }
 public enum BuffStatType { None, Strength, Defense, Initiative }
 public enum DebuffStatType { None, Strength, Defense, Initiative }
 public enum TimingBoostType { None, ParryWindow, DodgeWindow }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -122,6 +122,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (hpBar != null) hpBar.SetValue(currentHP);
         DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
+        GetComponent<SleepStatus>()?.OnDamageTaken();
         if (Data != null && Data.gameplayType == GameplayType.Rage)
         {
             GetComponent<RageSystem>()?.AddRage(amount);

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -177,4 +177,23 @@ public class InventoryManager : MonoBehaviour
 
         // TODO: étendre la durée des autres effets quand ils seront implémentés
     }
+
+    public void ApplySleep(CharacterUnit target)
+    {
+        if (target == null)
+            return;
+        var sleep = target.GetComponent<SleepStatus>();
+        if (sleep == null)
+            sleep = target.gameObject.AddComponent<SleepStatus>();
+        sleep.Sleep();
+    }
+
+    public void RemoveSleep(CharacterUnit target)
+    {
+        if (target == null)
+            return;
+        var sleep = target.GetComponent<SleepStatus>();
+        if (sleep != null)
+            sleep.WakeUp();
+    }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -551,6 +551,11 @@ public class NewBattleManager : MonoBehaviour
     {
         if (currentBattleState != BattleState.VictoryScreen_Await && currentBattleState != BattleState.VictoryScreen_CanContinue && currentBattleState != BattleState.GameOverScreen_Await && currentBattleState != BattleState.GameOverScreen_CanContinue)
         {
+            if (unit.TryGetComponent<SleepStatus>(out var sleep) && sleep.IsAsleep)
+            {
+                EndTurn();
+                yield break;
+            }
             if (unit.TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
             {
                 EndTurn();

--- a/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+public class SleepStatus : MonoBehaviour
+{
+    private bool isAsleep;
+    public bool IsAsleep => isAsleep;
+
+    public void Sleep()
+    {
+        isAsleep = true;
+    }
+
+    public void WakeUp()
+    {
+        isAsleep = false;
+    }
+
+    public void OnDamageTaken()
+    {
+        if (isAsleep)
+            WakeUp();
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ecc03c6af9144a599fb9cb997355a6b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: {}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Résumé
- création d'un composant `SleepStatus` pour gérer l'état d'endormissement
- ajout des effets `Sleep` et `WakeUp` dans `ItemData`
- mise à jour de `InventoryManager`, `CharacterUnit` et `NewBattleManager` pour prendre en compte ce nouvel état
- ajout de deux items ScriptableObject : **Endormissement** et **Réveil**

## Tests
- Aucun test automatisé fourni dans le dépôt

------
https://chatgpt.com/codex/tasks/task_e_6862bb915b58832586954ec8376bb38e