### PR TITLE
Aligner la caméra de timeline sur le caster

### DIFF
--- a/Assets/TimelineLauncher.cs
+++ b/Assets/TimelineLauncher.cs
@@ -32,6 +32,20 @@ public class TimelineLauncher : MonoBehaviour
 
         director.playableAsset = timelineAsset;
 
+        GameObject cameraGO = null;
+        Transform cameraParent = null;
+        if (!string.IsNullOrEmpty(cameraTag))
+        {
+            cameraGO = GameObject.FindGameObjectWithTag(cameraTag);
+            cameraParent = cameraGO != null ? cameraGO.transform.parent : null;
+
+            if (caster != null && cameraParent != null)
+            {
+                cameraParent.position = caster.transform.position;
+                cameraParent.rotation = caster.transform.rotation;
+            }
+        }
+
         foreach (var output in timelineAsset.outputs)
         {
             string trackName = output.streamName;
@@ -41,9 +55,8 @@ public class TimelineLauncher : MonoBehaviour
             {
                 BindObjectToTrack(output, caster);
             }
-            else if (trackName.ToLower().Contains("Camera") && cameraTag != null)
+            else if (trackName.ToLower().Contains("Camera") && cameraGO != null)
             {
-                GameObject cameraGO = GameObject.FindGameObjectWithTag(cameraTag);
                 BindObjectToTrack(output, cameraGO);
             }
             else


### PR DESCRIPTION
## Résumé
- positionne le parent de la BattleCamera sur le lanceur avant de jouer la timeline
- réutilise la caméra existante lors du binding des tracks

## Tests
- `dotnet --version` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_686ba4896b748325ac5fa72124f85e19