### PR TITLE
Gestion orientation unités en combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -132,6 +132,12 @@ public class NewBattleManager : MonoBehaviour
         {
             _currentTargetCharacter = value;
             UpdateCameraBehaviour(currentBattleState); // Met à jour la caméra quand la cible change
+
+            // Oriente l'unité en cours de jeu vers la nouvelle cible
+            if (currentCharacterUnit != null && _currentTargetCharacter != null)
+            {
+                OrientUnitTowardTarget(currentCharacterUnit, _currentTargetCharacter);
+            }
         }
     }
     //-------------------------------------------------------------------------------------
@@ -744,6 +750,9 @@ public class NewBattleManager : MonoBehaviour
             Debug.LogWarning("[ExecuteMoveOnTarget] Pas assez d'espace pour executer le mouvement.");
             yield break;
         }
+
+        OrientUnitTowardTarget(caster, target);
+
         if (move.interceptable && !caster.isInterceptionImmune)
         {
             var interceptor = CheckForInterception(caster, target, caster.Data.currentInterceptionRange);
@@ -788,6 +797,9 @@ public class NewBattleManager : MonoBehaviour
             ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
             yield break;
         }
+
+        OrientUnitTowardTarget(caster, target);
+
         // Animation ou Timeline d'utilisation
         yield return RhythmQTEManager.Instance.ItemRoutine(item, caster, target);
 
@@ -1226,6 +1238,19 @@ public class NewBattleManager : MonoBehaviour
         Quaternion filteredRotation = Quaternion.Euler(euler.x, euler.y, 0f);
 
         StartCoroutine(RotateTransformSmoothlyXY(targetTransform, filteredRotation, rotationSpeed));
+    }
+
+    public void OrientUnitTowardTarget(CharacterUnit unit, CharacterUnit target, float rotationSpeed = 360f)
+    {
+        if (unit == null || target == null || unit.currentHP <= 0 || target.currentHP <= 0)
+            return;
+
+        Vector3 direction = (target.transform.position - unit.transform.position).normalized;
+        if (direction == Vector3.zero)
+            return;
+
+        Quaternion targetRotation = Quaternion.LookRotation(direction);
+        StartCoroutine(RotateUnitSmoothly(unit, targetRotation, rotationSpeed));
     }
 
     public void OrientUnitTowardClosestOpponent(CharacterUnit unit, float rotationSpeed = 360f)

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -275,8 +275,6 @@ public class RhythmQTEManager : MonoBehaviour
             else if (teleportOffsetDir != Vector3.zero)
                 caster.transform.forward = teleportOffsetDir;
 
-            NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
-
             yield return null;
             Debug.Log("Fin du déplacement de " + caster.name);
             yield break;
@@ -336,7 +334,6 @@ public class RhythmQTEManager : MonoBehaviour
             }
 
             Debug.Log("Fin du déplacement de " + caster.name);
-            NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
             yield break;
         }
 
@@ -369,7 +366,6 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         Debug.Log("Fin du déplacement de " + caster.name);
-        NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
     }
 
     private IEnumerator ReturnToInitialPosition(MusicalMoveSO move, CharacterUnit caster, CharacterUnit target)
@@ -456,7 +452,6 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         Debug.Log("Le caster a terminé son retour.");
-        NewBattleManager.Instance?.OrientAllUnitsTowardClosestOpponent();
     }
 
     IEnumerator PlayMoveAnimations(string[] animationClips, CharacterUnit caster)


### PR DESCRIPTION
## Résumé
- réoriente l'unité active vers la cible quand on change de cible
- oriente également le lanceur vers la cible au lancement d'une action
- retire les réorientations globales déclenchées par `RhythmQTEManager`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872b3997c8083258d31fbcab84f43e4