### PR TITLE
Intégration des notes pour les QTE

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -19,6 +19,18 @@ public class MusicalMoveSO : ScriptableObject
     public string[] musicalMoveIntroAnimationNames;
     public string[] musicalMoveAnimationNames;
 
+    [System.Serializable]
+    public class NoteData
+    {
+        public AudioClip clip;
+        [Tooltip("Durée de la fenêtre QTE pour cette note (en secondes)")]
+        public float rhythm = 0.5f;
+    }
+
+    [Header("Partition musicale")]
+    [Range(2, 6)]
+    public List<NoteData> notes = new();
+
     [Header("Coût et Dégâts")]
     public float power = 0;
     public float fatigueCost = 1;
@@ -59,9 +71,17 @@ public class MusicalMoveSO : ScriptableObject
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {
+        ApplyEffect(caster, target, false);
+    }
+
+    public void ApplyEffect(CharacterUnit caster, CharacterUnit target, bool isCritical)
+    {
         float finalValue = effectValue;
         if (caster != null)
             finalValue += caster.currentPower;
+
+        if (isCritical)
+            finalValue *= 2f;
 
         if (effectType == MusicalEffectType.Damage && target.Data.characterType == CharacterType.EnemyUnit)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
@@ -13,6 +13,11 @@ public class AnimationEventsManager : MonoBehaviour
     {
         RhythmQTEManager.Instance?.TriggerQTE(windowDelay);
     }
+
+    public void TriggerNote(int noteIndex)
+    {
+        RhythmQTEManager.Instance?.TriggerNote(noteIndex);
+    }
     
     public void TryToDamage()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -713,7 +713,8 @@ public class NewBattleManager : MonoBehaviour
             }
         }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
-        move.ApplyEffect(caster, target);
+        if (move.notes == null || move.notes.Count == 0)
+            move.ApplyEffect(caster, target);
 
         // Ajout du système de rage manuellement
         var rage = caster.GetComponent<RageSystem>();
@@ -939,7 +940,8 @@ public class NewBattleManager : MonoBehaviour
         {
             ActionUIDisplayManager.Instance.DisplayAttackName(move.moveName);
             yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, interceptor, caster);
-            move.ApplyEffect(interceptor, caster);
+            if (move.notes == null || move.notes.Count == 0)
+                move.ApplyEffect(interceptor, caster);
         }
     }
 


### PR DESCRIPTION
## Résumé
- ajout d'une méthode `TriggerNote` dans `AnimationEventsManager` pour lancer chaque note depuis un AnimationEvent
- `RhythmQTEManager` gère désormais les notes une par une via `TriggerNote`
- attente de la résolution des notes dans `MusicalMoveRoutine`
- suivi de l'état courant du move et remise à zéro en fin de séquence

## Test
- `npm test` échoue car aucun `package.json` n'est présent dans le projet


------
https://chatgpt.com/codex/tasks/task_e_68678eaad2848325975070ef8637bd8f