### PR TITLE
Fix camera null reference

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2074,6 +2074,14 @@ public class NewBattleManager : MonoBehaviour
             }
         }
 
+        // Vérifie que l'unité courante est bien définie. Sans elle,
+        // certaines positions de caméra ne peuvent pas être calculées.
+        if (currentCharacterUnit == null)
+        {
+            Debug.LogWarning("[BattleCameraManager] currentCharacterUnit est nul lors de la mise à jour de la caméra.");
+            return;
+        }
+
         // Par défaut, on ne regarde pas le lanceur
         lookAtCasterDuringTargetSelection = false;
         // Désactive le focus spécial utilisé pendant le tour ennemi


### PR DESCRIPTION
## Summary
- avertir lors de l'absence de `currentCharacterUnit` pour éviter un crash dans `UpdateCameraBehaviour`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688272e754d48325bfa3a8e2d21cc4d6