### PR TITLE
Hold camera after item menu timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -105,6 +105,7 @@ public class NewBattleManager : MonoBehaviour
 
     [Header("Timeline d'objets")]
     public TimelineAsset itemPreparingTimeline;
+    private bool itemMenuTimelineActive = false;
 
     private CharacterUnit previousUnit; // Champ de classe, pas une variable locale
     [HideInInspector] public CharacterUnit currentCharacterUnit;
@@ -1539,6 +1540,12 @@ public class NewBattleManager : MonoBehaviour
         ChangeBattleState(BattleState.SquadUnit_MainMenu);
         ToggleMenuContainers(true, false, false);
 
+        if (itemMenuTimelineActive && TimelineLauncher.Instance != null)
+        {
+            TimelineLauncher.Instance.StopTimeline();
+            itemMenuTimelineActive = false;
+        }
+
         // Réinitialise les actions sélectionnées afin d'éviter des conflits
         currentMove = null;
         currentItem = null;
@@ -1597,6 +1604,7 @@ public class NewBattleManager : MonoBehaviour
         {
             GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
             TimelineLauncher.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
+            itemMenuTimelineActive = true;
         }
 
         itemChoices = InventoryManager.Instance.GetUsableItems();
@@ -1884,6 +1892,11 @@ public class NewBattleManager : MonoBehaviour
 
     public void HandleTargetSelection(ItemData item)
     {
+        if (itemMenuTimelineActive && TimelineLauncher.Instance != null)
+        {
+            TimelineLauncher.Instance.StopTimeline();
+            itemMenuTimelineActive = false;
+        }
         currentItem = item;
         currentMove = null; // on annule la sélection de compétence précédente
         currentItemTargetType = item.defaultTargetType;
@@ -2078,6 +2091,11 @@ public class NewBattleManager : MonoBehaviour
         if (cc != null && (cc.IsFollowingPath || cc.currentWorldCameraState != WorldCameraState.ResearchClosestCamPoint))
         {
             return; // Laisse la main au CameraController pour éviter les conflits
+        }
+
+        if (itemMenuTimelineActive)
+        {
+            return; // Laisse la caméra figée à la fin de la Timeline d'objets
         }
 
         if (isFollowingCurrentTarget && currentCharacterUnit != null && currentTargetCharacter != null)

--- a/Assets/TimelineLauncher.cs
+++ b/Assets/TimelineLauncher.cs
@@ -10,6 +10,8 @@ public class TimelineLauncher : MonoBehaviour
 
     [SerializeField] private PlayableDirector director;
     private Coroutine followCoroutine;
+    public bool IsTimelineActive => director != null &&
+        (director.state == PlayState.Playing || director.state == PlayState.Paused);
 
     private void Awake()
     {
@@ -33,6 +35,7 @@ public class TimelineLauncher : MonoBehaviour
         }
 
         director.playableAsset = timelineAsset;
+        director.extrapolationMode = DirectorWrapMode.Hold;
 
         GameObject cameraGO = null;
         Transform cameraParent = null;
@@ -105,6 +108,14 @@ public class TimelineLauncher : MonoBehaviour
                 cameraParent.rotation = caster.rotation;
             }
             yield return null;
+        }
+    }
+
+    public void StopTimeline()
+    {
+        if (director != null && (director.state == PlayState.Playing || director.state == PlayState.Paused))
+        {
+            director.Stop();
         }
     }
 }


### PR DESCRIPTION
## Summary
- configure `TimelineLauncher` so that timelines hold on their last frame and can be stopped
- add a flag in `NewBattleManager` to keep the camera frozen while the item menu timeline is active
- stop the timeline when returning to the main menu or selecting an item
- prevent camera updates during the item menu timeline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874c81c75b08325a92f758bf5fbd6d4