### PR TITLE
Fix CustomBar coroutine start error when inactive

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CustomBar.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CustomBar.cs
@@ -54,6 +54,11 @@ public class CustomBar : MonoBehaviour
 
     private void StartShake()
     {
+        // Si l'objet est désactivé dans la hiérarchie, on évite de lancer la coroutine
+        // afin d'empêcher l'erreur "Coroutine couldn't be started".
+        if (!isActiveAndEnabled)
+            return;
+
         if (isShaking)
             return;
 


### PR DESCRIPTION
## Summary
- avoid launching CustomBar shake when object is inactive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a21df3ec8325a601131dba018258