### PR TITLE
Ajout d'un délai au taunt de mort prématurée

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -71,7 +71,7 @@ public class RhythmQTEManager : MonoBehaviour
         {
             if (!tauntPlayed && isActive && caster != null && caster.Data.prematureDeathTaunt != null)
             {
-                AudioManager.Instance?.PlayVoice(caster.Data.prematureDeathTaunt);
+                StartCoroutine(PlayTauntWithDelay(caster.Data.prematureDeathTaunt, 1f));
                 tauntPlayed = true;
             }
         };
@@ -656,6 +656,12 @@ public class RhythmQTEManager : MonoBehaviour
     {
         var first = NewBattleManager.Instance.currentTargetCharacter;
         return first != null ? first.transform : null;
+    }
+
+    private IEnumerator PlayTauntWithDelay(AudioClip clip, float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        AudioManager.Instance?.PlayVoice(clip);
     }
 
     #endregion


### PR DESCRIPTION
## Résumé
- déclenchement du `prematureDeathTaunt` retardé d'une seconde pour les unités qui jouent leur mouvement
- ajout d'une coroutine `PlayTauntWithDelay` dans `RhythmQTEManager`

## Tests
- compilation par Unity non effectuée (environnement CI absent)


------
https://chatgpt.com/codex/tasks/task_e_6873c56c9ab0832585ebce1b185cd881