### PR TITLE
Amélioration du délai d'attaque ennemi

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -113,6 +113,8 @@ public class NewBattleManager : MonoBehaviour
     private bool interceptionSucceeded = false;
 
     private const float ATB_THRESHOLD = 100f;
+    // Délai appliqué avant qu'un ennemi n'exécute réellement son attaque
+    private const float ENEMY_MOVE_DELAY = 1f;
 
     [Header("Sprites des touches")]
     [SerializeField] private Sprite inputSprite1;
@@ -719,8 +721,8 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator EnemyTurnWithQTE(CharacterUnit enemy)
     {
         ChangeBattleState(BattleState.EnemyUnit_PerformingMusicalMove);
-        yield return new WaitForSeconds(1f);
 
+        // Choix de l'attaque et de la cible
         var move = enemy.GetRandomMusicalAttack();
         currentMove = move;
         var target = enemy.SelectTargetFromSquad();
@@ -742,6 +744,8 @@ public class NewBattleManager : MonoBehaviour
 
         ActionUIDisplayManager.Instance.DisplayActionMessage(enemy.Data.characterName, move.moveName, target.Data.characterName);
         MusicalCodexManager.Instance?.TryAddNewMelody(move);
+        // Laisse un délai pour que le joueur prenne connaissance de l'action
+        yield return new WaitForSeconds(ENEMY_MOVE_DELAY);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, enemy, target);
     }
 


### PR DESCRIPTION
## Résumé
- ajout d'une constante `ENEMY_MOVE_DELAY` pour centraliser le temps d'attente
- pendant le tour d'un ennemi, affichage de l'action puis pause d'une seconde avant d'exécuter le `MusicalMove`

## Test
- `grep -n "WaitForSeconds" -n -n Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6875143f81848325a5d4d48c1d736fee