### PR TITLE
Ajout des animations d'interception et de blessure

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -11,6 +11,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public HPBar hpBar;
     public CustomBar customBar;
 
+    [Header("Animations")]
+    public AnimationClip hurtAnimation;
+    public AnimationClip interceptedAnimation;
+    public AnimationClip interceptionAnimation;
+
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
     private Animator animator;
@@ -144,6 +149,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (hpBar != null) hpBar.SetValue(currentHP);
         DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
+        PlayHurtAnimation();
         GetComponent<SleepStatus>()?.OnDamageTaken();
         GetComponent<ConcentrationSystem>()?.OnDamageTaken(amount);
         if (Data != null && Data.gameplayType == GameplayType.Rage)
@@ -271,6 +277,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         transform.position = start;
     }
+
+    void PlayAnimationClip(AnimationClip clip)
+    {
+        if (animator != null && clip != null)
+            animator.Play(clip.name);
+    }
+
+    public void PlayHurtAnimation() => PlayAnimationClip(hurtAnimation);
+    public void PlayInterceptedAnimation() => PlayAnimationClip(interceptedAnimation);
+    public void PlayInterceptionAnimation() => PlayAnimationClip(interceptionAnimation);
 
     void PlayDamageFeedback()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -921,12 +921,8 @@ public class NewBattleManager : MonoBehaviour
     {
         if (interceptor == null) yield break;
 
-        // Trigger the "intercepted" animation on the caster
-        var casterAnim = caster.GetComponentInChildren<Animator>();
-        if (casterAnim != null)
-        {
-            casterAnim.SetTrigger("intercepted");
-        }
+        caster?.PlayInterceptedAnimation();
+        interceptor?.PlayInterceptionAnimation();
 
         var move = interceptor.GetRandomMusicalAttack();
         if (move != null)


### PR DESCRIPTION
## Résumé
- ajout de trois AnimationClip dans `CharacterUnit`
- lecture des animations lors des dégâts et des interceptions
- mise à jour de `NewBattleManager` pour déclencher les animations adéquates

## Tests
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864054412348325be13e9a83ed9b835