### PR TITLE
Fix item targeting state check

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -120,11 +120,8 @@ public class InputsManager : MonoBehaviour
     private void OnConfirm(InputAction.CallbackContext ctx)
     {
         NewBattleManager bm = NewBattleManager.Instance;
-        if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies
-            )
+
+        if (IsSkillTargetSelectionState(bm.currentBattleState))
         {
             if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentMove))
             {
@@ -136,9 +133,8 @@ public class InputsManager : MonoBehaviour
             bm.StartCoroutine(bm.ExecuteMoveOnTarget(bm.currentMove, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);
         }
-        else if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForItem)
-            {
+        else if (IsItemTargetSelectionState(bm.currentBattleState))
+        {
             if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentItem))
             {
                 ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();


### PR DESCRIPTION
## Summary
- fix target confirmation logic when using items by leveraging `IsItemTargetSelectionState` and `IsSkillTargetSelectionState`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866dfaa13c083259333ecbeb110a06c