### PR TITLE
Maintien du ralentissement lors de l'init du combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -90,7 +90,6 @@ public class BattleTransitionManager : MonoBehaviour
     {
         yield return SlowTimeScale(to: 0.1f, speed: 2f);
         yield return new WaitForSecondsRealtime(worldRiftTweener.tweenDuration);
-        yield return RestoreTimeScale(from: 0.1f, to: 1f, speed: 2f);
 
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
         int battlefieldIndex = playerDetection.detectedEnemies[0].battlefieldIndex;
@@ -161,6 +160,7 @@ public class BattleTransitionManager : MonoBehaviour
         }
 
         yield return NewBattleManager.Instance.StartBattle();
+        yield return RestoreTimeScale(from: 0.1f, to: 1f, speed: 2f);
     }
 
     public IEnumerator ExitVictoryScreenAndBattle()


### PR DESCRIPTION
## Summary
- ne rétablit plus le temps normal avant la mise en place du combat
- restaure Time.timeScale juste après `StartBattle`

## Testing
- `dotnet test` *(échoue : `dotnet` absent)*

------
https://chatgpt.com/codex/tasks/task_e_6868ab611a888325b289681bb9e76dd5