### PR TITLE
Ajout de l'état Awake et filtrage des attaques musicales

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -11,6 +11,8 @@ public class MusicalMoveSO : ScriptableObject
     public string moveName;
     public enum MoveType { Empty, Attack, Buff, Debuff}
     public MoveType moveType;
+    [Tooltip("Vrai si l'attaque n'est disponible qu'en état Awake")]
+    public bool onlyAwake = false;
     public Sprite moveIcon;
     [TextArea] public string description;
     public AnimationClip musicalMoveTargetingAnimation;

--- a/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+[RequireComponent(typeof(CharacterUnit))]
+public class AwakeState : UnitStateEffects
+{
+    [Tooltip("Multiplicateur appliqué aux caractéristiques en mode Awake")]
+    public float statMultiplier = 1.5f;
+
+    private CharacterUnit unit;
+    private bool isAwake;
+
+    public bool IsAwake => isAwake;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        unit = GetComponent<CharacterUnit>();
+    }
+
+    public void EnterAwake()
+    {
+        if (isAwake) return;
+        isAwake = true;
+        ApplyStatBonus();
+        EnterState();
+    }
+
+    public void ExitAwake()
+    {
+        if (!isAwake) return;
+        isAwake = false;
+        RemoveStatBonus();
+        ExitState();
+    }
+
+    private void ApplyStatBonus()
+    {
+        if (unit == null) return;
+        unit.currentStrength *= statMultiplier;
+        unit.currentDefense *= statMultiplier;
+        unit.currentReflex *= statMultiplier;
+        unit.currentMobility *= statMultiplier;
+        unit.currentPower *= statMultiplier;
+        unit.currentStability *= statMultiplier;
+        unit.currentVitality *= statMultiplier;
+        unit.currentSagacity *= statMultiplier;
+    }
+
+    private void RemoveStatBonus()
+    {
+        if (unit == null) return;
+        unit.currentStrength /= statMultiplier;
+        unit.currentDefense /= statMultiplier;
+        unit.currentReflex /= statMultiplier;
+        unit.currentMobility /= statMultiplier;
+        unit.currentPower /= statMultiplier;
+        unit.currentStability /= statMultiplier;
+        unit.currentVitality /= statMultiplier;
+        unit.currentSagacity /= statMultiplier;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -25,6 +25,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
     private Animator animator;
+    private AwakeState awakeState;
+
+    /// <summary>
+    /// Indique si l'unité est en état Awake (fusion avec l'ange gardien).
+    /// </summary>
+    public bool IsAwake => awakeState != null && awakeState.IsAwake;
 
     public CharacterType characterType => Data.characterType;
 
@@ -116,6 +122,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         spriteRenderer = GetComponent<SpriteRenderer>();
         audioSource = GetComponent<AudioSource>();
         animator = GetComponentInChildren<Animator>();
+        awakeState = GetComponent<AwakeState>();
 
         // Setup graphique
         if (spriteRenderer != null && Data.portrait != null)
@@ -464,11 +471,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
     public MusicalMoveSO GetRandomMusicalAttack()
     {
-        var availableAttacks = Data.musicalAttacks;
+        var availableAttacks = Data.musicalAttacks
+            .Where(m => !m.onlyAwake || IsAwake)
+            .ToArray();
 
         if (availableAttacks == null || availableAttacks.Length == 0)
         {
-            Debug.LogWarning($"[CharacterUnit] {Data.characterName} n'a aucune attaque musicale disponible !");
+            Debug.LogWarning($"[CharacterUnit] {Data.characterName} n'a aucune attaque musicale disponible pour l'état actuel !");
             return null;
         }
 
@@ -545,6 +554,22 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         if (move.cooldown > 0)
             moveCooldowns[move] = move.cooldown;
+    }
+
+    /// <summary>
+    /// Active l'état Awake et applique les bonus correspondants.
+    /// </summary>
+    public void EnterAwakeState()
+    {
+        awakeState?.EnterAwake();
+    }
+
+    /// <summary>
+    /// Désactive l'état Awake et retire les bonus.
+    /// </summary>
+    public void ExitAwakeState()
+    {
+        awakeState?.ExitAwake();
     }
 
     public float GetAttackMultiplier()

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1080,7 +1080,9 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
-        bool hasSkill = caster.Data.musicalAttacks.Any(m => caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost);
+        bool hasSkill = caster.Data.musicalAttacks.Any(m =>
+            (!m.onlyAwake || caster.IsAwake) &&
+            caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost);
         bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
 
         if (!hasSkill && !hasItem)
@@ -1589,7 +1591,9 @@ public class NewBattleManager : MonoBehaviour
         ToggleMenuContainers(false, true, false);
         currentMenuIndex = 0;
 
-        skillChoices = currentCharacterUnit.Data.musicalAttacks.ToList();
+        skillChoices = currentCharacterUnit.Data.musicalAttacks
+            .Where(m => !m.onlyAwake || currentCharacterUnit.IsAwake)
+            .ToList();
 
         // 7) Création des boutons de compétences
         for (int i = 0; i < skillChoices.Count && i < currentSkillsMenuSlots.Count; i++)


### PR DESCRIPTION
## Summary
- ajout du script `AwakeState` pour gérer la fusion avec l'ange gardien
- ajout du booléen `onlyAwake` dans `MusicalMoveSO`
- prise en compte de l'état `Awake` dans `CharacterUnit` et dans `NewBattleManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b94fa7ce4832597a799030cd75b48