### PR TITLE
Adaptation du système de caméras avec RenderTextures

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -39,6 +39,7 @@ public class BattleTransitionManager : MonoBehaviour
     [SerializeField] private AudioSource musicSource;
 
     private Camera battleCamera;
+    private MainCameraTextureManager mainCameraTextureManager; // gestionnaire des RT de la caméra principale
 
     #region Initialisation
     /// <summary>
@@ -60,6 +61,7 @@ public class BattleTransitionManager : MonoBehaviour
         worldFadeOverlay ??= GameObject.Find("WorldFadeOverlayPanel")?.GetComponent<Image>();
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
         battleCamera = GameObject.FindGameObjectWithTag(battleCameraTag)?.GetComponent<Camera>();
+        mainCameraTextureManager = FindFirstObjectByType<MainCameraTextureManager>();
     }
 
     #endregion
@@ -113,6 +115,8 @@ public class BattleTransitionManager : MonoBehaviour
         battleCamera = GameObject.FindGameObjectWithTag(battleCameraTag)?.GetComponent<Camera>();
         battleCamera.enabled = true;
         battleCamera.targetTexture = battleRenderTexture;
+        // Affiche la RenderTexture de combat sur la MainCamera
+        mainCameraTextureManager?.ShowBattleView();
 
         NewBattleManager.Instance.SpawnAll();
 
@@ -221,6 +225,8 @@ public class BattleTransitionManager : MonoBehaviour
         NewBattleManager.Instance.ResetBattleInfos();
 
         AudioManager.Instance.ReturnFromBattle();
+        // Retour à la vue du monde sur la MainCamera
+        mainCameraTextureManager?.ShowWorldView();
 
         InputsManager.Instance.ActivateOnly(InputsManager.Instance.playerInputs.World.Get());
 

--- a/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Gère l'affichage de la RenderTexture sur la MainCamera.
+/// Ce script doit être placé sur l'objet qui contient le RawImage devant la caméra.
+/// </summary>
+public class MainCameraTextureManager : MonoBehaviour
+{
+    [Header("RawImage affichant la vue")]
+    [SerializeField] private RawImage cameraDisplay;
+
+    [Header("RenderTextures")]
+    [SerializeField] private RenderTexture worldView;
+    [SerializeField] private RenderTexture battleView;
+
+    private void Awake()
+    {
+        // Si aucun RawImage n'est assigné, on tente de le récupérer automatiquement
+        if (cameraDisplay == null)
+            cameraDisplay = GetComponentInChildren<RawImage>();
+
+        // Par défaut on affiche la vue du monde
+        if (cameraDisplay != null && worldView != null)
+            cameraDisplay.texture = worldView;
+    }
+
+    /// <summary>
+    /// Applique la RenderTexture du monde sur le RawImage.
+    /// </summary>
+    public void ShowWorldView()
+    {
+        if (cameraDisplay != null && worldView != null)
+            cameraDisplay.texture = worldView;
+    }
+
+    /// <summary>
+    /// Applique la RenderTexture de combat sur le RawImage.
+    /// </summary>
+    public void ShowBattleView()
+    {
+        if (cameraDisplay != null && battleView != null)
+            cameraDisplay.texture = battleView;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c9e779859e82d0438498661e2b6c2d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- ajout du script **MainCameraTextureManager** pour gérer les RenderTextures affichées devant la MainCamera
- mise à jour de **BattleTransitionManager** pour utiliser ce nouveau gestionnaire : sélection automatique dans Awake, activation de la vue combat lors de la transition et restauration de la vue exploration en sortie

## Tests
- compilation via `mcs` impossible (pas d'environnement Unity complet).

------
https://chatgpt.com/codex/tasks/task_e_6878de1fdee883258ec6d80cb1add7bc