### PR TITLE
Amélioration des messages d'actions en combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -36,6 +36,14 @@ public class ActionUIDisplayManager : MonoBehaviour
         currentDisplayRoutine = StartCoroutine(DisplayRoutine(attackName));
     }
 
+    public void DisplayActionMessage(string actorName, string actionName, string targetName)
+    {
+        string message = $"{actorName} utilise {actionName}";
+        if (!string.IsNullOrEmpty(targetName))
+            message += $" sur {targetName}";
+        ShowMessage(message);
+    }
+
     private IEnumerator DisplayRoutine(string name)
     {
         actionText.text = name;

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -725,7 +725,7 @@ public class NewBattleManager : MonoBehaviour
                 yield break;
         }
 
-        ActionUIDisplayManager.Instance.DisplayAttackName(move.moveName);
+        ActionUIDisplayManager.Instance.DisplayActionMessage(enemy.Data.characterName, move.moveName, target.Data.characterName);
         MusicalCodexManager.Instance?.TryAddNewMelody(move);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, enemy, target);
     }
@@ -991,7 +991,7 @@ public class NewBattleManager : MonoBehaviour
         var move = interceptor.GetRandomMusicalAttack();
         if (move != null)
         {
-            ActionUIDisplayManager.Instance.DisplayAttackName(move.moveName);
+            ActionUIDisplayManager.Instance.DisplayActionMessage(interceptor.Data.characterName, move.moveName, caster.Data.characterName);
             yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, interceptor, caster);
             if (move.notes == null || move.notes.Count == 0)
                 move.ApplyEffect(interceptor, caster);


### PR DESCRIPTION
## Résumé
- ajout d'une méthode `DisplayActionMessage` dans `ActionUIDisplayManager`
- affichage du message complet lors de l'exécution d'une compétence ou d'une interception

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68727f310118832581b4c40ae9799dfa