### PR TITLE
Ajout logs interception

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -105,6 +105,17 @@ public class ActionUIDisplayManager : MonoBehaviour
         ShowMessage("Pas assez d'harmoniques");
     }
 
+    public void DisplayInterceptionResult(bool success)
+    {
+        string message = success ? "Interception réussie !" : "Interception échouée";
+        ShowMessage(message);
+    }
+
+    public void DisplayInterceptionAttempt()
+    {
+        ShowMessage("Tentative d'interception...");
+    }
+
     private void ShowMessage(string message)
     {
         if (currentDisplayRoutine != null)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -884,11 +884,16 @@ public class NewBattleManager : MonoBehaviour
         if (interceptor == null)
             yield break;
 
+        Debug.Log($"[Interception] {interceptor.name} tente d'intercepter {caster.name} ({move.moveName})");
+        ActionUIDisplayManager.Instance.DisplayInterceptionAttempt();
+
         var conc = interceptor.GetComponent<ConcentrationSystem>();
         if (conc != null && conc.IsFull)
         {
             yield return InterceptRoutine(interceptor, caster);
             interceptionSucceeded = true;
+            Debug.Log("[Interception] Réussite automatique grâce à la concentration pleine.");
+            ActionUIDisplayManager.Instance.DisplayInterceptionResult(true);
             yield break;
         }
 
@@ -918,6 +923,8 @@ public class NewBattleManager : MonoBehaviour
                 action.Disable();
                 yield return InterceptRoutine(interceptor, caster);
                 interceptionSucceeded = true;
+                Debug.Log("[Interception] Interception réussie !");
+                ActionUIDisplayManager.Instance.DisplayInterceptionResult(true);
                 yield break;
             }
             elapsed += Time.unscaledDeltaTime;
@@ -926,6 +933,8 @@ public class NewBattleManager : MonoBehaviour
 
         if (signalObj != null) Destroy(signalObj);
         action.Disable();
+        Debug.Log("[Interception] Interception échouée.");
+        ActionUIDisplayManager.Instance.DisplayInterceptionResult(false);
     }
 
     private IEnumerator InterceptRoutine(CharacterUnit interceptor, CharacterUnit caster)


### PR DESCRIPTION
## Résumé
- ajout de méthodes dans `ActionUIDisplayManager` pour afficher le résultat d'une interception et son lancement
- ajout de logs détaillés dans `NewBattleManager` indiquant la tentative, la réussite ou l'échec d'une interception
- ces messages sont aussi envoyés au panneau `ActionUIDisplayPanel`

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_686a892c8be08325a8c2fa5b03ffb8d2