### PR TITLE
Évite boucle infinie de redirection des dégâts

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -188,10 +188,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     /// <param name="amount">Quantité de dégâts subis.</param>
     /// <param name="attacker">Transform de l'attaquant pour déterminer la direction.</param>
-    public void TakeDamage(float amount, Transform attacker = null)
+    public void TakeDamage(float amount, Transform attacker = null, bool allowRedirect = true)
     {
+        // Vérifie la présence d'un marqueur de loyauté pouvant rediriger les dégâts.
+        // Le paramètre allowRedirect permet d'éviter une boucle infinie lorsque
+        // deux unités se protègent mutuellement.
         var mark = GetComponent<LoyaltyMark>();
-        if (mark != null && mark.RedirectDamage(amount))
+        if (allowRedirect && mark != null && mark.RedirectDamage(amount))
             return;
 
         currentHP = Mathf.Max(currentHP - amount, 0);

--- a/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
@@ -13,7 +13,11 @@ public class LoyaltyMark : MonoBehaviour
     {
         if (protector == null || protector.currentHP <= 0)
             return false;
-        protector.TakeDamage(amount * 0.5f);
+
+        // On inflige la moitié des dégâts au protecteur sans déclencher une
+        // nouvelle redirection afin d'éviter les boucles infinies en cas de
+        // protection mutuelle.
+        protector.TakeDamage(amount * 0.5f, null, false);
         return true;
     }
 }


### PR DESCRIPTION
## Résumé
- ajoute un paramètre `allowRedirect` à `CharacterUnit.TakeDamage` pour empêcher la redirection en chaîne
- utilise ce paramètre dans `LoyaltyMark` afin d'éviter les boucles

## Test
- _Aucun test automatisé fourni dans le dépôt_

------
https://chatgpt.com/codex/tasks/task_e_687e868127ec83258a9a9432deb99059