### PR TITLE
Ajout du move HyoiGattai et entrée en Awake

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai.meta
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38d598bbf7734b3db2b991463aa1abc0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai/MusicalMove_HyoiGattai.asset
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai/MusicalMove_HyoiGattai.asset
@@ -1,0 +1,48 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_HyoiGattai
+  m_EditorClassIdentifier: 
+  moveName: HyoiGattai
+  moveType: 1
+  moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
+  description: "Fusionne avec le protecteur pour entrer en Awake."
+  musicalMoveTargetingAnimation: {fileID: 0}
+  musicalMoveRunAnimationName: 
+  maxRunDuration: 0
+  stayFaceToTarget: 0
+  musicalMoveIntroAnimationNames: []
+  musicalMoveAnimationNames: []
+  notes: []
+  power: 0
+  fatigueCost: 0
+  harmonicCost: 1
+  harmonicGeneration: 0
+  cooldown: 0
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  effectType: 8
+  effectValue: 0
+  moveSpeed: 0
+  castDistance: 0
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  introVFXPrefab: {fileID: 0}
+  hitVFXPrefab: {fileID: 0}
+  useTeleportation: 0
+  teleportStartVFXPrefab: {fileID: 0}
+  teleportEndVFXPrefab: {fileID: 0}
+  startDelay: 2
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai/MusicalMove_HyoiGattai.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai/MusicalMove_HyoiGattai.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c17ca5d5061743c3b9828cb538da826d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -134,6 +134,11 @@ public class MusicalMoveSO : ScriptableObject
             if (target.GetComponent<LinkMark>() == null)
                 target.gameObject.AddComponent<LinkMark>();
         }
+        else if (effectType == MusicalEffectType.EnterAwake)
+        {
+            // Le lanceur entre en mode Awake après l'exécution du move
+            caster?.EnterAwakeState();
+        }
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
@@ -142,6 +147,17 @@ public class MusicalMoveSO : ScriptableObject
     }
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
+public enum MusicalEffectType
+{
+    Damage,
+    Heal,
+    Buff,
+    Debuff,
+    Sleep,
+    WakeUpAll,
+    LoyaltyMark,
+    LinkMark,
+    EnterAwake // Nouveau type d'effet pour faire entrer le lanceur en mode Awake
+}
 
 public enum RelativePosition { Front, Back, Left, Right }


### PR DESCRIPTION
## Résumé
- ajout d'un nouvel effet `EnterAwake` pour les MusicalMoves
- création du ScriptableObject `MusicalMove_HyoiGattai`
- le move fait entrer le lanceur en état Awake via `EnterAwakeState`

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_687d1ce2eed48325b971b86120c54ecc