### PR TITLE
Ajout du lancement de la timeline d'intro après la transition

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -143,25 +143,38 @@ public class BattleTransitionManager : MonoBehaviour
         while (NewBattleManager.Instance.unitsInBattle.Count <= 0)
             yield return null;
 
-        GameObject introCam = GameObject.Find("BattleScene_Camera_BattleIntro");
-        PlayableDirector introDirector = introCam ? introCam.GetComponentInChildren<PlayableDirector>() : null;
-        if (introDirector != null)
-        {
-            TimelineManager.Instance.PlayTimeline(introDirector);
-            while (TimelineManager.Instance.IsTimelinePlaying)
-                yield return null;
-        }
-        else
-        {
-            Debug.LogWarning("[BattleTransitionManager] Timeline d'intro introuvable.");
-        }
-
         worldRiftTweener.TweenToZeroRoutine();
         yield return battleRiftTweener.TweenToZeroRoutine();
 
         NewBattleManager.Instance.ChangeBattleState(BattleState.Initialization);
 
         yield return NewBattleManager.Instance.StartBattle();
+
+        GameObject introCam = GameObject.Find("BattleScene_Camera_BattleIntro");
+        if (introCam != null)
+        {
+            var firstUnit = NewBattleManager.Instance.activeCharacterUnits
+                .OrderByDescending(u => u.currentInitiative)
+                .FirstOrDefault();
+            if (firstUnit != null)
+                introCam.transform.position = firstUnit.transform.position;
+
+            PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>();
+            if (introDirector != null)
+            {
+                TimelineManager.Instance.PlayTimeline(introDirector);
+                while (TimelineManager.Instance.IsTimelinePlaying)
+                    yield return null;
+            }
+            else
+            {
+                Debug.LogWarning("[BattleTransitionManager] Timeline d'intro introuvable.");
+            }
+        }
+        else
+        {
+            Debug.LogWarning("[BattleTransitionManager] BattleScene_Camera_BattleIntro introuvable.");
+        }
     }
 
     public IEnumerator ExitVictoryScreenAndBattle()


### PR DESCRIPTION
## Résumé
- démarre maintenant la timeline de `BattleScene_Camera_BattleIntro` après la transition de combat
- place cette caméra sur la position de la première unité à jouer

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bbf571c408325ab79cc10fa39253e