### PR TITLE
Amélioration de la navigation retour dans le ciblage

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -313,19 +313,39 @@ public class InputsManager : MonoBehaviour
     private void OnBackInput(InputAction.CallbackContext ctx)
     {
         NewBattleManager bm = NewBattleManager.Instance;
-        if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu || bm.currentBattleState == BattleState.SquadUnit_ItemsMenu)
+
+        if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu ||
+            bm.currentBattleState == BattleState.SquadUnit_ItemsMenu)
         {
             bm.ShowMainMenu();
+            return;
         }
-        else if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill)
+
+        if (IsSkillTargetSelectionState(bm.currentBattleState))
         {
             bm.OpenSkillsMenu();
             bm.currentCharacterUnit.GetComponentInChildren<Animator>().SetTrigger("exitAction");
         }
-        else if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem)
+        else if (IsItemTargetSelectionState(bm.currentBattleState))
         {
             bm.OpenItemMenu();
         }
+    }
+
+    private bool IsSkillTargetSelectionState(BattleState state)
+    {
+        return state == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill ||
+               state == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
+               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && NewBattleManager.Instance.currentMove != null) ||
+               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && NewBattleManager.Instance.currentMove != null);
+    }
+
+    private bool IsItemTargetSelectionState(BattleState state)
+    {
+        return state == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem ||
+               state == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
+               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && NewBattleManager.Instance.currentItem != null) ||
+               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && NewBattleManager.Instance.currentItem != null);
     }
 
     private void OnBackStarted(InputAction.CallbackContext ctx)


### PR DESCRIPTION
## Résumé
- ajout de nouvelles vérifications dans `InputsManager` pour reconnaître tous les états de sélection de cible
- possibilité de revenir vers les menus de compétences ou d'objets tant qu'aucune cible n'a été validée

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68642cd50d408325af1b538630c93956