### PR TITLE
Ajuste de la sélection de cibles

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -69,6 +69,8 @@ public class InputsManager : MonoBehaviour
         battle.Back.performed += OnBackInput;
         battle.Back.canceled += OnBackCanceled;
         battle.Confirm.performed += OnConfirm;
+        battle.EnemiesGroupSelection.performed += OnEnemiesGroupSelection;
+        battle.SquadGroupSelection.performed += OnSquadGroupSelection;
 
         var world = playerInputs.World;
         world.ForceCam.performed += OnForceCamInput;
@@ -88,6 +90,8 @@ public class InputsManager : MonoBehaviour
         battle.Back.performed -= OnBackInput;
         battle.Back.canceled -= OnBackCanceled;
         battle.Confirm.performed -= OnConfirm;
+        battle.EnemiesGroupSelection.performed -= OnEnemiesGroupSelection;
+        battle.SquadGroupSelection.performed -= OnSquadGroupSelection;
 
         var world = playerInputs.World;
         world.ForceCam.performed -= OnForceCamInput;
@@ -370,7 +374,7 @@ public class InputsManager : MonoBehaviour
         NewBattleManager.Instance.EndTurn();
     }
 
-    private void OnEnemiesGroupSelection()
+    private void OnEnemiesGroupSelection(InputAction.CallbackContext ctx)
     {
         NewBattleManager bm = NewBattleManager.Instance;
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad)
@@ -397,7 +401,7 @@ public class InputsManager : MonoBehaviour
         }
     }
 
-    private void OnSquadGroupSelection()
+    private void OnSquadGroupSelection(InputAction.CallbackContext ctx)
     {
         NewBattleManager bm = NewBattleManager.Instance;
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1599,48 +1599,37 @@ public class NewBattleManager : MonoBehaviour
             case TargetType.Self:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForSkill);
                 currentTargetCharacter = currentCharacterUnit;
-                currentTargetIndex = 0;
                 break;
 
             case TargetType.SingleEnemy:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill);
-
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
                 break;
 
             case TargetType.AllEnemies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
-
                 currentTargetCharacter = activeCharacterUnits
-                    .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
-                break;
+                    .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
                 break;
 
             case TargetType.SingleAlly:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForSkill);
-                break;
-
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
                 break;
 
             case TargetType.AllAllies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
-
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
-                break;
                 break;
 
             default:
                 Debug.LogWarning($"[BattleTurnManager] Type de cible par défaut non géré : {move.defaultTargetType}");
                 return;
         }
+        currentTargetIndex = 0;
     }
 
     public void HandleTargetSelection(ItemData item)
@@ -1652,42 +1641,37 @@ public class NewBattleManager : MonoBehaviour
             case TargetType.Self:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForItem);
                 currentTargetCharacter = currentCharacterUnit;
-                currentTargetIndex = 0;
                 break;
 
             case TargetType.SingleEnemy:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem);
-
                 currentTargetCharacter = activeCharacterUnits
-                    .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
+                    .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
                 break;
 
             case TargetType.AllEnemies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
                 currentTargetCharacter = activeCharacterUnits
-                    .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
+                    .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
                 break;
 
             case TargetType.SingleAlly:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadForItem);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
                 break;
 
             case TargetType.AllAllies:
                 ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.SquadUnit && u.currentHP > 0);
-                currentTargetIndex = 0;
                 break;
 
             default:
                 Debug.LogWarning($"[BattleTurnManager] Type de cible par défaut non géré : {item.defaultTargetType}");
                 return;
         }
+        currentTargetIndex = 0;
 
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectTarget();
     }

--- a/Assets/Scripts/PlayerInputs.inputactions
+++ b/Assets/Scripts/PlayerInputs.inputactions
@@ -771,7 +771,7 @@
                 {
                     "name": "",
                     "id": "8f0ccf5a-0a44-46a9-bb1f-84a91689a846",
-                    "path": "<Gamepad>/leftShoulder",
+                    "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -793,7 +793,7 @@
                 {
                     "name": "",
                     "id": "5a63149a-5684-4e90-88ba-69a9dc0b6a68",
-                    "path": "<Gamepad>/rightShoulder",
+                    "path": "<Gamepad>/leftTrigger",
                     "interactions": "",
                     "processors": "",
                     "groups": "",


### PR DESCRIPTION
## Résumé
- ajout du changement de groupe cible via les triggers
- correction de la sélection par défaut des cibles
- mise à jour des bindings dans `PlayerInputs.inputactions`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68642793ec388325a148b2ac7a754a6e