### PR TITLE
Ajout du gameplay de Link et des marques

### DIFF
--- a/Assets/Characters/Link.meta
+++ b/Assets/Characters/Link.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a809efb192248799a1d380d47da7419
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Characters/Link/Character_Link.asset
+++ b/Assets/Characters/Link/Character_Link.asset
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbc0c89b53ea7e246ba03cfe31f29194, type: 3}
+  m_Name: Character_Link
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterData
+  characterName: Link
+  portrait: {fileID: 0}
+  characterType: 0
+  gameplayType: 0
+  harmonicType: 0
+  characterWorldModel: {fileID: 0}
+  characterBattleModel: {fileID: 901204007372340786, guid: 48bc122d024634b4789a14a245e83484, type: 3}
+  battlefieldIndex: 0
+  baseReflex: 0
+  baseMobility: 0
+  baseVitality: 0
+  basePower: 0
+  baseStability: 0
+  baseSagacity: 0
+  baseInitiative: 1
+  baseRange: 5
+  baseHP: 90
+  baseStrength: 1
+  baseDefense: 1
+  baseSpeed: 0
+  baseInterceptionRange: 1
+  baseInterceptionChance: 0
+  baseRage: 0
+  maxRage: 0
+  rageDamageMultiplier: 0
+  baseFatigue: 0
+  maxFatigue: 0
+  battleIdleAnimationName: Idle
+  musicalAttacks:
+  - {fileID: 11400000, guid: 569e2f6c75b54c48a2168cd683ef5a5b, type: 2}
+  - {fileID: 11400000, guid: 056fa00282444ed5922b42e8f67ffa55, type: 2}
+  currentInitiative: 1
+  currentRange: 5
+  currentHP: 90
+  currentStrength: 1
+  currentDefense: 1
+  currentPower: 0
+  currentStability: 0
+  currentVitality: 0
+  currentSagacity: 0
+  isPlayerControlled: 1
+  currentRage: 0
+  currentFatigue: 0
+  currentReflex: 0
+  currentMobility: 0
+  currentSpeed: 0
+  currentInterceptionRange: 1
+  currentInterceptionChance: 0
+  hitSound: {fileID: 0}
+  hitEffect: {fileID: 0}
+  deathEffect: {fileID: 0}
+  owner: {fileID: 0}

--- a/Assets/Characters/Link/Character_Link.asset.meta
+++ b/Assets/Characters/Link/Character_Link.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 424d859fedf542358ce3dbd2add216cd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Eclair.meta
+++ b/Assets/MusicalMoves/MusicalMove_Eclair.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6525719a9a0e4a84b32a8152c25da3d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_Eclair
+  m_EditorClassIdentifier: 
+  moveName: Eclair
+  moveType: 1
+  moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
+  description: 
+  musicalMoveTargetingAnimationName:
+  musicalMoveRunAnimationName:
+  maxRunDuration: 0.5
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames:
+  - Rhapsodie_Move
+  power: 10
+  fatigueCost: 1
+  targetType: 1
+  defaultTargetType: 1
+  effectType: 0
+  effectValue: 10
+  moveSpeed: 20
+  castDistance: 1.5
+  stayInPlace: 0
+  relativePosition: 1
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}
+  useTeleportation: 1
+  teleportStartVFXPrefab: {fileID: 0}
+  teleportEndVFXPrefab: {fileID: 0}
+  cameraPathPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 056fa00282444ed5922b42e8f67ffa55
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Marque.meta
+++ b/Assets/MusicalMoves/MusicalMove_Marque.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f917dd0b74124af5a322ab538b4c3b84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_Marque
+  m_EditorClassIdentifier: 
+  moveName: Marque
+  moveType: 2
+  moveIcon: {fileID: 0}
+  description: "Applique une marque sur un ennemi."
+  musicalMoveTargetingAnimation: {fileID: 0}
+  musicalMoveRunAnimationName:
+  maxRunDuration: 0
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  effectType: 7
+  effectValue: 0
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 1
+  interceptable: 1
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}
+  useTeleportation: 0
+  teleportStartVFXPrefab: {fileID: 0}
+  teleportEndVFXPrefab: {fileID: 0}
+  cameraPathPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 569e2f6c75b54c48a2168cd683ef5a5b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -110,6 +110,11 @@ public class MusicalMoveSO : ScriptableObject
                 mark = target.gameObject.AddComponent<LoyaltyMark>();
             mark.SetProtector(caster);
         }
+        else if (effectType == MusicalEffectType.LinkMark)
+        {
+            if (target.GetComponent<LinkMark>() == null)
+                target.gameObject.AddComponent<LinkMark>();
+        }
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
@@ -118,6 +123,6 @@ public class MusicalMoveSO : ScriptableObject
     }
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
 
 public enum RelativePosition { Front, Back, Left, Right }

--- a/Assets/Scripts/MonoBehavioursUsed/LinkMark.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LinkMark.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+/// <summary>
+/// Marque appliquée par l'unité Link pour cibler plusieurs ennemis.
+/// </summary>
+public class LinkMark : MonoBehaviour {
+}

--- a/Assets/Scripts/MonoBehavioursUsed/LinkMark.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/LinkMark.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fae3a2010f3f4073b4cd680ba9050c9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -446,6 +446,22 @@ public class RhythmQTEManager : MonoBehaviour
         qteActive = false;
     }
 
+    /// <summary>
+    /// Exécute un MusicalMove sur toutes les cibles marquées par Link.
+    /// </summary>
+    public IEnumerator MusicalMoveOnMarkedTargets(MusicalMoveSO move, CharacterUnit caster)
+    {
+        var targets = NewBattleManager.Instance.activeCharacterUnits
+            .Where(u => u.GetComponent<LinkMark>() != null && u.currentHP > 0 && u != caster)
+            .OrderBy(u => Vector3.Distance(caster.transform.position, u.transform.position))
+            .ToList();
+
+        foreach (var target in targets)
+        {
+            yield return MusicalMoveRoutine(move, caster, target);
+        }
+    }
+
 
     private Transform FindTargetForMove(MusicalMoveSO move)
     {


### PR DESCRIPTION
## Résumé
- ajoute la classe `LinkMark`
- étend `MusicalMoveSO` avec l'effet `LinkMark`
- ajoute une méthode de chaîne de cibles dans `RhythmQTEManager`
- crée les ScriptableObjects nécessaires (`MusicalMove_Eclair`, `MusicalMove_Marque`)
- ajoute la fiche personnage `Character_Link`

## Tests
- `Test suite placeholder`

------
https://chatgpt.com/codex/tasks/task_e_686828a9f3ac83259432b1cc28b30ab1