### PR TITLE
Set cursor to first unit when switching target group

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -448,6 +448,7 @@ public class InputsManager : MonoBehaviour
                 return;
 
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
+            bm.SetCurrentTargetToFirst(CharacterType.EnemyUnit);
 
         }
     }
@@ -506,6 +507,7 @@ public class InputsManager : MonoBehaviour
                 return;
 
             bm.ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad);
+            bm.SetCurrentTargetToFirst(CharacterType.SquadUnit);
 
         }
     }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2066,6 +2066,13 @@ public class NewBattleManager : MonoBehaviour
         }
     }
 
+    public void SetCurrentTargetToFirst(CharacterType type)
+    {
+        currentTargetIndex = 0;
+        currentTargetCharacter = activeCharacterUnits
+            .FirstOrDefault(u => u.characterType == type && u.currentHP > 0);
+    }
+
     public void ResetBattleInfos()
     {
         // Réinitialise l’état du combat


### PR DESCRIPTION
## Summary
- add helper `SetCurrentTargetToFirst` in `NewBattleManager`
- when switching target group via inputs, select the first living unit of that group

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866da313bd483259063d29b3364c834