### PR TITLE
Fix glass explode delay

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -105,8 +105,10 @@ public class BattleTransitionManager : MonoBehaviour
             PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>();
             if (introDirector != null)
             {
+                // On joue la Timeline d'introduction et on attend qu'elle se termine
+                // au lieu d'attendre un temps fixe qui pouvait provoquer un délai inutile
                 TimelineManager.Instance.PlayTimeline(introDirector);
-                yield return new WaitForSecondsRealtime(1.8f);
+                yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
             }
             else
             {


### PR DESCRIPTION
## Summary
- attendre la fin réelle de la timeline d'introduction avant de lancer Glass_Explode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ff0172efc8325abcf0f69aada5618