### PR TITLE
Ajout de la position personnalisée pour les QTE

### DIFF
--- a/Assets/Scripts/Classes/QTETriggerSO.cs
+++ b/Assets/Scripts/Classes/QTETriggerSO.cs
@@ -9,4 +9,6 @@ public class QTETriggerSO : ScriptableObject
 {
     [Tooltip("Icône de l'input à afficher")] public Sprite inputIcon;
     [Tooltip("Fenêtre de saisie en millisecondes")] public float windowDelay = 200f;
+
+    [Tooltip("Position du visuel dans le canvas (pixels)")] public Vector2 uiPosition = Vector2.zero;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
@@ -16,6 +16,6 @@ public class QTESignalReceiver : MonoBehaviour
             Debug.LogWarning("[QTESignalReceiver] TriggerQTE appelé avec null.");
             return;
         }
-        RhythmQTEManager.Instance?.TriggerQTE(trigger.windowDelay, trigger.inputIcon);
+        RhythmQTEManager.Instance?.TriggerQTE(trigger.windowDelay, trigger.inputIcon, trigger.uiPosition);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -498,7 +498,7 @@ public class RhythmQTEManager : MonoBehaviour
             audioSource.PlayOneShot(note.clip);
 
         // Pas d'icône spécifique pour les notes, on passe null
-        StartCoroutine(WaitForQTE(note.rhythm, null, success =>
+        StartCoroutine(WaitForQTE(note.rhythm, null, Vector2.zero, success =>
         {
             currentMove.ApplyEffect(currentCaster, currentTarget, success);
             pendingNotes = Mathf.Max(0, pendingNotes - 1);
@@ -509,7 +509,7 @@ public class RhythmQTEManager : MonoBehaviour
     public void TriggerQTE(float windowDelay)
     {
         // Appel historique sans icône
-        StartCoroutine(WaitForQTE(windowDelay, null, _ => { }));
+        StartCoroutine(WaitForQTE(windowDelay, null, Vector2.zero, _ => { }));
     }
 
     /// <summary>
@@ -519,10 +519,21 @@ public class RhythmQTEManager : MonoBehaviour
     /// <param name="icon">Icône de l'input à afficher</param>
     public void TriggerQTE(float windowDelay, Sprite icon)
     {
-        StartCoroutine(WaitForQTE(windowDelay, icon, _ => { }));
+        StartCoroutine(WaitForQTE(windowDelay, icon, Vector2.zero, _ => { }));
     }
 
-    private IEnumerator WaitForQTE(float windowDelay, Sprite icon, System.Action<bool> callback)
+    /// <summary>
+    /// Lance un QTE en précisant icône et position de l'affichage.
+    /// </summary>
+    /// <param name="windowDelay">Durée de la fenêtre en millisecondes</param>
+    /// <param name="icon">Icône de l'input à afficher</param>
+    /// <param name="position">Position du visuel dans le canvas</param>
+    public void TriggerQTE(float windowDelay, Sprite icon, Vector2 position)
+    {
+        StartCoroutine(WaitForQTE(windowDelay, icon, position, _ => { }));
+    }
+
+    private IEnumerator WaitForQTE(float windowDelay, Sprite icon, Vector2 position, System.Action<bool> callback)
     {
         qteActive = true;
         float slowestTimeScale = 0f;
@@ -546,6 +557,10 @@ public class RhythmQTEManager : MonoBehaviour
         Time.fixedDeltaTime = defaultFixedDeltaTime * slowestTimeScale;
 
         GameObject qteVisual = Instantiate(qteCirclePrefab, qteUIParent);
+        // Positionne le visuel selon la valeur fournie par le Trigger
+        var visualRect = qteVisual.GetComponent<RectTransform>();
+        if (visualRect != null)
+            visualRect.anchoredPosition = position;
         RectTransform dynamicCircle = qteVisual.transform.Find("Circle_Dynamic")?.GetComponent<RectTransform>();
         if (dynamicCircle != null)
             dynamicCircle.localScale = Vector3.one * qteStartScale;


### PR DESCRIPTION
## Résumé
- ajout d'un champ `uiPosition` dans `QTETriggerSO`
- passage de cette position au `QTESignalReceiver`
- surcharges de `RhythmQTEManager.TriggerQTE` permettant de définir la position du visuel
- instanciation du visuel QTE placée selon la position désirée

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884d22ac4d883259b58117c871d98f2