### PR TITLE
Gestion audio/animation lors d'une interception

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -71,6 +71,7 @@ public class CharacterData : ScriptableObject, ITargetable
 
     [Header("Effets visuels et sonores")]
     public AudioClip hitSound;
+    public AudioClip interceptedSound;
     public GameObject hitEffect;
     public GameObject deathEffect;
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -236,6 +236,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             audioSource.PlayOneShot(Data.hitSound);
     }
 
+    public void PlayInterceptedSound()
+    {
+        if (Data.interceptedSound != null && audioSource != null)
+            audioSource.PlayOneShot(Data.interceptedSound);
+    }
+
     public IEnumerator PlayDamageFlash()
     {
         if (spriteRenderer == null) yield break;
@@ -358,6 +364,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public int GetHarmonicCount(HarmonicType type)
     {
         return harmonicReserve.ContainsKey(type) ? harmonicReserve[type] : 0;
+    }
+
+    public void ClearAllHarmonics()
+    {
+        var keys = harmonicReserve.Keys.ToList();
+        foreach (var key in keys)
+            harmonicReserve[key] = 0;
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -933,6 +933,8 @@ public class NewBattleManager : MonoBehaviour
         if (interceptor == null) yield break;
 
         caster?.PlayInterceptedAnimation();
+        caster?.PlayInterceptedSound();
+        caster?.ClearAllHarmonics();
         interceptor?.PlayInterceptionAnimation();
 
         var move = interceptor.GetRandomMusicalAttack();


### PR DESCRIPTION
## Résumé
- ajout d'un `AudioClip` `interceptedSound` dans `CharacterData`
- ajout des méthodes `PlayInterceptedSound` et `ClearAllHarmonics` dans `CharacterUnit`
- déclenchement de ces nouvelles actions dans `NewBattleManager` lors d'une interception

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6869678943c08325b2e897175a8176d2