### PR TITLE
Ajout description objets dans le menu de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -195,11 +195,7 @@ public class InputsManager : MonoBehaviour
             if (bm.itemChoices.Count > 0)
             {
                 bm.currentItem = bm.itemChoices[0];
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowItemInfoAndHandleSelection(bm.currentItem));
             }
             else
             {
@@ -242,11 +238,7 @@ public class InputsManager : MonoBehaviour
             if (bm.itemChoices.Count > 1)
             {
                 bm.currentItem = bm.itemChoices[1];
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowItemInfoAndHandleSelection(bm.currentItem));
             }
             else
             {
@@ -285,11 +277,7 @@ public class InputsManager : MonoBehaviour
             if (bm.itemChoices.Count > 2)
             {
                 bm.currentItem = bm.itemChoices[2];
-                bm.ToggleMenuContainers(false, false, false);
-                bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                bm.StartCoroutine(bm.ShowItemInfoAndHandleSelection(bm.currentItem));
             }
             else
             {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1019,6 +1019,27 @@ public class NewBattleManager : MonoBehaviour
             OpenSkillsMenu();
         }
     }
+
+    public IEnumerator ShowItemInfoAndHandleSelection(ItemData item)
+    {
+        string message = item.description;
+        InfoBoxManager.Instance.OpenInfoBox(item.itemName, message, item.itemIcon);
+        while (!InfoBoxManager.Instance.choix.HasValue)
+            yield return null;
+
+        if (InfoBoxManager.Instance.choix.Value)
+        {
+            ToggleMenuContainers(false, false, false);
+            HandleTargetSelection(item);
+
+            if (item.itemTargetingAnimation != null)
+                currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(item.itemTargetingAnimation.name);
+        }
+        else
+        {
+            OpenItemMenu();
+        }
+    }
     #endregion
 
     #region Gestion de l'orientation des unités


### PR DESCRIPTION
## Résumé
- ajout d'une méthode `ShowItemInfoAndHandleSelection` dans `NewBattleManager`
- présentation de la description des objets avant la sélection d'une cible
- mise à jour de `InputsManager` pour appeler cette nouvelle méthode lors de la sélection d'objets

## Tests
- `dotnet --version` *(échoue : commande indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_68666eb73bac832597c8e6cdf7a3c48c