### PR TITLE
Ajout d'animations de téléportation et de dégâts

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -81,6 +81,11 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Animations de déplacement")]
     public AnimationClip moveClip;
 
+    [Header("Animations spéciales")]
+    public AnimationClip hitAnimation;                // Jouée quand l'unité subit des dégâts
+    public AnimationClip TPAnimation_Start;           // Jouée avant la téléportation
+    public AnimationClip TPAnimation_Destination;     // Jouée après la téléportation
+
     [Header("Sons de déplacement")]
     public AudioClip moveStartClip;
     public AudioClip moveEndClip;

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -366,7 +366,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             animator.Play(clip.name);
     }
 
-    public void PlayHurtAnimation() => PlayAnimationClip(hurtAnimation);
+    public void PlayHurtAnimation()
+    {
+        // Priorité à l'animation définie dans les données du personnage
+        if (Data != null && Data.hitAnimation != null)
+        {
+            PlayAnimationClip(Data.hitAnimation);
+        }
+        else
+        {
+            PlayAnimationClip(hurtAnimation);
+        }
+    }
     public void PlayInterceptedAnimation() => PlayAnimationClip(interceptedAnimation);
     public void PlayInterceptionAnimation() => PlayAnimationClip(interceptionAnimation);
     public void PlayPrepareToUndergoAnimation()

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -213,7 +213,10 @@ public class RhythmQTEManager : MonoBehaviour
             Instantiate(caster.Data.TPEffect_Start, caster.transform.position, Quaternion.identity);
 
         Animator animator = caster.GetComponentInChildren<Animator>();
-        if (caster.Data.moveClip != null)
+        // Animation de début de téléportation
+        if (caster.Data.TPAnimation_Start != null)
+            animator?.Play(caster.Data.TPAnimation_Start.name);
+        else if (caster.Data.moveClip != null)
             animator?.Play(caster.Data.moveClip.name);
 
         // Laisse un court délai pour jouer l'effet avant de déplacer
@@ -224,6 +227,8 @@ public class RhythmQTEManager : MonoBehaviour
 
         if (caster.Data.TPEffect_Destination != null)
             Instantiate(caster.Data.TPEffect_Destination, destination, Quaternion.identity);
+        if (animator != null && caster.Data.TPAnimation_Destination != null)
+            animator.Play(caster.Data.TPAnimation_Destination.name);
 
         // Orientation vers la cible
         Vector3 dir = (target.transform.position - caster.transform.position).normalized;
@@ -248,7 +253,10 @@ public class RhythmQTEManager : MonoBehaviour
             Instantiate(caster.Data.TPEffect_Start, caster.transform.position, Quaternion.identity);
 
         Animator animator = caster.GetComponentInChildren<Animator>();
-        if (caster.Data.moveClip != null)
+        // Animation de début de téléportation retour
+        if (caster.Data.TPAnimation_Start != null)
+            animator?.Play(caster.Data.TPAnimation_Start.name);
+        else if (caster.Data.moveClip != null)
             animator?.Play(caster.Data.moveClip.name);
 
         // Laisse un court délai pour jouer l'effet avant de déplacer
@@ -258,6 +266,8 @@ public class RhythmQTEManager : MonoBehaviour
 
         if (caster.Data.TPEffect_Destination != null)
             Instantiate(caster.Data.TPEffect_Destination, origin, Quaternion.identity);
+        if (animator != null && caster.Data.TPAnimation_Destination != null)
+            animator.Play(caster.Data.TPAnimation_Destination.name);
 
         // Orientation optionnelle vers la cible
         if (target != null)
@@ -308,8 +318,12 @@ public class RhythmQTEManager : MonoBehaviour
             if (move.teleportStartVFXPrefab != null)
                 Instantiate(move.teleportStartVFXPrefab, caster.transform.position, Quaternion.identity);
 
-            if (caster.Data.moveClip != null)
-                caster.GetComponentInChildren<Animator>()?.Play(caster.Data.moveClip.name);
+            Animator animator = caster.GetComponentInChildren<Animator>();
+            // Animation de début de téléportation
+            if (caster.Data.TPAnimation_Start != null)
+                animator?.Play(caster.Data.TPAnimation_Start.name);
+            else if (caster.Data.moveClip != null)
+                animator?.Play(caster.Data.moveClip.name);
 
             // Délai pour séparer départ et arrivée
             yield return new WaitForSeconds(teleportDelay);
@@ -321,6 +335,8 @@ public class RhythmQTEManager : MonoBehaviour
 
             if (caster.Data.TPEffect_Destination != null)
                 Instantiate(caster.Data.TPEffect_Destination, teleportTargetPosition, Quaternion.identity);
+            if (animator != null && caster.Data.TPAnimation_Destination != null)
+                animator.Play(caster.Data.TPAnimation_Destination.name);
 
             Vector3 lookDir = Vector3.zero;
             if (target != null)
@@ -360,8 +376,12 @@ public class RhythmQTEManager : MonoBehaviour
         if (move.teleportStartVFXPrefab != null)
             Instantiate(move.teleportStartVFXPrefab, caster.transform.position, Quaternion.identity);
 
-        if (caster.Data.moveClip != null)
-            caster.GetComponentInChildren<Animator>()?.Play(caster.Data.moveClip.name);
+        Animator animator = caster.GetComponentInChildren<Animator>();
+        // Animation de début de retour
+        if (caster.Data.TPAnimation_Start != null)
+            animator?.Play(caster.Data.TPAnimation_Start.name);
+        else if (caster.Data.moveClip != null)
+            animator?.Play(caster.Data.moveClip.name);
 
         // Délai avant de revenir à la position initiale
         yield return new WaitForSeconds(teleportDelay);
@@ -373,6 +393,8 @@ public class RhythmQTEManager : MonoBehaviour
 
         if (caster.Data.TPEffect_Destination != null)
             Instantiate(caster.Data.TPEffect_Destination, initialPosition, Quaternion.identity);
+        if (animator != null && caster.Data.TPAnimation_Destination != null)
+            animator.Play(caster.Data.TPAnimation_Destination.name);
 
         yield return null;
 


### PR DESCRIPTION
## Résumé
- ajout de nouveaux AnimationClips dans `CharacterData`
- lecture de `hitAnimation` lors des dégâts dans `CharacterUnit`
- déclenchement d'animations de téléportation dans `RhythmQTEManager`

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68750953333883259700dfd94a7ba1ba