### PR TITLE
Fix movement audio repeating

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -195,7 +195,6 @@ public class RhythmQTEManager : MonoBehaviour
 
     private IEnumerator SimpleMoveTo(CharacterUnit caster, CharacterUnit target, ItemData item)
     {
-        caster.PlayMoveStartSound();
         Vector3 origin = caster.transform.position;
         Vector3 destination = target.transform.position + target.transform.forward * item.castDistance;
         bool hasMovement = Vector3.Distance(origin, destination) > 0.01f;
@@ -221,7 +220,6 @@ public class RhythmQTEManager : MonoBehaviour
 
     private IEnumerator SimpleReturnToInitialPosition(CharacterUnit caster, CharacterUnit target, ItemData item)
     {
-        caster.PlayMoveStartSound();
         Vector3 origin = caster.transform.parent.position;
         bool hasMovement = Vector3.Distance(caster.transform.position, origin) > 0.01f;
         if (hasMovement)
@@ -255,7 +253,6 @@ public class RhythmQTEManager : MonoBehaviour
     private IEnumerator MoveTo(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)
     {
         Debug.Log("Déplacement de " + caster.name + " vers " + target.name);
-        caster.PlayMoveStartSound();
 
         Vector3 startPosition = caster.transform.position;
 


### PR DESCRIPTION
## Summary
- stop playing the move sound if the unit isn't actually moving

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873c17eb2348325a557462efc902521