### PR TITLE
Ajout des sons de déplacement personnalisés

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -81,6 +81,10 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Animations de déplacement")]
     public AnimationClip moveClip;
 
+    [Header("Sons de déplacement")]
+    public AudioClip moveStartClip;
+    public AudioClip moveEndClip;
+
     // Ajoute une référence au GameObject source
     public MonoBehaviour owner;
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -256,6 +256,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             audioSource.PlayOneShot(Data.interceptedSound);
     }
 
+    public void PlayMoveStartSound()
+    {
+        if (Data.moveStartClip != null && audioSource != null)
+            audioSource.PlayOneShot(Data.moveStartClip);
+    }
+
+    public void PlayMoveEndSound()
+    {
+        if (Data.moveEndClip != null && audioSource != null)
+            audioSource.PlayOneShot(Data.moveEndClip);
+    }
+
     public IEnumerator PlayDamageFlash()
     {
         if (spriteRenderer == null) yield break;

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -195,6 +195,7 @@ public class RhythmQTEManager : MonoBehaviour
 
     private IEnumerator SimpleMoveTo(CharacterUnit caster, CharacterUnit target, ItemData item)
     {
+        caster.PlayMoveStartSound();
         Vector3 origin = caster.transform.position;
         Vector3 destination = target.transform.position + target.transform.forward * item.castDistance;
 
@@ -211,10 +212,12 @@ public class RhythmQTEManager : MonoBehaviour
                 caster.transform.forward = dir;
             yield return null;
         }
+        caster.PlayMoveEndSound();
     }
 
     private IEnumerator SimpleReturnToInitialPosition(CharacterUnit caster, CharacterUnit target, ItemData item)
     {
+        caster.PlayMoveStartSound();
         Vector3 origin = caster.transform.parent.position;
 
         Animator animator = caster.GetComponentInChildren<Animator>();
@@ -238,11 +241,13 @@ public class RhythmQTEManager : MonoBehaviour
             if (lookDir != Vector3.zero)
                 caster.transform.forward = lookDir;
         }
+        caster.PlayMoveEndSound();
     }
 
     private IEnumerator MoveTo(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)
     {
         Debug.Log("Déplacement de " + caster.name + " vers " + target.name);
+        caster.PlayMoveStartSound();
 
         if (caster.Data.TPEffect_Start != null)
             Instantiate(caster.Data.TPEffect_Start, caster.transform.position, Quaternion.identity);
@@ -293,6 +298,7 @@ public class RhythmQTEManager : MonoBehaviour
 
             yield return null;
             Debug.Log("Fin du déplacement de " + caster.name);
+            caster.PlayMoveEndSound();
             yield break;
         }
 
@@ -350,6 +356,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
 
             Debug.Log("Fin du déplacement de " + caster.name);
+            caster.PlayMoveEndSound();
             yield break;
         }
 
@@ -382,11 +389,13 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         Debug.Log("Fin du déplacement de " + caster.name);
+        caster.PlayMoveEndSound();
     }
 
     private IEnumerator ReturnToInitialPosition(MusicalMoveSO move, CharacterUnit caster, CharacterUnit target)
     {
         Debug.Log("Retour de " + caster.name + " vers sa position parent");
+        caster.PlayMoveStartSound();
 
         if (caster.Data.TPEffect_Start != null)
             Instantiate(caster.Data.TPEffect_Start, caster.transform.position, Quaternion.identity);
@@ -411,6 +420,7 @@ public class RhythmQTEManager : MonoBehaviour
                 Instantiate(caster.Data.TPEffect_Destination, initialPosition, Quaternion.identity);
 
             yield return null;
+            caster.PlayMoveEndSound();
         }
         else
         {
@@ -466,8 +476,8 @@ public class RhythmQTEManager : MonoBehaviour
             if (finalDirToParent != Vector3.zero)
                 caster.transform.forward = finalDirToParent;
         }
-
         Debug.Log("Le caster a terminé son retour.");
+        caster.PlayMoveEndSound();
     }
 
     IEnumerator PlayMoveAnimations(string[] animationClips, CharacterUnit caster)


### PR DESCRIPTION
## Résumé
- ajout de deux `AudioClip` dans `CharacterData` pour définir les sons de départ et d'arrivée
- ajout des méthodes `PlayMoveStartSound` et `PlayMoveEndSound` dans `CharacterUnit`
- appel de ces méthodes dans `RhythmQTEManager` lors de chaque déplacement

## Tests
- Aucun test automatisé présent dans le dépôt

------
https://chatgpt.com/codex/tasks/task_e_687397c7319c8325afb58b097e3be3d5