### PR TITLE
Retrait du verrouillage caméra sur tours ennemis

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1992,19 +1992,10 @@ public class NewBattleManager : MonoBehaviour
             case BattleState.EnemyUnit_PerformingMusicalMove:
             case BattleState.EnemyUnit_Item_Prepare:
             case BattleState.EnemyUnit_Item_Use:
+                // L'ancienne fonctionnalité fixant la caméra sur un point dédié
+                // lors du tour ennemi a été supprimée.
                 isFollowingCurrentTarget = false;
-                GameObject enemyCam = GameObject.Find("BattleScene_Camera_EnemyTurn");
-                if (enemyCam != null)
-                {
-                    desiredTransform = enemyCam.transform;
-                    if (currentCharacterUnit != null)
-                        OrientTransformTowardUnitSmoothXY(desiredTransform, currentCharacterUnit);
-                }
-                else
-                {
-                    desiredTransform = null;
-                    Debug.LogWarning("[BattleCameraManager] BattleScene_Camera_EnemyTurn introuvable.");
-                }
+                desiredTransform = null;
                 break;
 
             case BattleState.VictoryScreen_Await:


### PR DESCRIPTION
## Résumé
- suppression du script qui fixait la caméra sur `BattleScene_Camera_EnemyTurn` durant l'action d'une unité ennemie

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68728175a8cc8325bd2729e0c333622b