### PR TITLE
Ajout gestion rage Lucian

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -724,6 +724,8 @@ public class NewBattleManager : MonoBehaviour
             {
                 target.TakeDamage(bonus);
             }
+            if (rage.IsEnraged)
+                rage.ConsumeRage();
         }
 
         var concentration = caster.GetComponent<ConcentrationSystem>();

--- a/Assets/Scripts/MonoBehavioursUsed/RageState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RageState.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CharacterUnit))]
+public class RageState : MonoBehaviour
+{
+    [Header("Effets visuels")]
+    public GameObject rageEffectPrefab;
+    public GameObject calmEffectPrefab;
+    public Vector3 effectOffset = new(0f, 2f, 0f);
+
+    [Header("Animations")]
+    public AnimationClip rageAnimation;
+    public AnimationClip calmAnimation;
+
+    [Header("Effets sonores")]
+    public AudioClip rageClip;
+    public AudioClip calmClip;
+
+    [Header("Camera")]
+    public OrbitAroundTriggerSO rageCameraPath;
+
+    private AudioSource audioSource;
+    private Animator animator;
+    private GameObject currentEffect;
+    private bool isEnraged;
+
+    private CharacterUnit unit;
+
+    private void Awake()
+    {
+        unit = GetComponent<CharacterUnit>();
+        audioSource = GetComponent<AudioSource>();
+        animator = GetComponent<Animator>();
+    }
+
+    public void OnRageChanged(float currentRage)
+    {
+        if (!isEnraged && currentRage >= GetMaxRage())
+            EnterRage();
+        else if (isEnraged && currentRage <= GetBaseRage())
+            ExitRage();
+    }
+
+    private float GetMaxRage() => unit != null && unit.Data != null ? unit.Data.maxRage : 100f;
+    private float GetBaseRage() => unit != null && unit.Data != null ? unit.Data.baseRage : 0f;
+
+    private void EnterRage()
+    {
+        isEnraged = true;
+        if (rageClip != null && audioSource != null)
+            audioSource.PlayOneShot(rageClip);
+        if (rageAnimation != null && animator != null)
+            animator.Play(rageAnimation.name);
+        rageCameraPath?.StartOrbit();
+        if (rageEffectPrefab != null)
+            currentEffect = Instantiate(rageEffectPrefab, transform.position + effectOffset, Quaternion.identity, transform);
+    }
+
+    private void ExitRage()
+    {
+        isEnraged = false;
+        if (calmClip != null && audioSource != null)
+            audioSource.PlayOneShot(calmClip);
+        if (calmAnimation != null && animator != null)
+            animator.Play(calmAnimation.name);
+        rageCameraPath?.StopOrbit();
+        if (currentEffect != null)
+        {
+            Destroy(currentEffect);
+            currentEffect = null;
+        }
+        if (calmEffectPrefab != null)
+            Instantiate(calmEffectPrefab, transform.position + effectOffset, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/RageSystem.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RageSystem.cs
@@ -4,10 +4,12 @@ using UnityEngine;
 public class RageSystem : MonoBehaviour
 {
     private CharacterUnit unit;
+    private RageState rageState;
 
     private void Awake()
     {
         unit = GetComponent<CharacterUnit>();
+        rageState = GetComponent<RageState>();
     }
 
     public void AddRage(float damage)
@@ -16,7 +18,19 @@ public class RageSystem : MonoBehaviour
         unit.currentRage = Mathf.Clamp(unit.currentRage + damage, unit.Data.baseRage, unit.Data.maxRage);
         if (unit.customBar != null)
             unit.customBar.SetValue(unit.currentRage);
+        rageState?.OnRageChanged(unit.currentRage);
     }
+
+    public void ConsumeRage()
+    {
+        if (unit == null || unit.Data == null) return;
+        unit.currentRage = unit.Data.baseRage;
+        if (unit.customBar != null)
+            unit.customBar.SetValue(unit.currentRage);
+        rageState?.OnRageChanged(unit.currentRage);
+    }
+
+    public bool IsEnraged => unit != null && unit.Data != null && unit.currentRage >= unit.Data.maxRage;
 
     public float CalculateBonusDamage()
     {


### PR DESCRIPTION
## Résumé
- ajout d'un composant `RageState` contrôlant l'entrée et la sortie de rage
- intégration de `RageState` dans `RageSystem`
- consommation automatique de la rage après une attaque

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68658aafdf54832590994471d28400ab