### PR TITLE
Ajout d'effets d'état génériques

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ConcentrationSystem.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ConcentrationSystem.cs
@@ -9,12 +9,15 @@ public class ConcentrationSystem : MonoBehaviour
 
     private CharacterUnit unit;
     private float lastDamageTime;
+    private bool wasFull;
+    private UnitStateEffects stateEffects;
 
     public bool IsFull => currentConcentration >= maxConcentration;
 
     private void Awake()
     {
         unit = GetComponent<CharacterUnit>();
+        stateEffects = GetComponent<UnitStateEffects>();
     }
 
     private void Update()
@@ -24,6 +27,7 @@ public class ConcentrationSystem : MonoBehaviour
             currentConcentration = Mathf.Max(currentConcentration - decayPerSecond * Time.deltaTime, 0f);
             UpdateBar();
         }
+        CheckState();
     }
 
     public void OnDamageTaken(float damage)
@@ -31,6 +35,7 @@ public class ConcentrationSystem : MonoBehaviour
         lastDamageTime = Time.time;
         currentConcentration = Mathf.Clamp(currentConcentration + damage * 0.1f, 0f, maxConcentration);
         UpdateBar();
+        CheckState();
     }
 
     public float CalculateBonusDamage(float baseDamage)
@@ -42,5 +47,19 @@ public class ConcentrationSystem : MonoBehaviour
     {
         if (unit != null && unit.customBar != null)
             unit.customBar.SetValue(currentConcentration);
+    }
+
+    private void CheckState()
+    {
+        if (!wasFull && IsFull)
+        {
+            stateEffects?.EnterState();
+            wasFull = true;
+        }
+        else if (wasFull && !IsFull)
+        {
+            stateEffects?.ExitState();
+            wasFull = false;
+        }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/FatigueSystem.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FatigueSystem.cs
@@ -11,10 +11,12 @@ public class FatigueSystem : MonoBehaviour
     private bool isAsleep;
     private Coroutine routine;
     public bool IsAsleep => isAsleep;
+    private UnitStateEffects stateEffects;
 
     private void Awake()
     {
         unit = GetComponent<CharacterUnit>();
+        stateEffects = GetComponent<UnitStateEffects>();
     }
 
     public void OnActionPerformed(float amount = 1f)
@@ -34,10 +36,12 @@ public class FatigueSystem : MonoBehaviour
     private IEnumerator SleepRoutine()
     {
         isAsleep = true;
+        stateEffects?.EnterState();
         yield return new WaitForSeconds(asleepDuration);
         unit.currentFatigue = unit.Data.baseFatigue;
         if (unit.customBar != null)
             unit.customBar.SetValue(unit.currentFatigue);
+        stateEffects?.ExitState();
         isAsleep = false;
         routine = null;
     }

--- a/Assets/Scripts/MonoBehavioursUsed/RageState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RageState.cs
@@ -1,36 +1,16 @@
 using UnityEngine;
 
 [RequireComponent(typeof(CharacterUnit))]
-public class RageState : MonoBehaviour
+public class RageState : UnitStateEffects
 {
-    [Header("Effets visuels")]
-    public GameObject rageEffectPrefab;
-    public GameObject calmEffectPrefab;
-    public Vector3 effectOffset = new(0f, 2f, 0f);
-
-    [Header("Animations")]
-    public AnimationClip rageAnimation;
-    public AnimationClip calmAnimation;
-
-    [Header("Effets sonores")]
-    public AudioClip rageClip;
-    public AudioClip calmClip;
-
-    [Header("Camera")]
-    public OrbitAroundTriggerSO rageCameraPath;
-
-    private AudioSource audioSource;
-    private Animator animator;
-    private GameObject currentEffect;
     private bool isEnraged;
 
     private CharacterUnit unit;
 
-    private void Awake()
+    protected override void Awake()
     {
+        base.Awake();
         unit = GetComponent<CharacterUnit>();
-        audioSource = GetComponent<AudioSource>();
-        animator = GetComponent<Animator>();
     }
 
     public void OnRageChanged(float currentRage)
@@ -47,29 +27,12 @@ public class RageState : MonoBehaviour
     private void EnterRage()
     {
         isEnraged = true;
-        if (rageClip != null && audioSource != null)
-            audioSource.PlayOneShot(rageClip);
-        if (rageAnimation != null && animator != null)
-            animator.Play(rageAnimation.name);
-        rageCameraPath?.StartOrbit();
-        if (rageEffectPrefab != null)
-            currentEffect = Instantiate(rageEffectPrefab, transform.position + effectOffset, Quaternion.identity, transform);
+        EnterState();
     }
 
     private void ExitRage()
     {
         isEnraged = false;
-        if (calmClip != null && audioSource != null)
-            audioSource.PlayOneShot(calmClip);
-        if (calmAnimation != null && animator != null)
-            animator.Play(calmAnimation.name);
-        rageCameraPath?.StopOrbit();
-        if (currentEffect != null)
-        {
-            Destroy(currentEffect);
-            currentEffect = null;
-        }
-        if (calmEffectPrefab != null)
-            Instantiate(calmEffectPrefab, transform.position + effectOffset, Quaternion.identity);
+        ExitState();
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/UnitStateEffects.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/UnitStateEffects.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+[RequireComponent(typeof(AudioSource))]
+[RequireComponent(typeof(Animator))]
+public class UnitStateEffects : MonoBehaviour
+{
+    [Header("Effets visuels")]
+    public GameObject enterEffectPrefab;
+    public GameObject exitEffectPrefab;
+    public Vector3 effectOffset = new(0f, 2f, 0f);
+
+    [Header("Animations")]
+    public AnimationClip enterAnimation;
+    public AnimationClip exitAnimation;
+
+    [Header("Effets sonores")]
+    public AudioClip enterClip;
+    public AudioClip exitClip;
+
+    [Header("Camera")]
+    public OrbitAroundTriggerSO cameraPath;
+
+    protected AudioSource audioSource;
+    protected Animator animator;
+    private GameObject currentEffect;
+
+    protected virtual void Awake()
+    {
+        audioSource = GetComponent<AudioSource>();
+        animator = GetComponent<Animator>();
+    }
+
+    public void EnterState()
+    {
+        if (enterClip != null)
+            audioSource?.PlayOneShot(enterClip);
+        if (enterAnimation != null)
+            animator?.Play(enterAnimation.name);
+        cameraPath?.StartOrbit();
+        if (enterEffectPrefab != null)
+            currentEffect = Instantiate(enterEffectPrefab, transform.position + effectOffset, Quaternion.identity, transform);
+    }
+
+    public void ExitState()
+    {
+        if (exitClip != null)
+            audioSource?.PlayOneShot(exitClip);
+        if (exitAnimation != null)
+            animator?.Play(exitAnimation.name);
+        cameraPath?.StopOrbit();
+        if (currentEffect != null)
+        {
+            Destroy(currentEffect);
+            currentEffect = null;
+        }
+        if (exitEffectPrefab != null)
+            Instantiate(exitEffectPrefab, transform.position + effectOffset, Quaternion.identity);
+    }
+}


### PR DESCRIPTION
## Summary
- créer `UnitStateEffects` pour gérer effets visuels/sonores, animations et caméras lors d'un changement d'état
- utiliser ce système dans `RageState`, `FatigueSystem` et `ConcentrationSystem`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68658d87cc8c8325bec8bb07d75480af