### PR TITLE
Correction dégâts appliqués en fin de move

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -754,8 +754,6 @@ public class NewBattleManager : MonoBehaviour
             }
         }
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
-        if (move.notes == null || move.notes.Count == 0)
-            move.ApplyEffect(caster, target);
 
         // Ajout du système de rage manuellement
         var rage = caster.GetComponent<RageSystem>();


### PR DESCRIPTION
## Résumé
- évite un second appel à `ApplyEffect` après la fin d'un `MusicalMove`

Les dégâts sont désormais appliqués uniquement durant l'exécution du mouvement via `RhythmQTEManager`, sans attendre la fin du move.

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687260c63df08325b67281fcc3a5f140