### PR TITLE
Fix: retour au menu principal après utilisation d'objet

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -161,7 +161,8 @@ public class RhythmQTEManager : MonoBehaviour
         if (item.performingTimeline != null && TimelineLauncher.Instance != null && animator != null)
         {
             TimelineLauncher.Instance.PlayTimeline(item.performingTimeline, animator.gameObject, "BattleCamera");
-            yield return new WaitForSeconds((float)item.performingTimeline.duration);
+            // ⏳ Attendre la fin effective de la Timeline avant de continuer
+            yield return new WaitUntil(() => !TimelineLauncher.Instance.IsTimelineActive);
         }
         else if (item.introAnimationClip != null && animator != null)
         {


### PR DESCRIPTION
## Résumé
- attente de la fin réelle de la timeline lors de l'utilisation d'un objet

## Détails
- `RhythmQTEManager.ItemRoutine` utilise maintenant `WaitUntil` pour patienter tant que la timeline est active, garantissant que le retour au menu principal se fait après la fin de la timeline


------
https://chatgpt.com/codex/tasks/task_e_6874e17a23f88325bb71788f71da6e13