### PR TITLE
Implémente l'effet de distorsion pour le bris de caméra

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
@@ -18,12 +18,29 @@ public class BattleCameraShatter : MonoBehaviour
     private LensDistortion lensDistortion;
     private Bloom bloom;
 
+    private float baseLensIntensity;
+    private float baseDirtIntensity;
+    private Texture baseDirtTexture;
+    private float baseBloomThreshold;
+    private float baseBloomIntensity;
+
     private void Awake()
     {
         if (volume != null && volume.profile != null)
         {
             volume.profile.TryGet(out lensDistortion);
             volume.profile.TryGet(out bloom);
+
+            if (lensDistortion != null)
+                baseLensIntensity = lensDistortion.intensity.value;
+
+            if (bloom != null)
+            {
+                baseDirtIntensity = bloom.dirtIntensity.value;
+                baseDirtTexture = bloom.dirtTexture.value;
+                baseBloomThreshold = bloom.threshold.value;
+                baseBloomIntensity = bloom.intensity.value;
+            }
         }
     }
 
@@ -37,6 +54,23 @@ public class BattleCameraShatter : MonoBehaviour
 
         if (lensDistortion != null && bloom != null)
             StartCoroutine(ShatterRoutine());
+    }
+
+    /// <summary>
+    /// Réinitialise les paramètres de post-processing modifiés par l'effet.
+    /// </summary>
+    public void ResetEffect()
+    {
+        if (lensDistortion != null)
+            lensDistortion.intensity.value = baseLensIntensity;
+
+        if (bloom != null)
+        {
+            bloom.dirtIntensity.value = baseDirtIntensity;
+            bloom.dirtTexture.value = baseDirtTexture;
+            bloom.threshold.value = baseBloomThreshold;
+            bloom.intensity.value = baseBloomIntensity;
+        }
     }
 
     private IEnumerator ShatterRoutine()

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
@@ -1,4 +1,7 @@
+using System.Collections;
 using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
 
 /// <summary>
 /// Déclenche un effet de bris de caméra en combat.
@@ -7,8 +10,22 @@ public class BattleCameraShatter : MonoBehaviour
 {
     [Tooltip("Son joué lors du bris de la caméra")]
     public AudioClip shatterSound;
-    [Tooltip("Effet visuel à instancier sur la caméra")]
-    public GameObject shatterEffect;
+    [Tooltip("Volume contenant les effets de post-processing")]
+    public Volume volume;
+    [Tooltip("Texture utilisée pour la salissure de l'objectif")]
+    public Texture fractureTex;
+
+    private LensDistortion lensDistortion;
+    private Bloom bloom;
+
+    private void Awake()
+    {
+        if (volume != null && volume.profile != null)
+        {
+            volume.profile.TryGet(out lensDistortion);
+            volume.profile.TryGet(out bloom);
+        }
+    }
 
     /// <summary>
     /// Joue le son et l'effet de bris de caméra.
@@ -18,7 +35,28 @@ public class BattleCameraShatter : MonoBehaviour
         if (shatterSound != null)
             AudioManager.Instance?.PlaySound(shatterSound);
 
-        if (shatterEffect != null)
-            Instantiate(shatterEffect, transform.position, Quaternion.identity);
+        if (lensDistortion != null && bloom != null)
+            StartCoroutine(ShatterRoutine());
+    }
+
+    private IEnumerator ShatterRoutine()
+    {
+        bloom.dirtIntensity.value = 50f;
+        bloom.dirtTexture.value = fractureTex;
+        bloom.threshold.value = 0.4f;
+        bloom.intensity.value = 1f;
+
+        float duration = 0.4f;
+        float timer = 0f;
+        while (timer < duration)
+        {
+            float normalized = timer / duration;
+            float strength = Mathf.Sin(normalized * Mathf.PI);
+            lensDistortion.intensity.value = Mathf.Lerp(0f, -0.6f, strength);
+            timer += Time.deltaTime;
+            yield return null;
+        }
+
+        lensDistortion.intensity.value = 0f;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -28,9 +28,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         get => _currentHP;
         set
         {
+            bool wasDead = _currentHP <= 0f;
             _currentHP = value;
             if (Data != null)
                 Data.currentHP = value;
+
+            if (wasDead && _currentHP > 0f && Data != null && Data.characterName == "Lucian")
+            {
+                BattleCameraShatter shatter = FindFirstObjectByType<BattleCameraShatter>();
+                shatter?.ResetEffect();
+            }
         }
     }
     public float currentMP;


### PR DESCRIPTION
## Résumé
- remplace l'ancien prefab `shatterEffect` par des réglages de post‐processing
- applique une distorsion et règle le Bloom via un `Volume`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873d19ab0d08325bbb4ebec3356f8d5