### PR TITLE
Gestion affichage attaques ennemies

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -52,10 +52,26 @@ public class ActionUIDisplayManager : MonoBehaviour
         displayGroup.alpha = 0;
     }
 
-    public void DisplayMelodyDiscovery(string melodyName)
+    /// <summary>
+    /// Affiche un message lorsque le joueur découvre une nouvelle attaque musicale.
+    /// </summary>
+    /// <param name="melodyName">Nom de l'attaque</param>
+    public void DisplayMoveDiscovery(string melodyName)
     {
-        string message = $"♪ Nouvelle mélodie découverte : {melodyName} ♪";
+        string message = $"Mouvement découvert : {melodyName}";
         StartCoroutine(DisplayRoutine(message));
+    }
+
+    /// <summary>
+    /// Affiche la préparation de l'attaque d'un ennemi.
+    /// Si moveName est null ou vide, indique qu'il s'agit d'un mouvement inconnu.
+    /// </summary>
+    public void DisplayEnemyPreparation(string enemyName, string moveName)
+    {
+        string message = string.IsNullOrEmpty(moveName)
+            ? $"{enemyName} s'apprête à jouer un mouvement inconnu"
+            : $"{enemyName} s'apprête à jouer {moveName}";
+        ShowMessage(message);
     }
 
     public void DisplayInstruction(string instruction)

--- a/Assets/Scripts/MonoBehavioursUsed/MusicalCodexManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MusicalCodexManager.cs
@@ -19,26 +19,22 @@ public class MusicalCodexManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Tente d'ajouter une attaque musicale au Codex.
-    /// Retourne true si elle vient d'être découverte.
-    /// </summary>
-    public bool TryAddNewMelody(MusicalMoveSO move)
-    {
-        if (!knownMoves.Contains(move))
+        /// Tente d'ajouter une attaque musicale au Codex.
+        /// Retourne true si elle vient d'Ãªtre dÃ©couverte.
+        /// </summary>
+        public bool TryAddNewMelody(MusicalMoveSO move)
         {
-            knownMoves.Add(move);
-
-            // Affichage de découverte
-            ActionUIDisplayManager.Instance.DisplayMelodyDiscovery(move.moveName);
-
-            Debug.Log($"Nouvelle mélodie découverte : {move.moveName}");
-            return true;
+            if (!knownMoves.Contains(move))
+            {
+                knownMoves.Add(move);
+                Debug.Log($"Nouvelle mÃ©lodie dÃ©couverte : {move.moveName}");
+                return true;
+            }
+            return false;
         }
-        return false;
-    }
 
     /// <summary>
-    /// Vérifie si cette attaque est déjà connue.
+    /// VÃ©rifie si cette attaque est dÃ©jÃ  connue.
     /// </summary>
     public bool IsMelodyKnown(MusicalMoveSO move)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -744,11 +744,19 @@ public class NewBattleManager : MonoBehaviour
                 yield break;
         }
 
-        ActionUIDisplayManager.Instance.DisplayActionMessage(enemy.Data.characterName, move.moveName, target.Data.characterName);
-        MusicalCodexManager.Instance?.TryAddNewMelody(move);
+        bool alreadyKnown = MusicalCodexManager.Instance != null && MusicalCodexManager.Instance.IsMelodyKnown(move);
+        // Affiche le move que l'ennemi prépare
+        ActionUIDisplayManager.Instance.DisplayEnemyPreparation(enemy.Data.characterName, alreadyKnown ? move.moveName : null);
+
         // Laisse un délai pour que le joueur prenne connaissance de l'action
         yield return new WaitForSeconds(ENEMY_MOVE_DELAY);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, enemy, target);
+
+        // Ajoute le move au codex et affiche sa découverte si nécessaire
+        if (!alreadyKnown && MusicalCodexManager.Instance != null && MusicalCodexManager.Instance.TryAddNewMelody(move))
+        {
+            ActionUIDisplayManager.Instance.DisplayMoveDiscovery(move.moveName);
+        }
     }
 
     public IEnumerator ExecuteMoveOnTarget(MusicalMoveSO move, CharacterUnit caster, CharacterUnit target)


### PR DESCRIPTION
## Résumé
- ajout de l'affichage de la préparation d'une attaque ennemie
- affichage d'un message de découverte lorsque l'attaque est inconnue
- mise à jour de la gestion du codex des mouvements

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687519b7ae788325a21f962104506330