### PR TITLE
Ajout d'un système d'harmoniques par type

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique.meta
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e85a4295e6930e418b4e66f6607bcef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_ContrepointChaotique
+  m_EditorClassIdentifier:
+  moveName: Contrepoint chaotique
+  moveType: 1
+  moveIcon: {fileID: 0}
+  description:
+  musicalMoveTargetingAnimationName:
+  musicalMoveRunAnimationName:
+  maxRunDuration: 0.5
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  power: 50
+  fatigueCost: 1
+  harmonicCost: 3
+  targetType: 2
+  defaultTargetType: 2
+  effectType: 0
+  effectValue: 50
+  moveSpeed: 20
+  castDistance: 0
+  stayInPlace: 0
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 857c2cb2a8614382b75615f4f5a589f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -8,6 +8,7 @@ public class CharacterData : ScriptableObject, ITargetable
     public Sprite portrait;
     public CharacterType characterType;
     public GameplayType gameplayType = GameplayType.Rage;
+    public HarmonicType harmonicType = HarmonicType.Lumiere;
     public GameObject characterWorldModel;
     public GameObject characterBattleModel;
 

--- a/Assets/Scripts/Classes/HarmonicType.cs
+++ b/Assets/Scripts/Classes/HarmonicType.cs
@@ -1,0 +1,5 @@
+public enum HarmonicType
+{
+    Lumiere,
+    Brume
+}

--- a/Assets/Scripts/Classes/HarmonicType.cs.meta
+++ b/Assets/Scripts/Classes/HarmonicType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a95f0a388ee4ccaa4beb4ad252dcf8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
@@ -11,6 +11,7 @@ public class BattleTimelineUnit : MonoBehaviour
     [SerializeField] private TextMeshProUGUI hpText;
     [SerializeField] private Slider atbSlider;
     [SerializeField] private CustomBar customBar;
+    [SerializeField] private TextMeshProUGUI harmonicsText;
 
     [Header("Couleurs")]
     [SerializeField] private Image backgroundImage;
@@ -59,7 +60,14 @@ public class BattleTimelineUnit : MonoBehaviour
             atbSlider.value = unit.currentATB;
         }
 
+        UpdateHarmonicsDisplay();
+
         SetHighlight(false);
+    }
+
+    void Update()
+    {
+        UpdateHarmonicsDisplay();
     }
 
     public void UpdateATBGauge()
@@ -89,6 +97,18 @@ public class BattleTimelineUnit : MonoBehaviour
         {
             customBar.SetValue(unit.currentFatigue);
         }
+    }
+
+    public void UpdateHarmonicsDisplay()
+    {
+        var unit = NewBattleManager.Instance.activeCharacterUnits
+            .Find(u => u.Data == characterData);
+
+        if (unit == null || harmonicsText == null)
+            return;
+
+        int count = unit.GetHarmonicCount(unit.Data.harmonicType);
+        harmonicsText.text = count.ToString();
     }
 
     public void UpdateHPBar()

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -31,7 +31,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentSagacity { get => Data.currentSagacity; set => Data.currentSagacity = value; }
 
     public float currentMusicalGauge;
-    public int currentHarmonics = 0;
+    // Nouvelle réserve d'harmoniques par type
+    public Dictionary<HarmonicType, int> harmonicReserve = new();
     public float currentFatigue { get => Data.currentFatigue; set => Data.currentFatigue = value; }
 
     // Gestion de l'initiative
@@ -74,7 +75,9 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         currentReflex = Data.baseReflex;
         currentMobility = Data.baseMobility;
         currentFatigue = Data.baseFatigue;
-        currentHarmonics = 1;
+
+        harmonicReserve.Clear();
+        AddHarmonic(Data.harmonicType);
 
         spriteRenderer = GetComponent<SpriteRenderer>();
         audioSource = GetComponent<AudioSource>();
@@ -301,6 +304,26 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         // Fallback aléatoire
         return squad[Random.Range(0, squad.Count)];
+    }
+
+    public void AddHarmonic(HarmonicType type, int amount = 1)
+    {
+        if (!harmonicReserve.ContainsKey(type))
+            harmonicReserve[type] = 0;
+        harmonicReserve[type] += amount;
+    }
+
+    public bool ConsumeHarmonic(HarmonicType type, int amount = 1)
+    {
+        if (!harmonicReserve.ContainsKey(type) || harmonicReserve[type] < amount)
+            return false;
+        harmonicReserve[type] -= amount;
+        return true;
+    }
+
+    public int GetHarmonicCount(HarmonicType type)
+    {
+        return harmonicReserve.ContainsKey(type) ? harmonicReserve[type] : 0;
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -173,7 +173,7 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 0)
             {
                 bm.currentMove = bm.skillChoices[0];
-                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
                     bm.ShowMainMenu();
@@ -224,7 +224,7 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 1)
             {
                 bm.currentMove = bm.skillChoices[1];
-                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
                     bm.ShowMainMenu();
@@ -271,7 +271,7 @@ public class InputsManager : MonoBehaviour
             if (bm.skillChoices.Count > 2)
             {
                 bm.currentMove = bm.skillChoices[2];
-                if (bm.currentCharacterUnit.currentHarmonics < bm.currentMove.harmonicCost)
+                if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
                     bm.ShowMainMenu();

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -519,7 +519,7 @@ public class NewBattleManager : MonoBehaviour
 
         ChangeCurrentCharacterUnit(characterUnit);
 
-        characterUnit.currentHarmonics += 1;
+        characterUnit.AddHarmonic(characterUnit.Data.harmonicType);
 
         // S'assure que la BattleCamera peut se déplacer librement
         CameraController cc = CameraController.Instance;
@@ -945,7 +945,7 @@ public class NewBattleManager : MonoBehaviour
     {
         if (caster != null)
         {
-            caster.currentHarmonics = Mathf.Max(0, caster.currentHarmonics - move.harmonicCost);
+            caster.ConsumeHarmonic(caster.Data.harmonicType, move.harmonicCost);
         }
 
         if (!caster.Data.isPlayerControlled)
@@ -954,7 +954,7 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
-        bool hasSkill = caster.Data.musicalAttacks.Any(m => caster.currentHarmonics >= m.harmonicCost);
+        bool hasSkill = caster.Data.musicalAttacks.Any(m => caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost);
         bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
 
         if (!hasSkill && !hasItem)


### PR DESCRIPTION
## Résumé
- création du type `HarmonicType`
- ajout d'une réserve d'harmoniques dans `CharacterUnit`
- gestion de la consommation et du gain d'harmoniques dans le déroulement du combat
- affichage simplifié des harmoniques dans la Timeline
- nouveau `MusicalMove` **Contrepoint chaotique**

## Test
- _Aucun test automatisé. Compilation non vérifiée._


------
https://chatgpt.com/codex/tasks/task_e_6862f40bc4048325978e477c3b827c0d