### PR TITLE
Implémentation du mode Awake via HyoiGattai

### DIFF
--- a/Assets/Characters/Kael/Character_Kael.asset
+++ b/Assets/Characters/Kael/Character_Kael.asset
@@ -63,3 +63,5 @@ MonoBehaviour:
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}
   owner: {fileID: 0}
+  resonancePoint: 1
+  dissonancePoint: 0

--- a/Assets/Characters/Link/Character_Link.asset
+++ b/Assets/Characters/Link/Character_Link.asset
@@ -76,3 +76,5 @@ MonoBehaviour:
   weepForLinkDeath: {fileID: 0}
   weepForLunaDeath: {fileID: 0}
   owner: {fileID: 0}
+  resonancePoint: 1
+  dissonancePoint: 0

--- a/Assets/Characters/Lucian/Character_Lucian.asset
+++ b/Assets/Characters/Lucian/Character_Lucian.asset
@@ -84,3 +84,5 @@ MonoBehaviour:
   weepForLinkDeath: {fileID: 0}
   weepForLunaDeath: {fileID: 0}
   owner: {fileID: 0}
+  resonancePoint: 1
+  dissonancePoint: 0

--- a/Assets/Characters/Luna/Character_Luna.asset
+++ b/Assets/Characters/Luna/Character_Luna.asset
@@ -62,3 +62,5 @@ MonoBehaviour:
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}
   owner: {fileID: 0}
+  resonancePoint: 1
+  dissonancePoint: 0

--- a/Assets/Characters/Thalia/Character_Thalia.asset
+++ b/Assets/Characters/Thalia/Character_Thalia.asset
@@ -74,3 +74,5 @@ MonoBehaviour:
   weepForLinkDeath: {fileID: 0}
   weepForLunaDeath: {fileID: 0}
   owner: {fileID: 0}
+  resonancePoint: 1
+  dissonancePoint: 0

--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
@@ -43,3 +43,4 @@ MonoBehaviour:
   startDelay: 2
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
+  enterAwake: 1

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -116,6 +116,10 @@ public class CharacterData : ScriptableObject, ITargetable
     [Tooltip("Lamentation jouée par ce personnage quand Luna meurt")]
     public AudioClip weepForLunaDeath;
 
+    [Header("Awake Mechanics")]
+    [Tooltip("Nombre d'harmoniques requis pour entrer en Awake")] public int resonancePoint = 1;
+    [Tooltip("Seuil minimal d'harmoniques avant de sortir d'Awake")] public int dissonancePoint = 0;
+
     // Ajoute une référence au GameObject source
     public MonoBehaviour owner;
 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -73,6 +73,9 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Temps en secondes à attendre après la téléportation avant d'exécuter le move")]
     public float startDelay = 2f;
 
+    [Header("Awake")]
+    [Tooltip("Si vrai, ce move fait entrer le lanceur en mode Awake")] public bool enterAwake = false;
+
 
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation du move")]

--- a/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
@@ -6,6 +6,10 @@ public class AwakeState : UnitStateEffects
     [Tooltip("Multiplicateur appliqué aux caractéristiques en mode Awake")]
     public float statMultiplier = 1.5f;
 
+    [Header("Aura")]
+    [Tooltip("Prefab de l'aura affichée en mode Awake")] public GameObject auraPrefab;
+    private GameObject auraInstance;
+
     private CharacterUnit unit;
     private bool isAwake;
 
@@ -22,6 +26,8 @@ public class AwakeState : UnitStateEffects
         if (isAwake) return;
         isAwake = true;
         ApplyStatBonus();
+        if (auraPrefab != null && auraInstance == null)
+            auraInstance = Instantiate(auraPrefab, transform.position, Quaternion.identity, transform);
         EnterState();
     }
 
@@ -30,6 +36,11 @@ public class AwakeState : UnitStateEffects
         if (!isAwake) return;
         isAwake = false;
         RemoveStatBonus();
+        if (auraInstance != null)
+        {
+            Destroy(auraInstance);
+            auraInstance = null;
+        }
         ExitState();
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -473,6 +473,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         var availableAttacks = Data.musicalAttacks
             .Where(m => !m.onlyAwake || IsAwake)
+            .Where(m => !m.enterAwake || !IsAwake)
+            .Where(m => !m.enterAwake || GetHarmonicCount(Data.harmonicType) >= Data.resonancePoint)
             .ToArray();
 
         if (availableAttacks == null || availableAttacks.Length == 0)
@@ -516,6 +518,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (!harmonicReserve.ContainsKey(type))
             harmonicReserve[type] = 0;
         harmonicReserve[type] += amount;
+        CheckDissonance();
     }
 
     public bool ConsumeHarmonic(HarmonicType type, int amount = 1)
@@ -523,6 +526,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (!harmonicReserve.ContainsKey(type) || harmonicReserve[type] < amount)
             return false;
         harmonicReserve[type] -= amount;
+        CheckDissonance();
         return true;
     }
 
@@ -536,6 +540,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         var keys = harmonicReserve.Keys.ToList();
         foreach (var key in keys)
             harmonicReserve[key] = 0;
+        CheckDissonance();
     }
 
     public void ReduceCooldowns()
@@ -554,6 +559,15 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         if (move.cooldown > 0)
             moveCooldowns[move] = move.cooldown;
+    }
+
+    /// <summary>
+    /// Vérifie si l'unité doit sortir de l'état Awake en fonction de ses harmoniques.
+    /// </summary>
+    private void CheckDissonance()
+    {
+        if (IsAwake && GetHarmonicCount(Data.harmonicType) < Data.dissonancePoint)
+            ExitAwakeState();
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -785,6 +785,13 @@ public class NewBattleManager : MonoBehaviour
             yield break;
         }
 
+        if (move.enterAwake && (caster.IsAwake ||
+            caster.GetHarmonicCount(caster.Data.harmonicType) < caster.Data.resonancePoint))
+        {
+            Debug.LogWarning("[ExecuteMoveOnTarget] Conditions d'Awake non remplies.");
+            yield break;
+        }
+
         OrientUnitTowardTarget(caster, target);
 
         if (move.interceptable && !caster.isInterceptionImmune)
@@ -1073,6 +1080,13 @@ public class NewBattleManager : MonoBehaviour
             caster.AddHarmonic(caster.Data.harmonicType, move.harmonicGeneration);
             caster.SetMoveCooldown(move);
 
+            // Activation du mode Awake si le move le permet
+            if (move.enterAwake && !caster.IsAwake &&
+                caster.GetHarmonicCount(caster.Data.harmonicType) >= caster.Data.resonancePoint)
+            {
+                caster.EnterAwakeState();
+            }
+
             // Si l'unité n'a plus d'harmonique, son tour se termine immédiatement
             if (caster.GetHarmonicCount(caster.Data.harmonicType) <= 0)
             {
@@ -1089,7 +1103,9 @@ public class NewBattleManager : MonoBehaviour
 
         bool hasSkill = caster.Data.musicalAttacks.Any(m =>
             (!m.onlyAwake || caster.IsAwake) &&
-            caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost);
+            (!m.enterAwake || !caster.IsAwake) &&
+            caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost &&
+            (!m.enterAwake || caster.GetHarmonicCount(caster.Data.harmonicType) >= caster.Data.resonancePoint));
         bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
 
         if (!hasSkill && !hasItem)
@@ -1600,6 +1616,7 @@ public class NewBattleManager : MonoBehaviour
 
         skillChoices = currentCharacterUnit.Data.musicalAttacks
             .Where(m => !m.onlyAwake || currentCharacterUnit.IsAwake)
+            .Where(m => !m.enterAwake || !currentCharacterUnit.IsAwake)
             .ToList();
 
         // 7) Création des boutons de compétences
@@ -1608,7 +1625,11 @@ public class NewBattleManager : MonoBehaviour
             var move = skillChoices[i];
             UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
 
-            bool available = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= move.harmonicCost;
+            bool enoughHarmonic = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= move.harmonicCost;
+            bool resonanceOk = true;
+            if (move.enterAwake)
+                resonanceOk = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.resonancePoint;
+            bool available = enoughHarmonic && resonanceOk;
             SetButtonAvailability(currentSkillsMenuSlots[i], available);
         }
         // Indique les emplacements vides


### PR DESCRIPTION
## Résumé
- ajout d'un champ `enterAwake` aux `MusicalMoveSO`
- ajout des variables `resonancePoint` et `dissonancePoint` dans `CharacterData`
- gestion d'une aura pour l'état Awake dans `AwakeState`
- contrôle du seuil de dissonance dans `CharacterUnit`
- activation du mode Awake avec HyoiGattai dans `NewBattleManager`
- ajustement de l'affichage des compétences et des IA
- mise à jour des assets concernés

## Tests
- Aucun test automatique disponible
- Compilation non réalisée (dépendances Unity)

------
https://chatgpt.com/codex/tasks/task_e_687d20d9953883258abc4004358573db