### PR TITLE
Implémente roue pour la timeline de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
@@ -21,6 +21,21 @@ public class BattleTimelineUnit : MonoBehaviour
 
     [HideInInspector] public CharacterData characterData;
 
+    [SerializeField] private CanvasGroup canvasGroup;
+
+    private float baseScale = 1f;
+    private float highlightMultiplier = 1f;
+
+    private void Awake()
+    {
+        if (canvasGroup == null)
+        {
+            canvasGroup = GetComponent<CanvasGroup>();
+            if (canvasGroup == null)
+                canvasGroup = gameObject.AddComponent<CanvasGroup>();
+        }
+    }
+
     public void Initialize(CharacterUnit unit)
     {
         if (unit == null || unit.Data == null)
@@ -138,6 +153,22 @@ public class BattleTimelineUnit : MonoBehaviour
         if (backgroundImage != null)
             backgroundImage.color = active ? highlightColor : normalColor;
 
-        transform.localScale = active ? Vector3.one * 1.15f : Vector3.one;
+        highlightMultiplier = active ? 1.15f : 1f;
+        ApplyScale();
+    }
+
+    public void SetAppearance(float scale, float alpha)
+    {
+        baseScale = scale;
+        if (canvasGroup != null)
+            canvasGroup.alpha = alpha;
+
+        ApplyScale();
+    }
+
+    private void ApplyScale()
+    {
+        transform.localScale = Vector3.one * baseScale * highlightMultiplier;
     }
 }
+

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -582,6 +582,7 @@ public class NewBattleManager : MonoBehaviour
             // 2) Mise à jour de l’unité courante
             currentCharacterUnit = unit;
             UpdateTimelineHighlight(unit);
+            UpdateTimelineWheel(unit);
 
             ChangeBattleState(BattleState.NewTurn);
 
@@ -616,6 +617,43 @@ public class NewBattleManager : MonoBehaviour
         {
             bool isCurrent = activeUnit != null && ui.characterData == activeUnit.Data;
             ui.SetHighlight(isCurrent);
+        }
+    }
+
+    private void UpdateTimelineWheel(CharacterUnit activeUnit)
+    {
+        if (activeUnit == null || timelineUIObjects.Count == 0)
+            return;
+
+        int currentIndex = timelineUIObjects.FindIndex(ui => ui.characterData == activeUnit.Data);
+        if (currentIndex == -1)
+            return;
+
+        // Positionne l'unité active en troisième position
+        while (currentIndex < 2)
+        {
+            var first = timelineUIObjects[0];
+            timelineUIObjects.RemoveAt(0);
+            timelineUIObjects.Add(first);
+            currentIndex++;
+        }
+        while (currentIndex > 2)
+        {
+            var last = timelineUIObjects[timelineUIObjects.Count - 1];
+            timelineUIObjects.RemoveAt(timelineUIObjects.Count - 1);
+            timelineUIObjects.Insert(0, last);
+            currentIndex--;
+        }
+
+        for (int i = 0; i < timelineUIObjects.Count; i++)
+        {
+            timelineUIObjects[i].transform.SetSiblingIndex(i);
+
+            int distance = Mathf.Abs(i - 2);
+            float t = Mathf.Clamp01(distance / 2f);
+            float scale = Mathf.Lerp(1f, 0.8f, t);
+            float alpha = Mathf.Lerp(1f, 0.2f, t);
+            timelineUIObjects[i].SetAppearance(scale, alpha);
         }
     }
 


### PR DESCRIPTION
## Résumé
- ajout d'un `CanvasGroup` et de la gestion d'échelle/transparence dans `BattleTimelineUnit`
- réorganisation automatique de la timeline pour placer l'unité active sous le curseur et ajuster l'apparence selon la distance dans `NewBattleManager`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871618ebfa4832588bc9e61cd9be228