### PR TITLE
Gérer le sommeil pour le gameplay Fatigue

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -75,7 +75,7 @@ public class ItemData : ScriptableObject
     public GameObject visualEffect;
     public AudioClip introClip;
 
-    public void ApplyEffect(CharacterUnit target)
+    public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {
         switch (effectType)
         {
@@ -95,7 +95,7 @@ public class ItemData : ScriptableObject
                 Debug.Log("[ItemData] Effet BoostTiming non implémenté.");
                 break;
             case ItemEffectType.Damage:
-                ApplyDamage(target);
+                ApplyDamage(caster, target);
                 break;
             case ItemEffectType.IncreaseRange:
                 ApplyIncreaseRange(target);
@@ -152,10 +152,15 @@ public class ItemData : ScriptableObject
         InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, buffDuration, buffIsPercentage);
     }
 
-    private void ApplyDamage(CharacterUnit target)
+    private void ApplyDamage(CharacterUnit caster, CharacterUnit target)
     {
         if (target != null)
-            target.TakeDamage(effectValue);
+        {
+            float damage = effectValue;
+            if (caster != null)
+                damage *= caster.GetAttackMultiplier();
+            target.TakeDamage(damage);
+        }
     }
 
     private void ApplyIncreaseRange(CharacterUnit target)

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -84,7 +84,10 @@ public class MusicalMoveSO : ScriptableObject
     {
         float finalValue = effectValue;
         if (caster != null)
+        {
             finalValue += caster.currentPower;
+            finalValue *= caster.GetAttackMultiplier();
+        }
 
         if (isCritical)
             finalValue *= 2f;

--- a/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
@@ -32,7 +32,11 @@ public class AnimationEventsManager : MonoBehaviour
         }
         else
         {
-            target.TakeDamage(move.power);
+            CharacterUnit caster = transform.GetComponentInParent<CharacterUnit>();
+            float damage = move.power;
+            if (caster != null)
+                damage *= caster.GetAttackMultiplier();
+            target.TakeDamage(damage);
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -467,6 +467,15 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             moveCooldowns[move] = move.cooldown;
     }
 
+    public float GetAttackMultiplier()
+    {
+        if (TryGetComponent<SleepStatus>(out var sleep) && sleep.IsAsleep && Data != null && Data.gameplayType == GameplayType.Fatigue)
+            return 2f;
+        if (TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep && Data != null && Data.gameplayType == GameplayType.Fatigue)
+            return 2f;
+        return 1f;
+    }
+
     public void PlayIdleAnimation()
     {
         if (currentHP <= 0)

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -61,7 +61,7 @@ public class InventoryManager : MonoBehaviour
 
         Debug.Log($"[Inventory] Utilisation de l'objet : {item.itemName} sur {target.Data.characterName}");
 
-        item.ApplyEffect(target);
+        item.ApplyEffect(caster, target);
         inventoryItems.Remove(item);
     }
 
@@ -71,7 +71,7 @@ public class InventoryManager : MonoBehaviour
     public void PreviewItemEffect(ItemData item, CharacterUnit target)
     {
         Debug.Log($"[Inventory] Aperçu de l'effet de {item.itemName} sur {target.Data.characterName}");
-        item.ApplyEffect(target);
+        item.ApplyEffect(null, target);
     }
 
     public void ApplyBuff(CharacterUnit target, BuffStatType stat, int amount, float duration, bool isPercentage)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -568,12 +568,12 @@ public class NewBattleManager : MonoBehaviour
     {
         if (currentBattleState != BattleState.VictoryScreen_Await && currentBattleState != BattleState.VictoryScreen_CanContinue && currentBattleState != BattleState.GameOverScreen_Await && currentBattleState != BattleState.GameOverScreen_CanContinue)
         {
-            if (unit.TryGetComponent<SleepStatus>(out var sleep) && sleep.IsAsleep)
+            if (unit.TryGetComponent<SleepStatus>(out var sleep) && sleep.IsAsleep && unit.Data.gameplayType != GameplayType.Fatigue)
             {
                 EndTurn();
                 yield break;
             }
-            if (unit.TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
+            if (unit.TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep && unit.Data.gameplayType != GameplayType.Fatigue)
             {
                 EndTurn();
                 yield break;


### PR DESCRIPTION
## Résumé
- les unités dorment normalement sauf si leur `gameplayType` est `Fatigue`
- nouvelle méthode `GetAttackMultiplier` dans `CharacterUnit`
- application du multiplicateur de dégâts lors des attaques musicales, des items et des événements d'animation
- mise à jour de la gestion de tour dans `NewBattleManager`

## Tests
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_687406ca2af08325aaab0ec2d1e2f3e2