### PR TITLE
Ajout d'un déclencheur de Timeline conditionnel

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEngine.Playables;
+using System.Collections.Generic;
+
+/// <summary>
+/// Surveille les PV d'une unité et déclenche une Timeline lorsque certains seuils sont atteints.
+/// Permet par exemple de lancer des cinématiques au cours du combat.
+/// </summary>
+public class HPThresholdTimelineTrigger : MonoBehaviour
+{
+    [System.Serializable]
+    public class ThresholdData
+    {
+        [Tooltip("Seuil de PV en pourcentage (0-1). La timeline se déclenche lorsque les PV sont inférieurs ou égaux à ce ratio.")]
+        public float hpRatio = 0.5f;
+        [Tooltip("Timeline à jouer lorsque le seuil est atteint.")]
+        public PlayableDirector timeline;
+        [HideInInspector] public bool triggered = false;
+    }
+
+    [Header("Unité à surveiller")] public CharacterUnit targetUnit;
+    [Header("Liste des déclencheurs")]
+    public List<ThresholdData> thresholds = new();
+
+    private void Awake()
+    {
+        if (targetUnit == null)
+            targetUnit = GetComponent<CharacterUnit>();
+    }
+
+    private void Update()
+    {
+        if (targetUnit == null || thresholds.Count == 0)
+            return;
+
+        foreach (var t in thresholds)
+        {
+            if (!t.triggered && targetUnit.currentHP <= targetUnit.Data.baseHP * t.hpRatio)
+            {
+                t.triggered = true;
+                // On enfile la timeline dans le gestionnaire de combat pour qu'elle se joue au prochain tour
+                if (NewBattleManager.Instance != null)
+                    NewBattleManager.Instance.QueueConditionalTimeline(t.timeline);
+                break;
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 930261e9-18f6-4792-93eb-1f270dab1173

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -111,6 +111,8 @@ public class NewBattleManager : MonoBehaviour
     [HideInInspector] public CharacterUnit currentCharacterUnit;
     private bool isTurnResolving = false;
     private bool interceptionSucceeded = false;
+    // File d'attente de timelines à jouer entre deux tours
+    private readonly Queue<PlayableDirector> pendingTimelines = new();
 
     private const float ATB_THRESHOLD = 100f;
     // Délai appliqué avant qu'un ennemi n'exécute réellement son attaque
@@ -510,10 +512,43 @@ public class NewBattleManager : MonoBehaviour
                 yield break;
             }
 
+            // Avant de démarrer le prochain tour, on joue toutes les timelines en attente
+            if (pendingTimelines.Count > 0)
+                yield return PlayPendingTimelines();
+
             yield return ExecuteTurn(CalculateNextUnit());
             // Utilisation du temps non affecté par le timeScale pour ne pas bloquer
             // la boucle si le jeu est mis en pause (fin de combat par exemple)
             yield return new WaitForSecondsRealtime(0.2f);
+        }
+    }
+
+    /// <summary>
+    /// Ajoute une timeline à jouer avant le prochain tour.
+    /// </summary>
+    public void QueueConditionalTimeline(PlayableDirector director)
+    {
+        if (director != null)
+            pendingTimelines.Enqueue(director);
+    }
+
+    /// <summary>
+    /// Joue séquentiellement toutes les timelines en attente.
+    /// </summary>
+    private IEnumerator PlayPendingTimelines()
+    {
+        while (pendingTimelines.Count > 0)
+        {
+            var director = pendingTimelines.Dequeue();
+            BattleTransitionManager.Instance?.HideBattleUI();
+
+            TimelineManager.Instance.PlayTimeline(director);
+            while (TimelineManager.Instance.IsTimelinePlaying)
+                yield return null;
+
+            BattleTransitionManager.Instance?.ShowBattleUIIfNeeded();
+            // Petite pause pour éviter les enchaînements brusques
+            yield return new WaitForSecondsRealtime(0.1f);
         }
     }
     #endregion


### PR DESCRIPTION
## Résumé
- nouvelle classe `HPThresholdTimelineTrigger` pour lancer des cinématiques en fonction des PV
- ajout d'une file d'attente de Timelines dans `NewBattleManager` pour les jouer entre deux tours
- exécution des Timelines en attente avant chaque nouveau tour

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6884aa770ce083259bf9da4b0eb0a106