### PR TITLE
Fix camera timeline update

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -121,7 +121,7 @@ public class CameraController : MonoBehaviour
         if (cameraPositions == null || cameraPositions.Count == 0)
             UpdateCameraPositionsFromHandler();
 
-        if (TimelineStatus.IsTimelinePlaying)
+        if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)
             return;
 
         // ✅ Si la MainCamera est désactivée → skip toute logique

--- a/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
@@ -99,7 +99,7 @@ public class InteractionManager : MonoBehaviour
         }
 
         // ❗️ Ne pas détecter pendant une cinématique Timeline
-        if (TimelineStatus.IsTimelinePlaying)
+        if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)
         {
             // Si une Timeline joue, désactive la UI si elle était active
             if (currentInteractable != null)


### PR DESCRIPTION
## Summary
- empêchait le suivi correct des Timelines en début de combat
- détection d'interaction et caméra ne consultaient pas le bon indicateur
- désormais `TimelineManager` est vérifié pour stopper la logique le temps de la Timeline

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873c7090d5083258af5b59936c983e5