### PR TITLE
Ajout des timelines preparing et performing

### DIFF
--- a/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
+++ b/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
@@ -39,7 +39,8 @@ MonoBehaviour:
   defaultTargetType: 3
   targetTypes: 03000000
   introVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
   introAnimationClip: {fileID: 0}

--- a/Assets/Items/Item_Endormissement/Item_Endormissement.asset
+++ b/Assets/Items/Item_Endormissement/Item_Endormissement.asset
@@ -38,7 +38,8 @@ MonoBehaviour:
   defaultTargetType: 1
   targetTypes: 0100000003000000
   introVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 11400000, guid: 132371f140add7b44bb629233ff86ec1, type: 2}
+  performingTimeline: {fileID: 11400000, guid: 132371f140add7b44bb629233ff86ec1, type: 2}
+  preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
   introAnimationClip: {fileID: 0}

--- a/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
+++ b/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
@@ -38,7 +38,8 @@ MonoBehaviour:
   defaultTargetType: 5
   targetTypes: 05000000
   introVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
   introAnimationClip: {fileID: 0}

--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -38,7 +38,8 @@ MonoBehaviour:
   defaultTargetType: 0
   targetTypes: 00000000
   introVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
   introAnimationClip: {fileID: 0}

--- a/Assets/Items/Item_Reveil/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil/Item_Reveil.asset
@@ -38,7 +38,8 @@ MonoBehaviour:
   defaultTargetType: 3
   targetTypes: 03000000
   introVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
   introAnimationClip: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -44,4 +44,5 @@ MonoBehaviour:
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
+  performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
+++ b/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -44,4 +44,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 11400000, guid: 6c49bb58b5d61c84ca28f3e1fccbe9d4, type: 2}
+  performingTimeline: {fileID: 11400000, guid: 6c49bb58b5d61c84ca28f3e1fccbe9d4, type: 2}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -44,4 +44,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
+  performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
+  preparingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -43,4 +43,5 @@ MonoBehaviour:
   useTeleportation: 0
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}
-  timelineAsset: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  preparingTimeline: {fileID: 0}

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -50,8 +50,10 @@ public class ItemData : ScriptableObject
     public GameObject introVFXPrefab;
 
     [Header("Timeline")]
+    [Tooltip("Timeline jouée lors de la préparation de l'item")]
+    public TimelineAsset preparingTimeline;
     [Tooltip("Timeline à jouer lors de l'utilisation de l'item")]
-    public TimelineAsset timelineAsset;
+    public TimelineAsset performingTimeline;
 
     [Header("QTE Pattern")]
     public List<float> beatPattern;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -72,8 +72,10 @@ public class MusicalMoveSO : ScriptableObject
 
 
     [Header("Timeline")]
+    [Tooltip("Timeline jouée lors de la préparation du move")]
+    public TimelineAsset preparingTimeline;
     [Tooltip("Timeline à jouer lors de l'exécution du move")]
-    public TimelineAsset timelineAsset;
+    public TimelineAsset performingTimeline;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -146,9 +146,6 @@ public class InputsManager : MonoBehaviour
                 return;
             }
 
-            if (bm.currentItem != null && bm.currentItem.itemTargetingAnimation != null)
-                bm.currentCharacterUnit.GetComponentInChildren<Animator>()
-                    .Play(bm.currentItem.itemTargetingAnimation.name);
 
             bm.ChangeBattleState(BattleState.SquadUnit_Item_Use);
             bm.StartCoroutine(bm.UseItemOnTarget(bm.currentItem, bm.currentCharacterUnit, bm.currentTargetCharacter));
@@ -208,8 +205,15 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.itemTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
+                {
+                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
+                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
+                }
+                else if (bm.currentItem.itemTargetingAnimation != null)
+                {
+                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
+                }
             }
             else
             {
@@ -264,8 +268,15 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.itemTargetingAnimation)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
+                {
+                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
+                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
+                }
+                else if (bm.currentItem.itemTargetingAnimation)
+                {
+                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
+                }
             }
             else
             {
@@ -316,8 +327,15 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.itemTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentItem.itemTargetingAnimation.name);
+                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
+                {
+                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
+                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
+                }
+                else if (bm.currentItem.itemTargetingAnimation != null)
+                {
+                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
+                }
             }
             else
             {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1096,8 +1096,15 @@ public class NewBattleManager : MonoBehaviour
             ToggleMenuContainers(false, false, false);
             HandleTargetSelection(item);
 
-            if (item.itemTargetingAnimation != null)
+            if (item.preparingTimeline != null && TimelineLauncher.Instance != null)
+            {
+                GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
+                TimelineLauncher.Instance.PlayTimeline(item.preparingTimeline, animGO, "BattleCamera");
+            }
+            else if (item.itemTargetingAnimation != null)
+            {
                 currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(item.itemTargetingAnimation.name);
+            }
         }
         else
         {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -80,9 +80,9 @@ public class RhythmQTEManager : MonoBehaviour
 
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
 
-        if (move.timelineAsset != null && TimelineLauncher.Instance != null && casterAnimatorGO != null)
+        if (move.performingTimeline != null && TimelineLauncher.Instance != null && casterAnimatorGO != null)
         {
-            TimelineLauncher.Instance.PlayTimeline(move.timelineAsset, casterAnimatorGO, "BattleCamera");
+            TimelineLauncher.Instance.PlayTimeline(move.performingTimeline, casterAnimatorGO, "BattleCamera");
         }
         else if (move.musicalMoveIntroAnimationNames.Length > 0)
         {
@@ -91,7 +91,7 @@ public class RhythmQTEManager : MonoBehaviour
 
         yield return MoveTo(caster, target, move); // Déplacement vers l’ennemi
 
-        if (move.timelineAsset == null && move.musicalMoveAnimationNames.Length > 0)
+        if (move.performingTimeline == null && move.musicalMoveAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveAnimationNames, caster);
         }
@@ -112,9 +112,9 @@ public class RhythmQTEManager : MonoBehaviour
                 yield return null;
         }
 
-        if (move.timelineAsset != null)
+        if (move.performingTimeline != null)
         {
-            yield return new WaitForSeconds((float)move.timelineAsset.duration); // Attend la fin de la Timeline
+            yield return new WaitForSeconds((float)move.performingTimeline.duration); // Attend la fin de la Timeline
         }
         else
         {
@@ -155,10 +155,10 @@ public class RhythmQTEManager : MonoBehaviour
         Animator animator = caster.GetComponentInChildren<Animator>();
 
         // Lecture d'une Timeline ou d'une animation d'intro
-        if (item.timelineAsset != null && TimelineLauncher.Instance != null && animator != null)
+        if (item.performingTimeline != null && TimelineLauncher.Instance != null && animator != null)
         {
-            TimelineLauncher.Instance.PlayTimeline(item.timelineAsset, animator.gameObject, "BattleCamera");
-            yield return new WaitForSeconds((float)item.timelineAsset.duration);
+            TimelineLauncher.Instance.PlayTimeline(item.performingTimeline, animator.gameObject, "BattleCamera");
+            yield return new WaitForSeconds((float)item.performingTimeline.duration);
         }
         else if (item.introAnimationClip != null && animator != null)
         {
@@ -175,7 +175,7 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         // Animation principale si pas de Timeline
-        if (item.timelineAsset == null && item.animationClip != null && animator != null)
+        if (item.performingTimeline == null && item.animationClip != null && animator != null)
         {
             animator.Play(item.animationClip.name);
             yield return null;


### PR DESCRIPTION
## Résumé
- remplace `timelineAsset` par `performingTimeline` et `preparingTimeline`
- déclenche `preparingTimeline` à la sélection d'un objet
- joue `performingTimeline` lors de l'exécution
- met à jour les assets et les appels dans les scripts

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740f6d21f083258d0b4b9b9df9a773