### PR TITLE
Ajout du MusicalMove Hate

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_Hate.meta
+++ b/Assets/MusicalMoves/MusicalMove_Hate.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9091462d8c742a0a4784cdcc74c3443
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_Hate
+  m_EditorClassIdentifier: 
+  moveName: Hate
+  moveType: 1
+  moveIcon: {fileID: 0}
+  description: "Se place devant l'unit\u00e9 cible."
+  musicalMoveTargetingAnimation: {fileID: 0}
+  musicalMoveRunAnimationName: 
+  maxRunDuration: 0.5
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  notes: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 0
+  harmonicGeneration: 0
+  cooldown: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 0100000003000000
+  effectType: 0
+  effectValue: 0
+  moveSpeed: 20
+  castDistance: 1
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}
+  useTeleportation: 0
+  teleportStartVFXPrefab: {fileID: 0}
+  teleportEndVFXPrefab: {fileID: 0}
+  timelineAsset: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4994e2b9562f4dc190223fbdc506d57a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -38,6 +38,10 @@ public class MusicalMoveSO : ScriptableObject
     public int harmonicCost = 1;
     public int harmonicGeneration = 0;
 
+    [Header("Temps de recharge")]
+    [Tooltip("Nombre de tours avant de pouvoir réutiliser le move")]
+    public int cooldown = 0;
+
     [Header("Ciblage")]
     public TargetType targetType = TargetType.SingleEnemy;
     public TargetType defaultTargetType = TargetType.SingleEnemy;

--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -105,6 +105,11 @@ public class ActionUIDisplayManager : MonoBehaviour
         ShowMessage("Pas assez d'harmoniques");
     }
 
+    public void DisplayInstruction_MoveOnCooldown()
+    {
+        ShowMessage("Compétence en recharge");
+    }
+
     public void DisplayInterceptionResult(bool success)
     {
         string message = success ? "Interception réussie !" : "Interception échouée";

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -48,6 +48,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentMusicalGauge;
     // Nouvelle réserve d'harmoniques par type
     public Dictionary<HarmonicType, int> harmonicReserve = new();
+    public Dictionary<MusicalMoveSO, int> moveCooldowns = new();
     public float currentFatigue { get => Data.currentFatigue; set => Data.currentFatigue = value; }
 
     // Gestion de l'initiative
@@ -381,6 +382,24 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         var keys = harmonicReserve.Keys.ToList();
         foreach (var key in keys)
             harmonicReserve[key] = 0;
+    }
+
+    public void ReduceCooldowns()
+    {
+        var keys = moveCooldowns.Keys.ToList();
+        foreach (var key in keys)
+            moveCooldowns[key] = Mathf.Max(0, moveCooldowns[key] - 1);
+    }
+
+    public bool IsMoveOnCooldown(MusicalMoveSO move)
+    {
+        return moveCooldowns.ContainsKey(move) && moveCooldowns[move] > 0;
+    }
+
+    public void SetMoveCooldown(MusicalMoveSO move)
+    {
+        if (move.cooldown > 0)
+            moveCooldowns[move] = move.cooldown;
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -184,6 +184,12 @@ public class InputsManager : MonoBehaviour
                     bm.ShowMainMenu();
                     return;
                 }
+                if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_MoveOnCooldown();
+                    bm.ShowMainMenu();
+                    return;
+                }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
 
@@ -235,6 +241,12 @@ public class InputsManager : MonoBehaviour
                     bm.ShowMainMenu();
                     return;
                 }
+                if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_MoveOnCooldown();
+                    bm.ShowMainMenu();
+                    return;
+                }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
 
@@ -279,6 +291,12 @@ public class InputsManager : MonoBehaviour
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
+                    bm.ShowMainMenu();
+                    return;
+                }
+                if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
+                {
+                    ActionUIDisplayManager.Instance.DisplayInstruction_MoveOnCooldown();
                     bm.ShowMainMenu();
                     return;
                 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -572,6 +572,8 @@ public class NewBattleManager : MonoBehaviour
                 EndTurn();
                 yield break;
             }
+
+            unit.ReduceCooldowns();
             isTurnResolving = true;
 
             // 1) On stocke l’unité qui jouait juste avant (champ de classe)
@@ -1000,6 +1002,7 @@ public class NewBattleManager : MonoBehaviour
         {
             caster.ConsumeHarmonic(caster.Data.harmonicType, move.harmonicCost);
             caster.AddHarmonic(caster.Data.harmonicType, move.harmonicGeneration);
+            caster.SetMoveCooldown(move);
 
             // Si l'unité n'a plus d'harmonique, son tour se termine immédiatement
             if (caster.GetHarmonicCount(caster.Data.harmonicType) <= 0)


### PR DESCRIPTION
## Résumé
- ajout d'un champ de cooldown pour `MusicalMoveSO`
- ajout d'un suivi de cooldown dans `CharacterUnit`
- mise à jour de `NewBattleManager` pour réduire le cooldown à chaque tour et l'appliquer après un move
- ajout d'un message d'UI pour prévenir que la compétence est en recharge
- vérification du cooldown lors de la sélection des compétences
- création de la compétence `Hate`

## Tests
- `grep -n "ReduceCooldowns" -n Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs`

------
https://chatgpt.com/codex/tasks/task_e_687000c817f48325906a08d025c57020