### PR TITLE
Animation de préparation des cibles

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -369,6 +369,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public void PlayHurtAnimation() => PlayAnimationClip(hurtAnimation);
     public void PlayInterceptedAnimation() => PlayAnimationClip(interceptedAnimation);
     public void PlayInterceptionAnimation() => PlayAnimationClip(interceptionAnimation);
+    public void PlayPrepareToUndergoAnimation()
+    {
+        if (animator != null)
+            animator.Play("prepareToUndergo");
+    }
 
     void PlayDamageFeedback()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -76,7 +76,10 @@ public class RhythmQTEManager : MonoBehaviour
             }
         };
         if (target != null)
+        {
             target.OnDeath += deathHandler;
+            target.PlayPrepareToUndergoAnimation();
+        }
 
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
 


### PR DESCRIPTION
## Résumé
- ajoute une méthode `PlayPrepareToUndergoAnimation` sur `CharacterUnit`
- déclenche cette animation au début d'un `MusicalMoveRoutine`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874120010a083258226c6b15cb8ea19