### PR TITLE
Correction téléportation MusicalMove

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -84,7 +84,16 @@ public class RhythmQTEManager : MonoBehaviour
             target.PlayPrepareToUndergoAnimation();
         }
 
+        // Récupère le GameObject contenant l'Animator du lanceur
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
+
+        // --- Téléportation vers la position relative à la cible ---
+        // Cette étape était manquante, d'où l'absence de déplacement constatée.
+        if (caster != null && target != null)
+        {
+            // On attend la fin de la téléportation avant de poursuivre la séquence
+            yield return MoveTo(caster, target, move);
+        }
 
         // Si une Timeline est disponible, on la lit en adaptant la caméra selon le type de personnage
         bool hasTimeline = move.performingTimeline != null && TimelineLauncher.Instance != null && casterAnimatorGO != null;


### PR DESCRIPTION
## Résumé
- appel du déplacement vers la position relative de la cible avant l'exécution de la timeline
- ajout de commentaires explicatifs

## Tests
- compilation Unity non réalisée (pas de tests automatisés présents)


------
https://chatgpt.com/codex/tasks/task_e_687e751d4f1483258a87bbaff81ff05a