### PR TITLE
Ajout d'un effet de transition verre brisé

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -35,6 +35,9 @@ public class BattleTransitionManager : MonoBehaviour
     [Header("Music")]
     [SerializeField] private AudioSource musicSource;
 
+    [Header("Effet de transition verre brisé")]
+    [SerializeField] private GlassShatterTransition glassTransition;
+
     private Camera battleCamera;
     private MainCameraTextureManager mainCameraTextureManager; // gestionnaire des RT de la caméra principale
 
@@ -98,6 +101,10 @@ public class BattleTransitionManager : MonoBehaviour
     /// </summary>
     private IEnumerator TransitionRoutine()
     {
+        // Effet de verre brisé sur la caméra principale avant toute action
+        if (glassTransition != null)
+            yield return StartCoroutine(glassTransition.Play());
+
         // Ralenti le temps pour la transition
         yield return SlowTimeScale(to: 0.1f, speed: 2f);
 

--- a/Assets/Scripts/MonoBehavioursUsed/GlassShatterTransition.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GlassShatterTransition.cs
@@ -1,0 +1,85 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Gère l'effet de verre brisé entre la WorldView et la BattleView.
+/// </summary>
+public class GlassShatterTransition : MonoBehaviour
+{
+    [Header("Références")]
+    [Tooltip("Gestionnaire de texture de la MainCamera")]
+    public MainCameraTextureManager cameraTextureManager;
+    [Tooltip("Animator contenant l'animation de bris de verre")]
+    public Animator shatterAnimator;
+    [Tooltip("Image affichant la texture de la WorldView à briser (optionnel)")]
+    public RawImage overlayImage;
+    [Tooltip("Renderer affichant la texture de la WorldView à briser (optionnel)")]
+    public Renderer overlayRenderer;
+    [Tooltip("Source audio pour le son de bris")]
+    public AudioSource audioSource;
+    [Tooltip("Clip audio du bris de verre")]
+    public AudioClip shatterClip;
+
+    [Header("Paramètres")]
+    [Tooltip("Durée de l'arrêt sur image avant l'animation de fissures")]
+    public float freezeDuration = 0.3f;
+    [Tooltip("Nom du trigger dans l'Animator pour lancer l'animation")]
+    public string animatorTrigger = "Shatter";
+
+    /// <summary>
+    /// Lance l'effet de transition et attend sa fin.
+    /// </summary>
+    public IEnumerator Play()
+    {
+        yield return StartCoroutine(ShatterRoutine());
+    }
+
+    private IEnumerator ShatterRoutine()
+    {
+        // On applique la texture de la WorldView sur l'overlay avant de geler l'image
+        ApplyWorldTexture();
+
+        // Arrêt sur image
+        float previousScale = Time.timeScale;
+        Time.timeScale = 0f;
+        yield return new WaitForSecondsRealtime(freezeDuration);
+
+        // Lancement de l'animation de fissures/bris
+        if (shatterAnimator != null)
+            shatterAnimator.SetTrigger(animatorTrigger);
+
+        if (audioSource != null && shatterClip != null)
+            audioSource.PlayOneShot(shatterClip);
+
+        // Attente de la fin de l'animation principale si possible
+        if (shatterAnimator != null)
+        {
+            AnimatorStateInfo state = shatterAnimator.GetCurrentAnimatorStateInfo(0);
+            yield return new WaitForSecondsRealtime(state.length);
+        }
+        else
+        {
+            yield return new WaitForSecondsRealtime(0.5f);
+        }
+
+        // On affiche la BattleView derrière les morceaux de verre
+        if (cameraTextureManager != null)
+            cameraTextureManager.ShowBattleView();
+
+        // Reprise du temps normal
+        Time.timeScale = previousScale;
+    }
+
+    private void ApplyWorldTexture()
+    {
+        if (cameraTextureManager == null)
+            return;
+
+        RenderTexture worldTex = cameraTextureManager.WorldTexture;
+        if (overlayImage != null)
+            overlayImage.texture = worldTex;
+        else if (overlayRenderer != null)
+            overlayRenderer.material.mainTexture = worldTex;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainCameraTextureManager.cs
@@ -14,6 +14,14 @@ public class MainCameraTextureManager : MonoBehaviour
     [SerializeField] private RenderTexture worldView;
     [SerializeField] private RenderTexture battleView;
 
+    /// <summary>
+    /// Accès en lecture aux RenderTextures utilisées.
+    /// Permet à d'autres scripts (ex: effets de transition) d'utiliser
+    /// la texture du monde ou du combat.
+    /// </summary>
+    public RenderTexture WorldTexture => worldView;
+    public RenderTexture BattleTexture => battleView;
+
     private void Awake()
     {
         // Si aucun RawImage n'est assigné, on tente de le récupérer automatiquement


### PR DESCRIPTION
## Summary
- créer `GlassShatterTransition` pour geler l'image et briser la vue avant de passer au mode combat
- exposer les RenderTextures de `MainCameraTextureManager`
- intégrer cet effet dans `BattleTransitionManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792c488aac8325a9648b3e62da3625