### PR TITLE
Gestion du ralenti de fin de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -151,9 +151,8 @@ public class BattleTransitionManager : MonoBehaviour
 
     public IEnumerator ExitVictoryScreenAndBattle()
     {
-        Time.timeScale = 1f;
-        // Restauration du fixedDeltaTime après la pause du VictoryScreen
-        Time.fixedDeltaTime = 0.02f;
+        // Restauration progressive du temps vers la normale
+        yield return StartCoroutine(RestoreTimeScale(Time.timeScale, 1f, 2f));
 
         CombatSkyboxManager.Instance?.RestoreDefaultSkybox();
 
@@ -233,19 +232,19 @@ public class BattleTransitionManager : MonoBehaviour
             float newScale = Time.timeScale - Time.unscaledDeltaTime * speed;
             if (newScale <= to + epsilon)
                 newScale = to;
-            // Empêche toute valeur négative due au calcul
-            Time.timeScale = Mathf.Max(0f, newScale);
 
-            yield return new WaitForEndOfFrame();
+            Time.timeScale = Mathf.Max(0f, newScale);
+            Time.fixedDeltaTime = Time.timeScale * 0.02f;
+
+            yield return null;
         }
 
-        // Assure qu'à la fin, on a la bonne valeur pile
         Time.timeScale = to;
+        Time.fixedDeltaTime = Time.timeScale * 0.02f;
     }
 
     private IEnumerator RestoreTimeScale(float from, float to, float speed)
     {
-        Debug.Log("Début de la restauration du temps");
         float epsilon = 0.001f;
 
         while (to - Time.timeScale > epsilon)
@@ -254,11 +253,12 @@ public class BattleTransitionManager : MonoBehaviour
             if (Time.timeScale > to)
                 Time.timeScale = to;
 
-            yield return new WaitForEndOfFrame();
+            Time.fixedDeltaTime = Time.timeScale * 0.02f;
+            yield return null;
         }
 
         Time.timeScale = to;
-        Debug.Log("Temps restauré");
+        Time.fixedDeltaTime = 0.02f;
     }
 
     private IEnumerator PlayTransitionSoundsSequentially()

--- a/Assets/Scripts/MonoBehavioursUsed/GameOverPanelManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GameOverPanelManager.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+/// <summary>
+/// Gère l'affichage du panneau Game Over.
+/// S'assure que son Animator utilise le temps non ralenti.
+/// </summary>
+public class GameOverPanelManager : MonoBehaviour
+{
+    void Awake()
+    {
+        // On force l'Animator à fonctionner en temps réel
+        Animator anim = GetComponent<Animator>();
+        if (anim != null)
+            anim.updateMode = AnimatorUpdateMode.UnscaledTime;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/GameOverPanelManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/GameOverPanelManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b799015af4b14a6c83e1f82f4e892907
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -154,10 +154,12 @@ public class InputsManager : MonoBehaviour
             bm.ToggleMenuContainers(false, false, false);
         }
 
-        if (bm.currentBattleState == BattleState.VictoryScreen_CanContinue)
+        if (bm.currentBattleState == BattleState.VictoryScreen_CanContinue ||
+            bm.currentBattleState == BattleState.GameOverScreen_CanContinue)
         {
             bm.ChangeBattleState(BattleState.None);
-            BattleTransitionManager.Instance.StartCoroutine(BattleTransitionManager.Instance.ExitVictoryScreenAndBattle());
+            BattleTransitionManager.Instance.StartCoroutine(
+                BattleTransitionManager.Instance.ExitVictoryScreenAndBattle());
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1454,35 +1454,24 @@ public class NewBattleManager : MonoBehaviour
 
     private IEnumerator ReduceTimeAndShowVictoryPanel()
     {
-        float transitionDuration = 0.3f;
-        float t = 0f;
+        // Ralentissement progressif vers un arrêt complet en 2 secondes
+        if (BattleTransitionManager.Instance != null)
+            yield return BattleTransitionManager.Instance.StartCoroutine(
+                BattleTransitionManager.Instance.SlowTimeScale(0f, 0.5f));
+        else
+            Time.timeScale = 0f;
 
-        while (t < transitionDuration)
-        {
-            // On utilise unscaledDeltaTime pour rendre la transition indépendante
-            // du Time.timeScale courant
-            t += Time.unscaledDeltaTime;
-            Time.timeScale = Mathf.Lerp(1f, 0.05f, t / transitionDuration);
-            Time.fixedDeltaTime = Time.timeScale * 0.02f;
-            yield return null;
-        }
-
-        // On s'assure d'atteindre exactement 0.05 de timeScale pour la capture
-        Time.timeScale = 0.05f;
-        Time.fixedDeltaTime = 0.001f;
-
-        TakeVictoryScreenshot(); // 👈 Capture ici immédiatement
-
-        // Optionnel : attendre encore un peu avant d’afficher le panneau
-        // On utilise un temps réel pour ne pas être affecté par le ralentissement
-        yield return new WaitForSecondsRealtime(0.1f);
-
-        //Prendre une photo de la dernière frame de la mort de l'ennemi avant VictoryScreen
-
-        victoryScreen.transform.GetChild(0).gameObject.SetActive(true);
-        // On met le temps en pause une fois le panneau affiché pour figer la scène
-        Time.timeScale = 0f;
         Time.fixedDeltaTime = 0f;
+
+        // Capture de la dernière image avant d'afficher l'écran de victoire
+        TakeVictoryScreenshot();
+
+        // Activation du panneau VictoryScreen (animation en temps réel)
+        Transform victoryPanel = victoryScreen.transform.GetChild(0);
+        Animator victoryAnim = victoryPanel.GetComponent<Animator>();
+        if (victoryAnim != null)
+            victoryAnim.updateMode = AnimatorUpdateMode.UnscaledTime;
+        victoryPanel.gameObject.SetActive(true);
 
         GameManager.Instance?.AddXPToSquad(rewardXP);
         GameManager.Instance?.AddItemsToInventory(rewardItems);
@@ -1513,9 +1502,25 @@ public class NewBattleManager : MonoBehaviour
 
     IEnumerator ShowGameOverPanel()
     {
-        // Petite attente en temps réel pour laisser la transition se terminer
-        yield return new WaitForSecondsRealtime(0.5f); // Attente pour la transition
-        gameOverScreen.transform.GetChild(0).gameObject.SetActive(true);
+        // Ralentit le temps jusqu'à l'arrêt complet avant d'afficher le panneau
+        if (BattleTransitionManager.Instance != null)
+            yield return BattleTransitionManager.Instance.StartCoroutine(
+                BattleTransitionManager.Instance.SlowTimeScale(0f, 0.5f));
+        else
+            Time.timeScale = 0f;
+
+        Time.fixedDeltaTime = 0f;
+
+        // Activation du panneau GameOver (animation en temps réel)
+        Transform panel = gameOverScreen.transform.GetChild(0);
+        Animator anim = panel.GetComponent<Animator>();
+        if (anim != null)
+            anim.updateMode = AnimatorUpdateMode.UnscaledTime;
+        panel.gameObject.SetActive(true);
+
+        CleanupAllSpawnedUnits();
+
+        ChangeBattleState(BattleState.GameOverScreen_CanContinue);
     }
 
     private void CleanupAllSpawnedUnits()

--- a/Assets/Scripts/MonoBehavioursUsed/VictoryPanelManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/VictoryPanelManager.cs
@@ -17,6 +17,10 @@ public class VictoryPanelManager : MonoBehaviour
 
     void Awake()
     {
+        // L'animation du panneau doit être indépendante du timeScale
+        Animator anim = GetComponent<Animator>();
+        if (anim != null)
+            anim.updateMode = AnimatorUpdateMode.UnscaledTime;
         if (xpText == null)
         {
             xpText = GetComponentsInChildren<TextMeshProUGUI>(true)


### PR DESCRIPTION
## Résumé
- ralentissement du temps de combat via `SlowTimeScale`
- restauration progressive lors du retour au monde
- animations des écrans de victoire et de défaite en temps réel
- ajout d'un gestionnaire pour le panneau Game Over

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882656478a083258cf4078ccd6a7f63