### PR TITLE
Ajout de Kael et de la marque de Loyauté

### DIFF
--- a/Assets/Characters/Kael.meta
+++ b/Assets/Characters/Kael.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffffffff000000000000000000000004

--- a/Assets/Characters/Kael/Character_Kael.asset
+++ b/Assets/Characters/Kael/Character_Kael.asset
@@ -1,0 +1,65 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbc0c89b53ea7e246ba03cfe31f29194, type: 3}
+  m_Name: Character_Kael
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterData
+  characterName: Kael
+  portrait: {fileID: 0}
+  characterType: 0
+  gameplayType: 0
+  harmonicType: 0
+  characterWorldModel: {fileID: 0}
+  characterBattleModel: {fileID: 0}
+  battlefieldIndex: 0
+  baseReflex: 0
+  baseMobility: 0
+  baseVitality: 0
+  basePower: 0
+  baseStability: 0
+  baseSagacity: 0
+  baseInitiative: 1
+  baseRange: 5
+  baseHP: 90
+  baseStrength: 1
+  baseDefense: 1
+  baseSpeed: 0
+  baseInterceptionRange: 1
+  baseInterceptionChance: 0
+  baseRage: 0
+  maxRage: 0
+  rageDamageMultiplier: 0
+  baseFatigue: 0
+  maxFatigue: 0
+  battleIdleAnimationName: Idle
+  musicalAttacks:
+  - {fileID: 11400000, guid: ffffffff000000000000000000000001, type: 2}
+  currentInitiative: 1
+  currentRange: 5
+  currentHP: 90
+  currentStrength: 1
+  currentDefense: 1
+  currentPower: 0
+  currentStability: 0
+  currentVitality: 0
+  currentSagacity: 0
+  isPlayerControlled: 1
+  currentRage: 0
+  currentFatigue: 0
+  currentReflex: 0
+  currentMobility: 0
+  currentSpeed: 0
+  currentInterceptionRange: 1
+  currentInterceptionChance: 0
+  hitSound: {fileID: 0}
+  hitEffect: {fileID: 0}
+  deathEffect: {fileID: 0}
+  owner: {fileID: 0}

--- a/Assets/Characters/Kael/Character_Kael.asset.meta
+++ b/Assets/Characters/Kael/Character_Kael.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffffffff000000000000000000000003
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas.meta
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffffffff000000000000000000000002

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_PourQuiSonneLeGlas
+  m_EditorClassIdentifier: 
+  moveName: Pour qui sonne le glas
+  moveType: 2
+  moveIcon: {fileID: 0}
+  description: Applique une marque de loyauté sur un allié.
+  musicalMoveTargetingAnimationName: 
+  musicalMoveRunAnimationName: 
+  maxRunDuration: 0
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 1
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes:
+  - 3
+  effectType: 6
+  effectValue: 0
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 1
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffffffff000000000000000000000001
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -82,6 +82,13 @@ public class MusicalMoveSO : ScriptableObject
                 InventoryManager.Instance?.RemoveSleep(unit);
             }
         }
+        else if (effectType == MusicalEffectType.LoyaltyMark)
+        {
+            var mark = target.GetComponent<LoyaltyMark>();
+            if (mark == null)
+                mark = target.gameObject.AddComponent<LoyaltyMark>();
+            mark.SetProtector(caster);
+        }
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
@@ -90,6 +97,6 @@ public class MusicalMoveSO : ScriptableObject
     }
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark }
 
 public enum RelativePosition { Front, Back, Left, Right }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -136,6 +136,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public void TakeDamage(float amount)
     {
+        var mark = GetComponent<LoyaltyMark>();
+        if (mark != null && mark.RedirectDamage(amount))
+            return;
+
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
         DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));

--- a/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public class LoyaltyMark : MonoBehaviour
+{
+    public CharacterUnit protector;
+
+    public void SetProtector(CharacterUnit unit)
+    {
+        protector = unit;
+    }
+
+    public bool RedirectDamage(float amount)
+    {
+        if (protector == null || protector.currentHP <= 0)
+            return false;
+        protector.TakeDamage(amount * 0.5f);
+        return true;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0123456789abcdef0123456789abcdef


### PR DESCRIPTION
## Résumé
- création du script **LoyaltyMark** pour rediriger les dégâts vers Kael
- modification de **CharacterUnit** pour prendre en compte cette marque
- ajout du nouvel effet `LoyaltyMark` dans **MusicalMoveSO**
- création du MusicalMove `PourQuiSonneLeGlas`
- ajout de la fiche de personnage pour Kael

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863cdbdf41883259ba0f57981d25998