### PR TITLE
Ajout de la scène MainMenu

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  - component: {fileID: 3}
+  m_Layer: 0
+  m_Name: MainMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbd45d5b19ee4d16b4fa08ad897b1270, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Scenes/MainMenu.unity.meta
+++ b/Assets/Scenes/MainMenu.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 058b58afa85749ecb91a92b3402e00d7
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
@@ -1,0 +1,84 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.InputSystem;
+
+public class MainMenuManager : MonoBehaviour
+{
+    [Header("UI Elements")]
+    public CanvasGroup pressAnyKeyGroup;
+    public GameObject menuContainer;
+    public SaveLoadMenu loadMenu;
+    public float fadeSpeed = 2f;
+
+    private bool waitingForInput = true;
+    private float timer = 0f;
+
+    private void Start()
+    {
+        if (pressAnyKeyGroup != null)
+            pressAnyKeyGroup.alpha = 0.5f;
+        if (menuContainer != null)
+            menuContainer.SetActive(false);
+        if (loadMenu != null)
+            loadMenu.gameObject.SetActive(false);
+    }
+
+    private void Update()
+    {
+        if (waitingForInput)
+        {
+            timer += Time.deltaTime * fadeSpeed;
+            float alpha = 0.25f + 0.25f * (1 + Mathf.Sin(timer));
+            if (pressAnyKeyGroup != null)
+                pressAnyKeyGroup.alpha = alpha;
+            if (Keyboard.current.anyKey.wasPressedThisFrame)
+                ShowMenu();
+        }
+    }
+
+    private void ShowMenu()
+    {
+        waitingForInput = false;
+        if (pressAnyKeyGroup != null)
+            pressAnyKeyGroup.gameObject.SetActive(false);
+        if (menuContainer != null)
+            menuContainer.SetActive(true);
+    }
+
+    public void ContinueGame()
+    {
+        if (SaveAndLoadManager.Instance == null)
+            return;
+
+        SaveInfo latest = null;
+        foreach (SaveInfo info in SaveAndLoadManager.Instance.GetAllSaveInfos())
+        {
+            if (latest == null || DateTime.Parse(info.dateTime) > DateTime.Parse(latest.dateTime))
+                latest = info;
+        }
+
+        if (latest != null)
+            SaveAndLoadManager.Instance.LoadGame(latest.saveName);
+        else
+            Debug.Log("Aucune sauvegarde trouvée.");
+    }
+
+    public void OpenLoadMenu()
+    {
+        if (loadMenu == null) return;
+        loadMenu.gameObject.SetActive(true);
+        loadMenu.RefreshList();
+    }
+
+    public void OpenOptions()
+    {
+        Debug.Log("Menu Options non implémenté.");
+    }
+
+    public void QuitGame()
+    {
+        Application.Quit();
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbd45d5b19ee4d16b4fa08ad897b1270
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/MainMenu.unity
+    guid: 058b58afa85749ecb91a92b3402e00d7
+  - enabled: 1
     path: Assets/Scenes/Commencement.unity
     guid: 8124e5870f4fd4c779e7a5f994e84ad1
   - enabled: 1


### PR DESCRIPTION
## Résumé
- nouvelle scène `MainMenu` ajoutée dans `Assets/Scenes`
- ajout du script `MainMenuManager` pour gérer l'affichage du menu principal
- enregistrement de la scène dans `EditorBuildSettings`

## Tests
- `No tests`


------
https://chatgpt.com/codex/tasks/task_e_68698cc101188325a06cb6715163c2ef