### PR TITLE
Refactor BattleState target selection

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -120,11 +120,7 @@ public class InputsManager : MonoBehaviour
     private void OnConfirm(InputAction.CallbackContext ctx)
     {
         NewBattleManager bm = NewBattleManager.Instance;
-        if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies
-            )
+        if (IsSkillTargetSelectionState(bm.currentBattleState))
         {
             if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentMove))
             {
@@ -136,8 +132,7 @@ public class InputsManager : MonoBehaviour
             bm.StartCoroutine(bm.ExecuteMoveOnTarget(bm.currentMove, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);
         }
-        else if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem
-            || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForItem)
+        else if (IsItemTargetSelectionState(bm.currentBattleState))
             {
             if (!bm.IsTargetInRange(bm.currentCharacterUnit, bm.currentTargetCharacter, bm.currentItem))
             {
@@ -334,18 +329,18 @@ public class InputsManager : MonoBehaviour
 
     private bool IsSkillTargetSelectionState(BattleState state)
     {
-        return state == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill ||
-               state == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
-               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && NewBattleManager.Instance.currentMove != null) ||
-               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && NewBattleManager.Instance.currentMove != null);
+        return state == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
+               ((state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad ||
+                 state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies) &&
+                NewBattleManager.Instance.currentMove != null);
     }
 
     private bool IsItemTargetSelectionState(BattleState state)
     {
-        return state == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem ||
-               state == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
-               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && NewBattleManager.Instance.currentItem != null) ||
-               (state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && NewBattleManager.Instance.currentItem != null);
+        return state == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
+               ((state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad ||
+                 state == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies) &&
+                NewBattleManager.Instance.currentItem != null);
     }
 
     private void OnBackStarted(InputAction.CallbackContext ctx)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -37,8 +37,6 @@ public enum BattleState
     SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies,
     SquadUnit_TargetSelectionAmongSquadForSkill,
     SquadUnit_TargetSelectionAmongSquadForItem,
-    SquadUnit_TargetSelectionAmongEnemiesForSkill,
-    SquadUnit_TargetSelectionAmongEnemiesForItem,
     SquadUnit_PerformingMusicalMove,
     SquadUnit_Item_Prepare,
     SquadUnit_Item_Use,
@@ -1532,13 +1530,11 @@ public class NewBattleManager : MonoBehaviour
     #region Gestion de la navigation dans les menus
     private void HandleTargetNavigation()
     {
-        bool isSkillTargeting = currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill ||
-                                currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
+        bool isSkillTargeting = currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
                                 (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && currentMove != null) ||
                                 (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && currentMove != null);
 
-        bool isItemTargeting = currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem ||
-                               currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
+        bool isItemTargeting = currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
                                (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && currentItem != null) ||
                                (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && currentItem != null);
 
@@ -1592,13 +1588,11 @@ public class NewBattleManager : MonoBehaviour
     private void HandleTargetCursor()
     {
         bool isSkillTargeting =
-            currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill ||
             currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill ||
             (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && currentMove != null) ||
             (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && currentMove != null);
 
         bool isItemTargeting =
-            currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem ||
             currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForItem ||
             (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad && currentItem != null) ||
             (currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies && currentItem != null);
@@ -1706,7 +1700,7 @@ public class NewBattleManager : MonoBehaviour
                 break;
 
             case TargetType.SingleEnemy:
-                ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill);
+                ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
                 break;
@@ -1763,10 +1757,7 @@ public class NewBattleManager : MonoBehaviour
                 break;
 
             case TargetType.SingleEnemy:
-                if (allowGroupSwitch)
-                    ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
-                else
-                    ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem);
+                ChangeBattleState(BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnEnemies);
                 currentTargetCharacter = activeCharacterUnits
                     .FirstOrDefault(u => u.characterType == CharacterType.EnemyUnit && u.currentHP > 0);
                 break;
@@ -1896,15 +1887,6 @@ public class NewBattleManager : MonoBehaviour
                 isFollowingCurrentTarget = true;
                 break;
 
-            case BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill:
-                isFollowingCurrentTarget = false;
-                desiredTransform = FindChildRecursive(targetCursor.transform, "Camera_TargetedPoint");
-                break;
-
-            case BattleState.SquadUnit_TargetSelectionAmongEnemiesForItem:
-                desiredTransform = FindChildRecursive(currentCharacterUnit.transform, "Camera_UseItem_Prepare");
-                isFollowingCurrentTarget = true;
-                break;
 
             case BattleState.SquadUnit_PerformingMusicalMove:
                 isFollowingCurrentTarget = true;


### PR DESCRIPTION
## Summary
- nettoie l'énumération `BattleState`
- utilise uniquement les états de ciblage partagés
- ajuste la navigation et les validations de cible

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866e2a46ddc8325ad0c9bc0eb7525af