### PR TITLE
Utilisation de Timelines pour l'intro de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.Playables;
 
 public class BattleTransitionManager : MonoBehaviour
 {
@@ -157,10 +158,17 @@ public class BattleTransitionManager : MonoBehaviour
 
         yield return RestoreTimeScale(from: 0.1f, to: 1f, speed: 2f);
 
-        while (battleIntroPath.IsPlaying)
+        GameObject introCam = GameObject.Find("BattleScene_Camera_BattleIntro");
+        PlayableDirector introDirector = introCam ? introCam.GetComponentInChildren<PlayableDirector>() : null;
+        if (introDirector != null)
         {
-            Debug.Log("[BattleTransitionManager] Attente de la fin du CameraPath Intro Combat...");
-            yield return null;
+            TimelineManager.Instance.PlayTimeline(introDirector);
+            while (TimelineManager.Instance.IsTimelinePlaying)
+                yield return null;
+        }
+        else
+        {
+            Debug.LogWarning("[BattleTransitionManager] Timeline d'intro introuvable.");
         }
 
         yield return NewBattleManager.Instance.StartBattle();

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -460,16 +460,18 @@ public class NewBattleManager : MonoBehaviour
             firstStrikeEffect.SetActive(true);
         else
             Debug.LogWarning("[BattleTurnManager] FirstStrikeEffect introuvable.");
-        Transform target = FindChildRecursive(unit.transform, "spine_03");
-        Transform position = FindChildRecursive(unit.transform, "spine_03");
-        CameraController.Instance.StartPathFollow(
-            firstStrikeCameraPath,
-            position,
-            forceLook: true,
-            targetToLook: target,
-            alignImmediately: false
-        );
-        yield return new WaitForSeconds(firstStrikeCameraPath.GetTotalDuration());
+        GameObject fsCam = GameObject.Find("BattleScene_Camera_FirstStrike");
+        PlayableDirector fsDirector = fsCam ? fsCam.GetComponentInChildren<PlayableDirector>() : null;
+        if (fsDirector != null)
+        {
+            TimelineManager.Instance.PlayTimeline(fsDirector);
+            while (TimelineManager.Instance.IsTimelinePlaying)
+                yield return null;
+        }
+        else
+        {
+            Debug.LogWarning("[BattleTurnManager] Timeline FirstStrike introuvable.");
+        }
     }
 
     //7 Démarre la boucle de tours


### PR DESCRIPTION
## Résumé
- lance la Timeline enfant de `BattleScene_Camera_BattleIntro` au lieu d'attendre la fin du `CameraPath`
- lance la Timeline enfant de `BattleScene_Camera_FirstStrike` pour la séquence d'attaque surprise

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686baaf4211883258c6e7dcf5697bb5e