### PR TITLE
Fix inspector null target errors

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -552,6 +552,10 @@ public class InputsManagerEditor : Editor
 
     public override void OnInspectorGUI()
     {
+        // Sécurité : on vérifie que l'objet sérialisé existe toujours
+        if (serializedObject == null)
+            return;
+
         serializedObject.Update();
 
         // Affiche l'inspecteur par défaut
@@ -566,6 +570,7 @@ public class InputsManagerEditor : Editor
             // Pour chaque instance sélectionnée
             foreach (var obj in targets)
             {
+                if (obj == null) continue;
                 var mgr = obj as InputsManager;
                 if (mgr == null) continue;
 


### PR DESCRIPTION
## Summary
- avoid inspector exceptions when an InputsManager target is null

## Testing
- `git commit -m "fix inspector errors due to null targets"`

------
https://chatgpt.com/codex/tasks/task_e_686befd15a188325bb7a71959bd5133c