### PR TITLE
Mise à jour préparation d'objets

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -205,12 +205,7 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
-                {
-                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
-                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
-                }
-                else if (bm.currentItem.itemTargetingAnimation != null)
+                if (bm.currentItem.itemTargetingAnimation != null)
                 {
                     bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
                 }
@@ -268,12 +263,7 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
-                {
-                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
-                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
-                }
-                else if (bm.currentItem.itemTargetingAnimation)
+                if (bm.currentItem.itemTargetingAnimation)
                 {
                     bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
                 }
@@ -327,12 +317,7 @@ public class InputsManager : MonoBehaviour
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
 
-                if (bm.currentItem.preparingTimeline != null && TimelineLauncher.Instance != null)
-                {
-                    GameObject animGO = bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
-                    TimelineLauncher.Instance.PlayTimeline(bm.currentItem.preparingTimeline, animGO, "BattleCamera");
-                }
-                else if (bm.currentItem.itemTargetingAnimation != null)
+                if (bm.currentItem.itemTargetingAnimation != null)
                 {
                     bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
                 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -7,6 +7,7 @@ using UnityEngine.UI;
 using UnityEngine.InputSystem;
 using TMPro;
 using UnityEngine.Playables;
+using UnityEngine.Timeline;
 
 #region TargetType
 public enum TargetType
@@ -101,6 +102,9 @@ public class NewBattleManager : MonoBehaviour
     public RectTransform timelineContainer;
     public GameObject timelineUnitPrefab;
     public List<BattleTimelineUnit> timelineUIObjects = new();
+
+    [Header("Timeline d'objets")]
+    public TimelineAsset itemPreparingTimeline;
 
     private CharacterUnit previousUnit; // Champ de classe, pas une variable locale
     [HideInInspector] public CharacterUnit currentCharacterUnit;
@@ -1096,10 +1100,10 @@ public class NewBattleManager : MonoBehaviour
             ToggleMenuContainers(false, false, false);
             HandleTargetSelection(item);
 
-            if (item.preparingTimeline != null && TimelineLauncher.Instance != null)
+            if (itemPreparingTimeline != null && TimelineLauncher.Instance != null)
             {
                 GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
-                TimelineLauncher.Instance.PlayTimeline(item.preparingTimeline, animGO, "BattleCamera");
+                TimelineLauncher.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
             }
             else if (item.itemTargetingAnimation != null)
             {
@@ -1588,6 +1592,12 @@ public class NewBattleManager : MonoBehaviour
         currentMove = null;
         ToggleMenuContainers(false, false, true);
         currentMenuIndex = 0;
+
+        if (itemPreparingTimeline != null && TimelineLauncher.Instance != null)
+        {
+            GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
+            TimelineLauncher.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
+        }
 
         itemChoices = InventoryManager.Instance.GetUsableItems();
 


### PR DESCRIPTION
## Résumé
- lecture d'une Timeline commune `itemPreparingTimeline` dans `NewBattleManager`
- utilisation de cette Timeline lors du menu d'objets et après confirmation d'utilisation

## Test
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874bfff0578832583f3fc5375875911