### PR TITLE
Griser compétences non utilisables

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -181,7 +181,6 @@ public class InputsManager : MonoBehaviour
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
-                    bm.ShowMainMenu();
                     return;
                 }
                 if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
@@ -238,7 +237,6 @@ public class InputsManager : MonoBehaviour
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
-                    bm.ShowMainMenu();
                     return;
                 }
                 if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
@@ -291,7 +289,6 @@ public class InputsManager : MonoBehaviour
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
-                    bm.ShowMainMenu();
                     return;
                 }
                 if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1528,6 +1528,9 @@ public class NewBattleManager : MonoBehaviour
         {
             var move = skillChoices[i];
             UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
+
+            bool available = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= move.harmonicCost;
+            SetButtonAvailability(currentSkillsMenuSlots[i], available);
         }
         // Indique les emplacements vides
         for (int j = skillChoices.Count; j < currentSkillsMenuSlots.Count; j++)
@@ -1536,6 +1539,8 @@ public class NewBattleManager : MonoBehaviour
                 UpdateButton(currentSkillsMenuSlots[j], emptyMove.moveName, emptyMove.moveIcon);
             else
                 UpdateButton(currentSkillsMenuSlots[j], "Indisponible", null);
+
+            SetButtonAvailability(currentSkillsMenuSlots[j], false);
         }
     }
 
@@ -1597,6 +1602,19 @@ public class NewBattleManager : MonoBehaviour
 
         if (txt != null) txt.text = label;
         if (img != null) img.sprite = icon;
+    }
+
+    private void SetButtonAvailability(Transform slot, bool available)
+    {
+        if (slot == null)
+            return;
+
+        var txt = slot.GetComponentInChildren<TextMeshProUGUI>();
+        var img = slot.childCount > 3 ? slot.GetChild(3).GetComponent<Image>() : null;
+
+        Color color = available ? Color.white : Color.gray;
+        if (txt != null) txt.color = color;
+        if (img != null) img.color = color;
     }
     #endregion
 


### PR DESCRIPTION
## Résumé
- les compétences sans suffisamment d'harmoniques ne ramènent plus au menu principal
- affichage grisé des compétences non disponibles dans le menu

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6872682058488325b02e29e0ae6ca36b