### PR TITLE
Utilise TimelineLauncher pour choisir la caméra

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Timeline;
 using System.Collections.Generic;
 
 [CreateAssetMenu(fileName = "New Item", menuName = "Symphonie/Item")]
@@ -51,6 +52,10 @@ public class ItemData : ScriptableObject
     [Header("Camera")]
     [Tooltip("Trajectoire de caméra à instancier lors de l'utilisation de l'item")]
     public GameObject cameraPathPrefab;
+
+    [Header("Timeline")]
+    [Tooltip("Timeline à jouer lors de l'utilisation de l'item")]
+    public TimelineAsset timelineAsset;
 
     [Header("QTE Pattern")]
     public List<float> beatPattern;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Timeline;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Callbacks;
@@ -68,6 +69,10 @@ public class MusicalMoveSO : ScriptableObject
     [Header("Camera")]
     [Tooltip("Trajectoire de caméra à instancier lors de l'utilisation du move")]
     public GameObject cameraPathPrefab;
+
+    [Header("Timeline")]
+    [Tooltip("Timeline à jouer lors de l'exécution du move")]
+    public TimelineAsset timelineAsset;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -89,6 +89,11 @@ public class InventoryManager : MonoBehaviour
             }
         }
 
+        if (item.timelineAsset != null && TimelineLauncher.Instance != null)
+        {
+            TimelineLauncher.Instance.PlayTimeline(item.timelineAsset, caster.gameObject);
+        }
+
         item.ApplyEffect(target);
         inventoryItems.Remove(item);
     }

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -95,6 +95,11 @@ public class RhythmQTEManager : MonoBehaviour
             }
         }
 
+        if (move.timelineAsset != null && TimelineLauncher.Instance != null)
+        {
+            TimelineLauncher.Instance.PlayTimeline(move.timelineAsset, caster.gameObject);
+        }
+
         if (move.musicalMoveIntroAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveIntroAnimationNames, caster);

--- a/Assets/TimelineLauncher.cs
+++ b/Assets/TimelineLauncher.cs
@@ -30,6 +30,13 @@ public class TimelineLauncher : MonoBehaviour
             return;
         }
 
+        if (cameraObject == null)
+        {
+            cameraObject = GameObject.FindGameObjectWithTag("BattleCamera");
+            if (cameraObject == null && Camera.main != null)
+                cameraObject = Camera.main.gameObject;
+        }
+
         director.playableAsset = timelineAsset;
 
         foreach (var output in timelineAsset.outputs)


### PR DESCRIPTION
## Résumé
- détection automatique de la BattleCamera dans `TimelineLauncher`
- simplification de l'appel dans `InventoryManager` et `RhythmQTEManager`

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b8a9c5bb08325916d30b38926526f