### PR TITLE
Corrige l'affichage anticipé des UI de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -94,6 +94,15 @@ public class BattleTransitionManager : MonoBehaviour
         battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
     }
 
+    /// <summary>
+    /// S'assure que l'interface de combat est masquée au chargement de la scène.
+    /// </summary>
+    private void Start()
+    {
+        // On cache toutes les UI liées au combat tant que le joueur n'a pas débuté son premier tour.
+        HideBattleUI();
+    }
+
     #endregion
 
     #region Transition


### PR DESCRIPTION
## Résumé
- masque les éléments d'interface dès la création de `BattleTransitionManager`

## Détails
- ajout d'une méthode `Start()` qui appelle `HideBattleUI()`

## Tests
- aucune suite de tests automatique fournie

------
https://chatgpt.com/codex/tasks/task_e_6883a2405ef883258b186237d4ac3bd3