### PR TITLE
Ajout Concentration et Souffle pour Luna

### DIFF
--- a/Assets/Characters/Luna/Character_Luna.asset
+++ b/Assets/Characters/Luna/Character_Luna.asset
@@ -15,8 +15,8 @@ MonoBehaviour:
   characterName: Luna
   portrait: {fileID: 0}
   characterType: 0
-  gameplayType: 0
-  harmonicType: 0
+  gameplayType: 2
+  harmonicType: 2
   characterWorldModel: {fileID: 0}
   characterBattleModel: {fileID: 0}
   battlefieldIndex: 0

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -102,5 +102,5 @@ public class CharacterData : ScriptableObject, ITargetable
 }
 
 public enum CharacterType { SquadUnit, EnemyUnit }
-public enum GameplayType { Rage, Fatigue }
+public enum GameplayType { Rage, Fatigue, Concentration }
 

--- a/Assets/Scripts/Classes/HarmonicType.cs
+++ b/Assets/Scripts/Classes/HarmonicType.cs
@@ -1,5 +1,6 @@
 public enum HarmonicType
 {
     Lumiere,
-    Brume
+    Brume,
+    Souffle
 }


### PR DESCRIPTION
## Summary
- ajout de `Concentration` dans l'enum `GameplayType`
- ajout de `Souffle` dans l'enum `HarmonicType`
- mise à jour des données de Luna pour utiliser ce gameplay et ces harmoniques

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68640f13be34832591fdf97cf1fdfb3f