### PR TITLE
Ajout d'un système de QTE déclenchable via Timeline

### DIFF
--- a/Assets/Scripts/Classes/QTETriggerSO.cs
+++ b/Assets/Scripts/Classes/QTETriggerSO.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// Objet scriptable représentant un déclencheur de QTE depuis une Timeline.
+/// Contient l'icône à afficher et la durée de la fenêtre de saisie.
+/// </summary>
+[CreateAssetMenu(menuName = "Symphonie/QTE Trigger")]
+public class QTETriggerSO : ScriptableObject
+{
+    [Tooltip("Icône de l'input à afficher")] public Sprite inputIcon;
+    [Tooltip("Fenêtre de saisie en millisecondes")] public float windowDelay = 200f;
+}

--- a/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+/// <summary>
+/// Récepteur appelé depuis une Timeline pour lancer un QTE.
+/// </summary>
+public class QTESignalReceiver : MonoBehaviour
+{
+    /// <summary>
+    /// Déclenche un QTE via le RhythmQTEManager en utilisant les données du QTETrigger.
+    /// </summary>
+    /// <param name="trigger">Données du QTE à jouer</param>
+    public void TriggerQTE(QTETriggerSO trigger)
+    {
+        if (trigger == null)
+        {
+            Debug.LogWarning("[QTESignalReceiver] TriggerQTE appelé avec null.");
+            return;
+        }
+        RhythmQTEManager.Instance?.TriggerQTE(trigger.windowDelay, trigger.inputIcon);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -497,7 +497,8 @@ public class RhythmQTEManager : MonoBehaviour
         if (note.clip != null)
             audioSource.PlayOneShot(note.clip);
 
-        StartCoroutine(WaitForQTE(note.rhythm, success =>
+        // Pas d'icône spécifique pour les notes, on passe null
+        StartCoroutine(WaitForQTE(note.rhythm, null, success =>
         {
             currentMove.ApplyEffect(currentCaster, currentTarget, success);
             pendingNotes = Mathf.Max(0, pendingNotes - 1);
@@ -507,10 +508,21 @@ public class RhythmQTEManager : MonoBehaviour
 
     public void TriggerQTE(float windowDelay)
     {
-        StartCoroutine(WaitForQTE(windowDelay, _ => { }));
+        // Appel historique sans icône
+        StartCoroutine(WaitForQTE(windowDelay, null, _ => { }));
     }
 
-    private IEnumerator WaitForQTE(float windowDelay, System.Action<bool> callback)
+    /// <summary>
+    /// Lance un QTE en précisant l'icône à afficher au centre du cercle.
+    /// </summary>
+    /// <param name="windowDelay">Durée de la fenêtre en millisecondes</param>
+    /// <param name="icon">Icône de l'input à afficher</param>
+    public void TriggerQTE(float windowDelay, Sprite icon)
+    {
+        StartCoroutine(WaitForQTE(windowDelay, icon, _ => { }));
+    }
+
+    private IEnumerator WaitForQTE(float windowDelay, Sprite icon, System.Action<bool> callback)
     {
         qteActive = true;
         float slowestTimeScale = 0f;
@@ -537,6 +549,19 @@ public class RhythmQTEManager : MonoBehaviour
         RectTransform dynamicCircle = qteVisual.transform.Find("Circle_Dynamic")?.GetComponent<RectTransform>();
         if (dynamicCircle != null)
             dynamicCircle.localScale = Vector3.one * qteStartScale;
+
+        // Ajoute dynamiquement l'icône si fournie
+        if (icon != null)
+        {
+            var iconGO = new GameObject("InputIcon", typeof(RectTransform), typeof(CanvasRenderer), typeof(UnityEngine.UI.Image));
+            iconGO.transform.SetParent(qteVisual.transform, false);
+            var rect = iconGO.GetComponent<RectTransform>();
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = Vector2.zero;
+            rect.sizeDelta = new Vector2(64f, 64f);
+            var img = iconGO.GetComponent<UnityEngine.UI.Image>();
+            img.sprite = icon;
+        }
 
         float elapsed = 0f;
         bool success = false;


### PR DESCRIPTION
## Résumé
- création d'un objet `QTETriggerSO` pour configurer les QTE dans les timelines
- ajout d'un composant `QTESignalReceiver` pour lancer ces QTE depuis les signaux
- mise à jour du `RhythmQTEManager` pour accepter une icône et instancier celle-ci dans l'interface

## Tests
- aucune suite de tests présente dans le dépôt

------
https://chatgpt.com/codex/tasks/task_e_6884ca16802483259b0d7a06d269a975