### PR TITLE
Activation des FireWings en mode Awake

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
@@ -10,6 +10,10 @@ public class AwakeState : UnitStateEffects
     [Tooltip("Prefab de l'aura affichée en mode Awake")] public GameObject auraPrefab;
     private GameObject auraInstance;
 
+    [Header("FireWing")]
+    [Tooltip("Référence à l'objet 'FireWing' à activer en mode Awake")]
+    [SerializeField] private GameObject fireWing; // Peut rester vide : recherché automatiquement
+
     private CharacterUnit unit;
     private bool isAwake;
 
@@ -19,6 +23,17 @@ public class AwakeState : UnitStateEffects
     {
         base.Awake();
         unit = GetComponent<CharacterUnit>();
+        // Si aucune référence n'est fournie, on recherche l'enfant nommé "FireWing"
+        if (fireWing == null)
+        {
+            Transform child = transform.Find("FireWing");
+            if (child != null)
+                fireWing = child.gameObject;
+        }
+
+        // Au départ l'objet FireWing doit être désactivé
+        if (fireWing != null)
+            fireWing.SetActive(false);
     }
 
     public void EnterAwake()
@@ -26,6 +41,9 @@ public class AwakeState : UnitStateEffects
         if (isAwake) return;
         isAwake = true;
         ApplyStatBonus();
+        // Activation des ailes de feu lorsque le personnage entre en mode Awake
+        if (fireWing != null)
+            fireWing.SetActive(true);
         if (auraPrefab != null && auraInstance == null)
             auraInstance = Instantiate(auraPrefab, transform.position, Quaternion.identity, transform);
         EnterState();
@@ -36,6 +54,9 @@ public class AwakeState : UnitStateEffects
         if (!isAwake) return;
         isAwake = false;
         RemoveStatBonus();
+        // Désactivation des ailes de feu quand on quitte le mode Awake
+        if (fireWing != null)
+            fireWing.SetActive(false);
         if (auraInstance != null)
         {
             Destroy(auraInstance);


### PR DESCRIPTION
## Résumé
- ajout d'une référence à l'objet FireWing dans `AwakeState`
- recherche automatique de FireWing et désactivation par défaut
- activation/désactivation automatique lors de l'entrée/sortie du mode Awake

## Tests
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687e2197c4a88325ba30bc07a1dca7e2