### PR TITLE
Ajout d'un outil d'aperçu des caméras

### DIFF
--- a/Assets/Scripts/Editor/CameraPreviewSwitcher.cs
+++ b/Assets/Scripts/Editor/CameraPreviewSwitcher.cs
@@ -1,0 +1,114 @@
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Outils d'aperçu rapide pour afficher les caméras dans la GameView.
+/// Permet de basculer entre la caméra du monde et celle de combat
+/// sans perdre les RenderTextures assignées.
+/// </summary>
+public static class CameraPreviewSwitcher
+{
+    // Sauvegardes temporaires des RenderTextures afin de pouvoir les restaurer.
+    private static RenderTexture worldSavedRT;
+    private static RenderTexture battleSavedRT;
+
+    /// <summary>
+    /// Affiche la caméra principale (MainCamera) directement dans la GameView.
+    /// </summary>
+    [MenuItem("Tools/Camera Preview/Aperçu World Camera")]
+    public static void PreviewWorldCamera()
+    {
+        Camera world = FindCameraWithTag("MainCamera");
+        Camera battle = FindCameraWithTag("BattleCamera");
+
+        if (world == null)
+        {
+            Debug.LogWarning("[CameraPreview] Caméra 'MainCamera' introuvable.");
+            return;
+        }
+
+        // Restaure la RT de la BattleCamera si elle avait été désassignée
+        if (battle != null && battle.targetTexture == null && battleSavedRT != null)
+        {
+            battle.targetTexture = battleSavedRT;
+        }
+
+        // Sauvegarde puis désactive la RT pour afficher directement dans la GameView
+        if (world.targetTexture != null)
+        {
+            worldSavedRT = world.targetTexture;
+            world.targetTexture = null;
+        }
+
+        Debug.Log("[CameraPreview] Aperçu World Camera activé.");
+    }
+
+    /// <summary>
+    /// Affiche la BattleCamera directement dans la GameView.
+    /// </summary>
+    [MenuItem("Tools/Camera Preview/Aperçu Battle Camera")]
+    public static void PreviewBattleCamera()
+    {
+        Camera world = FindCameraWithTag("MainCamera");
+        Camera battle = FindCameraWithTag("BattleCamera");
+
+        if (battle == null)
+        {
+            Debug.LogWarning("[CameraPreview] Caméra 'BattleCamera' introuvable.");
+            return;
+        }
+
+        // Restaure la RT de la WorldCamera si besoin
+        if (world != null && world.targetTexture == null && worldSavedRT != null)
+        {
+            world.targetTexture = worldSavedRT;
+        }
+
+        // Sauvegarde puis désactive la RT pour afficher la BattleCamera
+        if (battle.targetTexture != null)
+        {
+            battleSavedRT = battle.targetTexture;
+            battle.targetTexture = null;
+        }
+
+        Debug.Log("[CameraPreview] Aperçu Battle Camera activé.");
+    }
+
+    /// <summary>
+    /// Restaure les RenderTextures précédemment sauvegardées sur les caméras.
+    /// </summary>
+    [MenuItem("Tools/Camera Preview/Restaurer les RenderTextures")]
+    public static void RestoreRenderTextures()
+    {
+        Camera world = FindCameraWithTag("MainCamera");
+        Camera battle = FindCameraWithTag("BattleCamera");
+
+        if (world != null && worldSavedRT != null)
+        {
+            world.targetTexture = worldSavedRT;
+            worldSavedRT = null;
+        }
+
+        if (battle != null && battleSavedRT != null)
+        {
+            battle.targetTexture = battleSavedRT;
+            battleSavedRT = null;
+        }
+
+        Debug.Log("[CameraPreview] RenderTextures restaurées.");
+    }
+
+    /// <summary>
+    /// Cherche une caméra par son tag, même si elle est désactivée.
+    /// </summary>
+    private static Camera FindCameraWithTag(string tag)
+    {
+        Camera[] allCams = Resources.FindObjectsOfTypeAll<Camera>();
+        foreach (Camera cam in allCams)
+        {
+            if (cam.CompareTag(tag))
+                return cam;
+        }
+        return null;
+    }
+}

--- a/Assets/Scripts/Editor/CameraPreviewSwitcher.cs.meta
+++ b/Assets/Scripts/Editor/CameraPreviewSwitcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c212b840a9cb42769f0e93e75ac93141


### PR DESCRIPTION
## Résumé
- ajout d'un script `CameraPreviewSwitcher` dans `Assets/Scripts/Editor`
- ce script permet via le menu *Tools/Camera Preview* de basculer l'affichage entre la `MainCamera` et la `BattleCamera` dans la GameView
- possibilité de restaurer rapidement les RenderTextures sauvegardées

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6878e0ae27c08325834c76bc47d90e4c