### PR TITLE
Fix conflits de caméra lors du mode forcé

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -149,6 +149,17 @@ public class CameraController : MonoBehaviour
     }
 
     /// <summary>
+    /// Effectue les ajustements de caméra en fin de frame pour éviter les conflits.
+    /// </summary>
+    void LateUpdate()
+    {
+        if (Application.isPlaying && currentWorldCameraState == WorldCameraState.Forced)
+        {
+            FollowForcedCameraPoint();
+        }
+    }
+
+    /// <summary>
     /// Fait tourner la caméra autour de la cible. Incompatible avec PathFollow actif.
     /// </summary>
     void UpdateOrbit()
@@ -463,7 +474,6 @@ public class CameraController : MonoBehaviour
         {
             case WorldCameraState.Forced:
                 UpdateForcedCameraPoint();
-                FollowForcedCameraPoint();  // 🔑 Suivi direct, fluide
                 break;
 
             case WorldCameraState.ResearchClosestCamPoint:


### PR DESCRIPTION
## Résumé
- mise à jour du `CameraController` pour que le suivi de la caméra forcée se fasse dans `LateUpdate`
- retrait de l'appel direct à `FollowForcedCameraPoint` dans la boucle principale

## Tests
- `git status`


------
https://chatgpt.com/codex/tasks/task_e_68680c644b6c83258dd4a0e482e7d9cc