### PR TITLE
Mise à jour RhythmQTEManager

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -65,19 +65,20 @@ public class RhythmQTEManager : MonoBehaviour
         Debug.Log("Début de la séquence du MusicalMove: " + move + " de " + caster.name);
         isActive = true;
 
-        if (move.timelineAsset != null && TimelineLauncher.Instance != null)
-        {
-            TimelineLauncher.Instance.PlayTimeline(move.timelineAsset, caster.gameObject);
-        }
+        GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
 
-        if (move.musicalMoveIntroAnimationNames.Length > 0)
+        if (move.timelineAsset != null && TimelineLauncher.Instance != null && casterAnimatorGO != null)
+        {
+            TimelineLauncher.Instance.PlayTimeline(move.timelineAsset, casterAnimatorGO);
+        }
+        else if (move.musicalMoveIntroAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveIntroAnimationNames, caster);
         }
 
         yield return MoveTo(caster, target, move); // Déplacement vers l’ennemi
 
-        if (move.musicalMoveAnimationNames.Length > 0)
+        if (move.timelineAsset == null && move.musicalMoveAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveAnimationNames, caster);
         }
@@ -98,7 +99,8 @@ public class RhythmQTEManager : MonoBehaviour
                 yield return null;
         }
 
-        yield return caster.GetComponentInChildren<Animator>().GetCurrentAnimatorStateInfo(0).length; // Attend la fin de l’animation d’attaque
+        if (move.timelineAsset == null)
+            yield return caster.GetComponentInChildren<Animator>().GetCurrentAnimatorStateInfo(0).length; // Attend la fin de l’animation d’attaque
 
         if (!move.stayInPlace)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -99,7 +99,11 @@ public class RhythmQTEManager : MonoBehaviour
                 yield return null;
         }
 
-        if (move.timelineAsset == null)
+        if (move.timelineAsset != null)
+        {
+            yield return new WaitForSeconds((float)move.timelineAsset.duration); // Attend la fin de la Timeline
+        }
+        else
         {
             float animLength = caster.GetComponentInChildren<Animator>()
                 .GetCurrentAnimatorStateInfo(0).length;

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -100,7 +100,11 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         if (move.timelineAsset == null)
-            yield return caster.GetComponentInChildren<Animator>().GetCurrentAnimatorStateInfo(0).length; // Attend la fin de l’animation d’attaque
+        {
+            float animLength = caster.GetComponentInChildren<Animator>()
+                .GetCurrentAnimatorStateInfo(0).length;
+            yield return new WaitForSeconds(animLength); // Attend explicitement la fin de l’animation d’attaque
+        }
 
         if (!move.stayInPlace)
         {


### PR DESCRIPTION
## Summary
- n'exécute plus les animations si une Timeline est définie
- lie la Timeline à l'Animator présent sur un enfant du caster

## Testing
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_686b942d30c08325aefc22102e223c0f