### PR TITLE
Fix infinite recursion when redirecting damage

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -180,6 +180,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// <param name="amount">Quantité de dégâts subis.</param>
     public void TakeDamage(float amount)
     {
+        // Redirige vers la version complète en autorisant par défaut
+        // les éventuelles redirections de dégâts (LoyaltyMark, etc.).
         TakeDamage(amount, null);
     }
 
@@ -188,11 +190,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     /// <param name="amount">Quantité de dégâts subis.</param>
     /// <param name="attacker">Transform de l'attaquant pour déterminer la direction.</param>
-    public void TakeDamage(float amount, Transform attacker = null)
+    public void TakeDamage(float amount, Transform attacker = null, bool allowRedirect = true)
     {
-        var mark = GetComponent<LoyaltyMark>();
-        if (mark != null && mark.RedirectDamage(amount))
-            return;
+        // Si autorisé, on vérifie la présence d'une marque de loyauté qui
+        // pourrait rediriger les dégâts vers un protecteur.
+        if (allowRedirect)
+        {
+            var mark = GetComponent<LoyaltyMark>();
+            if (mark != null && mark.RedirectDamage(amount))
+                return;
+        }
 
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);

--- a/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
@@ -11,9 +11,13 @@ public class LoyaltyMark : MonoBehaviour
 
     public bool RedirectDamage(float amount)
     {
+        // Aucun protecteur valide ou protecteur déjà hors combat : on ne redirige pas
         if (protector == null || protector.currentHP <= 0)
             return false;
-        protector.TakeDamage(amount * 0.5f);
+
+        // On inflige la moitié des dégâts au protecteur sans déclencher à nouveau
+        // la redirection pour éviter une récursion infinie.
+        protector.TakeDamage(amount * 0.5f, transform, false);
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- prevent infinite recursion between LoyaltyMark and CharacterUnit
- skip redirection when damage is already redirected

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687e883e40ac83259bef720d67d86827