### PR TITLE
Ajout de réactions de deuil et bris de la caméra

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -85,6 +85,18 @@ public class CharacterData : ScriptableObject, ITargetable
     public AudioClip moveStartClip;
     public AudioClip moveEndClip;
 
+    [Header("Voix de deuil")]
+    [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt")]
+    public AudioClip weepForLucianDeath;
+    [Tooltip("Lamentation jouée par ce personnage quand Thalia meurt")]
+    public AudioClip weepForThaliaDeath;
+    [Tooltip("Lamentation jouée par ce personnage quand Kael meurt")]
+    public AudioClip weepForKaelDeath;
+    [Tooltip("Lamentation jouée par ce personnage quand Link meurt")]
+    public AudioClip weepForLinkDeath;
+    [Tooltip("Lamentation jouée par ce personnage quand Luna meurt")]
+    public AudioClip weepForLunaDeath;
+
     // Ajoute une référence au GameObject source
     public MonoBehaviour owner;
 

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+/// <summary>
+/// Déclenche un effet de bris de caméra en combat.
+/// </summary>
+public class BattleCameraShatter : MonoBehaviour
+{
+    [Tooltip("Son joué lors du bris de la caméra")]
+    public AudioClip shatterSound;
+    [Tooltip("Effet visuel à instancier sur la caméra")]
+    public GameObject shatterEffect;
+
+    /// <summary>
+    /// Joue le son et l'effet de bris de caméra.
+    /// </summary>
+    public void Break()
+    {
+        if (shatterSound != null)
+            AudioManager.Instance?.PlaySound(shatterSound);
+
+        if (shatterEffect != null)
+            Instantiate(shatterEffect, transform.position, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -214,7 +214,46 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             NewBattleManager.Instance?.OnEnemyDefeated(this);
         }
 
+        if (Data.isPlayerControlled)
+        {
+            PlayAllyWeep();
+
+            if (Data.characterName == "Lucian")
+            {
+                BattleCameraShatter shatter = FindFirstObjectByType<BattleCameraShatter>();
+                if (shatter != null)
+                    shatter.Break();
+            }
+        }
+
         OnDeath?.Invoke(this);
+    }
+
+    void PlayAllyWeep()
+    {
+        var allies = NewBattleManager.Instance.activeCharacterUnits
+            .Where(u => u.Data.isPlayerControlled && u != this && u.currentHP > 0)
+            .ToList();
+        if (allies.Count == 0)
+            return;
+
+        CharacterUnit randomAlly = allies[Random.Range(0, allies.Count)];
+        AudioClip clip = GetWeepClip(randomAlly.Data, Data.characterName);
+        if (clip != null)
+            AudioManager.Instance?.PlayVoice(clip);
+    }
+
+    AudioClip GetWeepClip(CharacterData allyData, string deadName)
+    {
+        return deadName switch
+        {
+            "Lucian" => allyData.weepForLucianDeath,
+            "Thalia" => allyData.weepForThaliaDeath,
+            "Kael" => allyData.weepForKaelDeath,
+            "Link" => allyData.weepForLinkDeath,
+            "Luna" => allyData.weepForLunaDeath,
+            _ => null,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- ajout d'un script `BattleCameraShatter` pour gérer le bris de la battle camera
- extension de `CharacterData` avec cinq AudioClips de lamentation
- déclenchement des lamentations et du bris de caméra dans `CharacterUnit`

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6873ca5f89d883259e72c476ec2045a5