### PR TITLE
Ajout taunt en cas de mort prématurée

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -71,6 +71,7 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Effets visuels et sonores")]
     public AudioClip hitSound;
     public AudioClip interceptedSound;
+    [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClip prematureDeathTaunt;
     public GameObject hitEffect;
     public GameObject deathEffect;
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -58,6 +58,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public bool IsReady => currentATB >= ATBMax && currentHP > 0;
 
     private bool deathTriggered;
+    public event System.Action<CharacterUnit> OnDeath;
     public bool isReadyToParry;
     [HideInInspector] public bool isInterceptionImmune = false;
     [HideInInspector] public int interceptionImmunityTurns = 0;
@@ -212,6 +213,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             GameManager.Instance?.IncrementEnemiesDefeated();
             NewBattleManager.Instance?.OnEnemyDefeated(this);
         }
+
+        OnDeath?.Invoke(this);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -65,6 +65,19 @@ public class RhythmQTEManager : MonoBehaviour
         Debug.Log("Début de la séquence du MusicalMove: " + move + " de " + caster.name);
         isActive = true;
 
+        bool tauntPlayed = false;
+        System.Action<CharacterUnit> deathHandler = null;
+        deathHandler = (dead) =>
+        {
+            if (!tauntPlayed && isActive && caster != null && caster.Data.prematureDeathTaunt != null)
+            {
+                AudioManager.Instance?.PlayVoice(caster.Data.prematureDeathTaunt);
+                tauntPlayed = true;
+            }
+        };
+        if (target != null)
+            target.OnDeath += deathHandler;
+
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
 
         if (move.timelineAsset != null && TimelineLauncher.Instance != null && casterAnimatorGO != null)
@@ -117,6 +130,9 @@ public class RhythmQTEManager : MonoBehaviour
 
         isActive = false;
         NewBattleManager.Instance.AfterMusicalMove(move, caster);
+
+        if (target != null)
+            target.OnDeath -= deathHandler;
 
         currentMove = null;
         currentCaster = null;


### PR DESCRIPTION
## Résumé
- ajout d'un champ `prematureDeathTaunt` dans `CharacterData`
- ajout d'un événement `OnDeath` dans `CharacterUnit` et invocation lors de la mort
- déclenchement du taunt dans `RhythmQTEManager` si la cible meurt pendant l'exécution d'un `MusicalMove`

## Tests
- compilation non effectuée faute d'environnement Unity


------
https://chatgpt.com/codex/tasks/task_e_6872b6709a3c83258bdd2203dab4d320