### PR TITLE
Attente de timeline aussi pour le QTECircle

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -44,6 +44,10 @@ public class BattleTransitionManager : MonoBehaviour
     /// </summary>
     public void HideBattleUI()
     {
+        // Désactive le cercle de QTE s'il est présent pour éviter son apparition précoce
+        if (qteCircle != null)
+            qteCircle.SetActive(false);
+
         if (battleTimeline != null)
             battleTimeline.SetActive(false);
         if (passTurnButton != null)
@@ -61,6 +65,9 @@ public class BattleTransitionManager : MonoBehaviour
     {
         if (battleUIShown)
             return;
+
+        if (qteCircle != null)
+            qteCircle.SetActive(true);
 
         if (battleTimeline != null)
             battleTimeline.SetActive(true);
@@ -170,9 +177,10 @@ public class BattleTransitionManager : MonoBehaviour
             PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>();
             if (introDirector != null)
             {
-                // On joue la Timeline d'introduction et on attend qu'elle se termine
+                // On joue la Timeline d'introduction
                 TimelineManager.Instance.PlayTimeline(introDirector);
-                //yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
+                // On attend la fin de la timeline pour éviter l'affichage de l'UI pendant la cinématique
+                yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
             }
             else
             {


### PR DESCRIPTION
## Résumé
- cache également le QTECircle tant que la timeline d'introduction n'est pas terminée
- réactive le QTECircle en même temps que les autres éléments d'interface

## Test
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883a99c7bf88325b544fd823195a6ad