### PR TITLE
Ajout du move Fausse note et mécanisme d'harmoniques

### DIFF
--- a/Assets/Characters/Thalia/Character_Thalia.asset
+++ b/Assets/Characters/Thalia/Character_Thalia.asset
@@ -40,6 +40,7 @@ MonoBehaviour:
   battleIdleAnimationName: Idle
   musicalAttacks:
   - {fileID: 11400000, guid: aa3a8aa7524d80e48b7cbfff02d64f32, type: 2}
+  - {fileID: 11400000, guid: ab188af9-f88e-46c0-a7fd-f9e2bdfd3ea2, type: 2}
   currentInitiative: 1
   currentRange: 0
   currentHP: 80

--- a/Assets/MusicalMoves/MusicalMove_FausseNote.meta
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fea4971-7cda-4bac-88fc-f52b6ba72955
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_FausseNote
+  m_EditorClassIdentifier:
+  moveName: Fausse note
+  moveType: 1
+  moveIcon: {fileID: 0}
+  description:
+  musicalMoveTargetingAnimationName:
+  musicalMoveRunAnimationName:
+  maxRunDuration: 0.5
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 1
+  targetType: 0
+  defaultTargetType: 0
+  effectType: 5
+  effectValue: 0
+  moveSpeed: 20
+  castDistance: 0
+  stayInPlace: 0
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab188af9-f88e-46c0-a7fd-f9e2bdfd3ea2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -22,6 +22,7 @@ public class MusicalMoveSO : ScriptableObject
     [Header("Coût et Dégâts")]
     public float power = 0;
     public float fatigueCost = 1;
+    public int harmonicCost = 1;
 
     [Header("Ciblage")]
     public TargetType targetType = TargetType.SingleEnemy;
@@ -74,6 +75,13 @@ public class MusicalMoveSO : ScriptableObject
         {
             InventoryManager.Instance?.ApplySleep(target);
         }
+        else if (effectType == MusicalEffectType.WakeUpAll)
+        {
+            foreach (var unit in NewBattleManager.Instance.activeCharacterUnits)
+            {
+                InventoryManager.Instance?.RemoveSleep(unit);
+            }
+        }
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
@@ -82,6 +90,6 @@ public class MusicalMoveSO : ScriptableObject
     }
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll }
 
 public enum RelativePosition { Front, Back, Left, Right }

--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -100,6 +100,11 @@ public class ActionUIDisplayManager : MonoBehaviour
         ShowMessage("Cible trop éloignée");
     }
 
+    public void DisplayInstruction_NotEnoughHarmonics()
+    {
+        ShowMessage("Pas assez d'harmoniques");
+    }
+
     private void ShowMessage(string message)
     {
         if (currentDisplayRoutine != null)

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -31,6 +31,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentSagacity { get => Data.currentSagacity; set => Data.currentSagacity = value; }
 
     public float currentMusicalGauge;
+    public int currentHarmonics = 0;
     public float currentFatigue { get => Data.currentFatigue; set => Data.currentFatigue = value; }
 
     // Gestion de l'initiative
@@ -73,6 +74,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         currentReflex = Data.baseReflex;
         currentMobility = Data.baseMobility;
         currentFatigue = Data.baseFatigue;
+        currentHarmonics = 1;
 
         spriteRenderer = GetComponent<SpriteRenderer>();
         audioSource = GetComponent<AudioSource>();

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -173,6 +173,12 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 0)
             {
                 bm.currentMove = bm.skillChoices[0];
+                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
+                    bm.ShowMainMenu();
+                    return;
+                }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
 
@@ -218,6 +224,12 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 1)
             {
                 bm.currentMove = bm.skillChoices[1];
+                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
+                    bm.ShowMainMenu();
+                    return;
+                }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
 
@@ -259,6 +271,12 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 2)
             {
                 bm.currentMove = bm.skillChoices[2];
+                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
+                    bm.ShowMainMenu();
+                    return;
+                }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -519,6 +519,8 @@ public class NewBattleManager : MonoBehaviour
 
         ChangeCurrentCharacterUnit(characterUnit);
 
+        characterUnit.currentHarmonics += 1;
+
         // S'assure que la BattleCamera peut se déplacer librement
         CameraController cc = CameraController.Instance;
         if (cc != null && cc.currentWorldCameraState != WorldCameraState.ResearchClosestCamPoint)
@@ -937,6 +939,28 @@ public class NewBattleManager : MonoBehaviour
         HandleEndOfBattle();
 
         PassTurnUI.Instance.Hide(); // Bouclage
+    }
+
+    public void AfterMusicalMove(MusicalMoveSO move, CharacterUnit caster)
+    {
+        if (caster != null)
+        {
+            caster.currentHarmonics = Mathf.Max(0, caster.currentHarmonics - move.harmonicCost);
+        }
+
+        if (!caster.Data.isPlayerControlled)
+        {
+            EndTurn();
+            return;
+        }
+
+        bool hasSkill = caster.Data.musicalAttacks.Any(m => caster.currentHarmonics >= m.harmonicCost);
+        bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
+
+        if (!hasSkill && !hasItem)
+            EndTurn();
+        else
+            ShowMainMenu();
     }
     #endregion
 

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -94,7 +94,7 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         isActive = false;
-        NewBattleManager.Instance.EndTurn();
+        NewBattleManager.Instance.AfterMusicalMove(move, caster);
 
         Debug.Log("Fin de la séquence du MusicalMove: " + move + " de " + caster.name);
     }


### PR DESCRIPTION
## Résumé
- ajout d'un coût en harmoniques aux `MusicalMoveSO`
- nouveau type d'effet `WakeUpAll` pour réveiller toutes les unités
- ajout du move "Fausse note"
- gestion des harmoniques sur les unités et gain en début de tour
- le tour se termine seulement si l'on n'a plus d'harmonique et aucun objet utilisable
- affichage d'un message si pas assez d'harmoniques

## Tests
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_6862e221ad088325839e5d0a323b207c