### PR TITLE
Correction animation items

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -61,11 +61,6 @@ public class InventoryManager : MonoBehaviour
 
         Debug.Log($"[Inventory] Utilisation de l'objet : {item.itemName} sur {target.Data.characterName}");
 
-        if (item.timelineAsset != null && TimelineLauncher.Instance != null)
-        {
-            TimelineLauncher.Instance.PlayTimeline(item.timelineAsset, caster.gameObject, "BattleCamera");
-        }
-
         item.ApplyEffect(target);
         inventoryItems.Remove(item);
     }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -788,6 +788,9 @@ public class NewBattleManager : MonoBehaviour
             ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
             yield break;
         }
+        // Animation ou Timeline d'utilisation
+        yield return RhythmQTEManager.Instance.ItemRoutine(item, caster, target);
+
         InventoryManager.Instance.UseItem(item, caster, target);
         if (item.effectType == ItemEffectType.Damage)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -127,13 +127,100 @@ public class RhythmQTEManager : MonoBehaviour
 
     /// <summary>
     /// Gère la séquence d'utilisation d'un objet en combat.
+    /// Cette routine reprend le même déroulé qu'un MusicalMove :
+    /// lecture d'une éventuelle introduction, déplacement optionnel,
+    /// animation principale puis retour à la position initiale.
     /// </summary>
     public IEnumerator ItemRoutine(ItemData item, CharacterUnit caster, CharacterUnit target)
     {
+        Debug.Log($"Début de la séquence d'utilisation de l'objet: {item.itemName} par {caster.name}");
+        isActive = true;
 
-        if (!item.stayInPlace)
+        Animator animator = caster.GetComponentInChildren<Animator>();
+
+        // Lecture d'une Timeline ou d'une animation d'intro
+        if (item.timelineAsset != null && TimelineLauncher.Instance != null && animator != null)
         {
+            TimelineLauncher.Instance.PlayTimeline(item.timelineAsset, animator.gameObject, "BattleCamera");
+            yield return new WaitForSeconds((float)item.timelineAsset.duration);
+        }
+        else if (item.introAnimationClip != null && animator != null)
+        {
+            animator.Play(item.introAnimationClip.name);
             yield return null;
+            float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
+            yield return new WaitForSeconds(clipDuration);
+        }
+
+        // Déplacement éventuel du lanceur
+        if (!item.stayInPlace && caster != null && target != null)
+        {
+            yield return SimpleMoveTo(caster, target, item);
+        }
+
+        // Animation principale si pas de Timeline
+        if (item.timelineAsset == null && item.animationClip != null && animator != null)
+        {
+            animator.Play(item.animationClip.name);
+            yield return null;
+            float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
+            yield return new WaitForSeconds(clipDuration);
+        }
+
+        // Retour à la position initiale si déplacement
+        if (!item.stayInPlace && caster != null)
+        {
+            yield return SimpleReturnToInitialPosition(caster, target, item);
+        }
+
+        isActive = false;
+        Debug.Log($"Fin de la séquence d'utilisation de l'objet: {item.itemName} par {caster.name}");
+    }
+
+    private IEnumerator SimpleMoveTo(CharacterUnit caster, CharacterUnit target, ItemData item)
+    {
+        Vector3 origin = caster.transform.position;
+        Vector3 destination = target.transform.position + target.transform.forward * item.castDistance;
+
+        Animator animator = caster.GetComponentInChildren<Animator>();
+        if (caster.Data.moveClip != null)
+            animator?.Play(caster.Data.moveClip.name);
+
+        while (Vector3.Distance(caster.transform.position, destination) > 0.1f)
+        {
+            Vector3 dir = (destination - caster.transform.position).normalized;
+            float step = item.moveSpeed * Time.deltaTime;
+            caster.transform.position = Vector3.MoveTowards(caster.transform.position, destination, step);
+            if (dir != Vector3.zero)
+                caster.transform.forward = dir;
+            yield return null;
+        }
+    }
+
+    private IEnumerator SimpleReturnToInitialPosition(CharacterUnit caster, CharacterUnit target, ItemData item)
+    {
+        Vector3 origin = caster.transform.parent.position;
+
+        Animator animator = caster.GetComponentInChildren<Animator>();
+        if (caster.Data.moveClip != null)
+            animator?.Play(caster.Data.moveClip.name);
+
+        while (Vector3.Distance(caster.transform.position, origin) > 0.1f)
+        {
+            Vector3 dir = (origin - caster.transform.position).normalized;
+            float step = item.moveSpeed * Time.deltaTime;
+            caster.transform.position = Vector3.MoveTowards(caster.transform.position, origin, step);
+            if (dir != Vector3.zero)
+                caster.transform.forward = dir;
+            yield return null;
+        }
+
+        // Après le retour, on réoriente éventuellement vers la cible
+        if (target != null)
+        {
+            Vector3 lookDir = (target.transform.position - caster.transform.position).normalized;
+            if (lookDir != Vector3.zero)
+                caster.transform.forward = lookDir;
         }
     }
 


### PR DESCRIPTION
## Résumé
- harmonisation de la routine d'utilisation d'objet pour suivre le même schéma qu'un MusicalMove
- déplacement optionnel et retour à la position d'origine lors de l'utilisation d'un objet

## Tests
- `find . -name '*Tests*' -or -name '*test*' | head`

------
https://chatgpt.com/codex/tasks/task_e_687264455dfc8325a8bb1b4c9d300116