### PR TITLE
Fix First Strike camera position

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -460,7 +460,10 @@ public class NewBattleManager : MonoBehaviour
         else
             Debug.LogWarning("[BattleTurnManager] FirstStrikeEffect introuvable.");
         GameObject fsCam = GameObject.Find("BattleScene_Camera_FirstStrike");
-        fsCam.transform.position = unit.transform.position + Vector3.up * 2f;
+        if (fsCam != null)
+        {
+            fsCam.transform.position = unit.transform.position + Vector3.up * 2f;
+        }
         PlayableDirector fsDirector = fsCam ? fsCam.GetComponentInChildren<PlayableDirector>() : null;
         if (fsDirector != null)
         {


### PR DESCRIPTION
## Résumé
- la caméra `BattleScene_Camera_FirstStrike` se place maintenant à la position de l'unité qui commence le combat sans être parentée

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `npm test` *(échoue : impossible de lire package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686bb724566c8325a6b60e8036f231d3