### PR TITLE
Ajout du masque d'occlusion caméra

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Affiche un masque circulaire autour de la cible lorsque celle-ci est occultée par un obstacle.
+/// </summary>
+public class CameraOcclusionMask : MonoBehaviour
+{
+    [Header("Cible")] [SerializeField] private Transform target;
+    [Header("Couches Obstacles")] [SerializeField] private LayerMask obstacleLayers = -1;
+
+    [Header("Masque Visuel")] [SerializeField] private Camera maskCamera;
+    [SerializeField] private GameObject maskObject;
+    [SerializeField] private float maskSize = 250f;
+
+    private RectTransform maskRect;
+
+    private void Awake()
+    {
+        if (maskObject != null)
+        {
+            maskRect = maskObject.GetComponent<RectTransform>();
+            maskObject.SetActive(false);
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (target == null || maskRect == null || maskCamera == null) return;
+
+        Vector3 dir = target.position - transform.position;
+        bool occluded = Physics.Raycast(transform.position, dir.normalized, dir.magnitude, obstacleLayers);
+
+        if (occluded)
+        {
+            if (!maskObject.activeSelf)
+                maskObject.SetActive(true);
+
+            Vector3 screenPos = maskCamera.WorldToScreenPoint(target.position);
+            maskRect.position = screenPos;
+            maskRect.sizeDelta = Vector2.one * maskSize;
+        }
+        else
+        {
+            if (maskObject.activeSelf)
+                maskObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08800a83b9da4b43bbae61b184797766


### PR DESCRIPTION
## Résumé
- ajout d'un script `CameraOcclusionMask` pour afficher un masque circulaire autour de la cible lorsque celle‑ci est masquée

## Test
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68650cb712908325914503e1753a23d5