### PR TITLE
Ajout de l'animation Idle en début et fin de tour

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -467,5 +467,25 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             moveCooldowns[move] = move.cooldown;
     }
 
+    public void PlayIdleAnimation()
+    {
+        if (currentHP <= 0)
+            return;
+
+        if (TryGetComponent<SleepStatus>(out var sleep) && sleep.IsAsleep)
+            return;
+
+        if (TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
+            return;
+
+        if (animator != null)
+        {
+            string idleName = !string.IsNullOrEmpty(Data.battleIdleAnimationName)
+                ? Data.battleIdleAnimationName
+                : "Idle";
+            animator.Play(idleName);
+        }
+    }
+
     #endregion
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -594,6 +594,7 @@ public class NewBattleManager : MonoBehaviour
 
             Debug.Log($"[BattleTurnManager] Tour de {unit.name} (ATB: {unit.currentATB})");
             OrientAllUnitsTowardClosestOpponent();
+            unit.PlayIdleAnimation();
 
             yield return new WaitForSeconds(0.5f);
 
@@ -1029,6 +1030,7 @@ public class NewBattleManager : MonoBehaviour
                 maxTurnDamage = currentTurnDamage;
                 mvpUnit = currentCharacterUnit;
             }
+            currentCharacterUnit.PlayIdleAnimation();
         }
 
         ChangeBattleState(BattleState.EndTurn);
@@ -1314,6 +1316,13 @@ public class NewBattleManager : MonoBehaviour
 
     private IEnumerator RotateUnitSmoothly(CharacterUnit unit, Quaternion targetRotation, float rotationSpeed)
     {
+        Animator anim = unit.GetComponentInChildren<Animator>();
+        if (anim != null)
+        {
+            // Joue l'animation de rotation en boucle pendant la rotation
+            anim.Play("Turn 90");
+        }
+
         // Tant que l’angle entre la rotation actuelle et la target est > 0.5f
         while (Quaternion.Angle(unit.transform.rotation, targetRotation) > 0.5f)
         {
@@ -1327,6 +1336,12 @@ public class NewBattleManager : MonoBehaviour
 
         // Orientation finale propre (uniquement sur l’axe Y)
         unit.transform.rotation = Quaternion.Euler(0, targetRotation.eulerAngles.y, 0);
+
+        // Lecture instantanée de l'animation "Exit" une fois la rotation terminée
+        if (anim != null)
+        {
+            anim.Play("Exit");
+        }
     }
     #endregion
 


### PR DESCRIPTION
## Résumé
- ajout d'une méthode `PlayIdleAnimation` dans `CharacterUnit`
- appel de cette méthode au début et à la fin de chaque tour dans `NewBattleManager`
- lecture de l'animation "Turn 90" durant la rotation des unités et déclenchement de l'animation "Exit" à la fin de la rotation

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6873db2f71fc8325b821caa3b6b8c204