### PR TITLE
Fix victoire immédiate

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -624,6 +624,7 @@ public class NewBattleManager : MonoBehaviour
     {
         rewardItems.AddRange(enemy.lootItems);
         rewardXP += enemy.experienceReward;
+        HandleEndOfBattle();
     }
 
     public void RegisterDamage(CharacterUnit caster, float amount)


### PR DESCRIPTION
## Résumé
- déclenche la vérification de fin de combat dès qu'un ennemi meurt

## Détails
- `OnEnemyDefeated` appelle désormais `HandleEndOfBattle()` pour afficher immédiatement l'écran de victoire lorsque tous les ennemis sont vaincus

------
https://chatgpt.com/codex/tasks/task_e_6862f82dc39c83259c18a9808269b660