### PR TITLE
Ajout d'une fenêtre d'information sur les compétences

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   power: 50
   fatigueCost: 1
   harmonicCost: 3
+  harmonicGeneration: 0
   targetType: 2
   defaultTargetType: 2
   effectType: 0

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   power: 0
   fatigueCost: 1
   harmonicCost: 1
+  harmonicGeneration: 0
   targetType: 0
   defaultTargetType: 0
   effectType: 5

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -25,6 +25,7 @@ MonoBehaviour:
   power: 0
   fatigueCost: 1
   harmonicCost: 1
+  harmonicGeneration: 0
   targetType: 3
   defaultTargetType: 3
   targetTypes: 03000000

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -23,6 +23,7 @@ public class MusicalMoveSO : ScriptableObject
     public float power = 0;
     public float fatigueCost = 1;
     public int harmonicCost = 1;
+    public int harmonicGeneration = 0;
 
     [Header("Ciblage")]
     public TargetType targetType = TargetType.SingleEnemy;

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -183,11 +183,7 @@ public class InputsManager : MonoBehaviour
                     bm.ShowMainMenu();
                     return;
                 }
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowMoveInfoAndHandleSelection(bm.currentMove));
             }
             else
             {
@@ -234,11 +230,7 @@ public class InputsManager : MonoBehaviour
                     bm.ShowMainMenu();
                     return;
                 }
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowMoveInfoAndHandleSelection(bm.currentMove));
             }
             else
             {
@@ -281,11 +273,7 @@ public class InputsManager : MonoBehaviour
                     bm.ShowMainMenu();
                     return;
                 }
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowMoveInfoAndHandleSelection(bm.currentMove));
             }
             else
             {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -974,6 +974,7 @@ public class NewBattleManager : MonoBehaviour
         if (caster != null)
         {
             caster.ConsumeHarmonic(caster.Data.harmonicType, move.harmonicCost);
+            caster.AddHarmonic(caster.Data.harmonicType, move.harmonicGeneration);
 
             // Si l'unité n'a plus d'harmonique, son tour se termine immédiatement
             if (caster.GetHarmonicCount(caster.Data.harmonicType) <= 0)
@@ -996,6 +997,27 @@ public class NewBattleManager : MonoBehaviour
             EndTurn();
         else
             ShowMainMenu();
+    }
+
+    public IEnumerator ShowMoveInfoAndHandleSelection(MusicalMoveSO move)
+    {
+        string message = $"{move.description}\nCoût : {move.harmonicCost} harmonique(s)\nGénère : {move.harmonicGeneration} harmonique(s)";
+        InfoBoxManager.Instance.OpenInfoBox(move.moveName, message, move.moveIcon);
+        while (!InfoBoxManager.Instance.choix.HasValue)
+            yield return null;
+
+        if (InfoBoxManager.Instance.choix.Value)
+        {
+            ToggleMenuContainers(false, false, false);
+            HandleTargetSelection(move);
+
+            if (move.musicalMoveTargetingAnimation != null)
+                currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(move.musicalMoveTargetingAnimation.name);
+        }
+        else
+        {
+            OpenSkillsMenu();
+        }
     }
     #endregion
 


### PR DESCRIPTION
## Résumé
- ajout d'un champ `harmonicGeneration` dans `MusicalMoveSO`
- prise en compte de cette génération d'harmonique après un coup
- nouvelle méthode `ShowMoveInfoAndHandleSelection` dans `NewBattleManager`
- modification des sélections dans `InputsManager` pour afficher une fenêtre d'information via `InfoBoxManager`
- mise à jour des assets de compétences pour inclure `harmonicGeneration`

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6866683f5c688325b44ef8e4f583f6db