### PR TITLE
Attente de fin de timeline avant affichage de l'UI

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -170,9 +170,10 @@ public class BattleTransitionManager : MonoBehaviour
             PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>();
             if (introDirector != null)
             {
-                // On joue la Timeline d'introduction et on attend qu'elle se termine
+                // On joue la Timeline d'introduction
                 TimelineManager.Instance.PlayTimeline(introDirector);
-                //yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
+                // On attend la fin de la timeline pour éviter l'affichage de l'UI pendant la cinématique
+                yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
             }
             else
             {


### PR DESCRIPTION
## Résumé
- évite l'affichage prématuré de l'UI lors de la timeline d'introduction
- la coroutine `TransitionRoutine` patiente désormais jusqu'à la fin de la timeline de caméra avant de poursuivre

## Test
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6883a99c7bf88325b544fd823195a6ad