### PR TITLE
Utilisation de la musique de zone pour le combat

### DIFF
--- a/Assets/Prefabs/BattleTransitionManager.prefab
+++ b/Assets/Prefabs/BattleTransitionManager.prefab
@@ -64,8 +64,4 @@ MonoBehaviour:
   transitionSFXClips:
   - {fileID: 8300000, guid: 9d4f961144889094aabb116ea91be633, type: 3}
   sfxSource: {fileID: 0}
-  battleMusics:
-  - {fileID: 8300000, guid: 0a5a8536e44e89149a70fda880b58b57, type: 3}
-  - {fileID: 8300000, guid: 744ce4c970e1c934d8e9e780df790aa5, type: 3}
-  - {fileID: 8300000, guid: 778b1ba268820f74081779d1aaa3f500, type: 3}
   musicSource: {fileID: 0}

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -36,7 +36,6 @@ public class BattleTransitionManager : MonoBehaviour
     [SerializeField] private AudioSource sfxSource;
 
     [Header("Music")]
-    [SerializeField] private List<AudioClip> battleMusics = new();
     [SerializeField] private AudioSource musicSource;
 
     private Camera battleCamera;
@@ -75,8 +74,17 @@ public class BattleTransitionManager : MonoBehaviour
 
         CombatSkyboxManager.Instance?.ApplyBattleSkybox();
 
-        AudioClip randomClip = battleMusics[Random.Range(0, battleMusics.Count)];
-        AudioManager.Instance.TransitionToCombat(randomClip);
+        AudioClip randomClip = null;
+        ZoneSO currentZone = ZoneManager.Instance != null ? ZoneManager.Instance.currentZone : null;
+        if (currentZone != null && currentZone.battleMusic != null && currentZone.battleMusic.Length > 0)
+        {
+            randomClip = currentZone.battleMusic[Random.Range(0, currentZone.battleMusic.Length)];
+        }
+
+        if (randomClip != null)
+            AudioManager.Instance.TransitionToCombat(randomClip);
+        else
+            Debug.LogWarning("[BattleTransitionManager] Aucune musique de combat trouvée pour la zone actuelle.");
         StartCoroutine(PlayTransitionSoundsSequentially());
         StartCoroutine(TransitionRoutine());
 


### PR DESCRIPTION
## Résumé
- la transition de combat choisit désormais la musique dans `ZoneSO`
- suppression de la liste `battleMusics` inutilisée dans `BattleTransitionManager`
- prefab mis à jour en conséquence

## Tests
- `grep -n "battleMusic" -n Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs`


------
https://chatgpt.com/codex/tasks/task_e_6873d7ce78748325a01c74e24ddd1393