### PR TITLE
Ajout du délai avant l'action des moves

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -71,6 +71,10 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("VFX joué au point d'arrivée de la téléportation")]
     public GameObject teleportEndVFXPrefab;
 
+    [Header("Timing")]
+    [Tooltip("Temps en secondes à attendre après la téléportation avant d'exécuter le move")]
+    public float startDelay = 0f;
+
 
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation du move")]

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -98,6 +98,10 @@ public class RhythmQTEManager : MonoBehaviour
         // Téléportation vers la position d'attaque
         yield return MoveTo(caster, target, move);
 
+        // Attente supplémentaire définie par le move avant d'enchaîner
+        if (move.startDelay > 0f)
+            yield return new WaitForSeconds(move.startDelay);
+
         if (move.performingTimeline == null && move.musicalMoveAnimationNames.Length > 0)
         {
             yield return PlayMoveAnimations(move.musicalMoveAnimationNames, caster);


### PR DESCRIPTION
## Résumé
- ajout d'un champ `startDelay` aux `MusicalMoveSO`
- attente de `startDelay` après la téléportation avant d'exécuter le move

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875181823388325a5eddc660bf12340