### PR TITLE
Amélioration du RhythmQTEManager

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/QTECircleUI.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTECircleUI.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Composant à placer sur le prefab de cercle QTE.
+/// Référence les images utilisées par le RhythmQTEManager
+/// afin d'éviter toute recherche par nom dans la hiérarchie.
+/// </summary>
+public class QTECircleUI : MonoBehaviour
+{
+    [SerializeField] private Image delayFillImage; // cercle se remplissant
+    [SerializeField] private Image inputIconImage; // icône de l'input au centre
+
+    /// <summary>
+    /// Accès en lecture à l'image représentant la progression du QTE.
+    /// </summary>
+    public Image DelayFillImage => delayFillImage;
+
+    /// <summary>
+    /// Accès en lecture à l'image de l'icône centrale.
+    /// </summary>
+    public Image InputIconImage => inputIconImage;
+}

--- a/Assets/Scripts/MonoBehavioursUsed/QTECircleUI.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/QTECircleUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48f2df64258b4ea3ac2e45f663fe270a

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using System;
+using UnityEngine.UI;
 
 public class RhythmQTEManager : MonoBehaviour
 {
@@ -555,17 +556,28 @@ public class RhythmQTEManager : MonoBehaviour
         Time.timeScale = slowestTimeScale;
         Time.fixedDeltaTime = defaultFixedDeltaTime * slowestTimeScale;
 
-        GameObject qteVisual = Instantiate(qteCirclePrefab, qteUIParent);
+        GameObject qteVisualGO = Instantiate(qteCirclePrefab, qteUIParent);
         // Positionne le visuel selon la valeur fournie par le Trigger
-        var visualRect = qteVisual.GetComponent<RectTransform>();
+        var visualRect = qteVisualGO.GetComponent<RectTransform>();
         if (visualRect != null)
             visualRect.anchoredPosition = position;
 
-        // Recherche de l'image représentant la progression du QTE.
-        // Le prefab peut s'appeler "Circle_Dynamic" ou "ShrinkingCircle" selon les versions.
-        UnityEngine.UI.Image delayFillImage = qteVisual.transform.Find("Circle_Dynamic")?.GetComponent<UnityEngine.UI.Image>();
-        if (delayFillImage == null)
-            delayFillImage = qteVisual.transform.Find("ShrinkingCircle")?.GetComponent<UnityEngine.UI.Image>();
+        // Récupère les références via le composant dédié s'il est présent
+        QTECircleUI qteVisual = qteVisualGO.GetComponent<QTECircleUI>();
+        UnityEngine.UI.Image delayFillImage = null;
+        UnityEngine.UI.Image iconImage = null;
+        if (qteVisual != null)
+        {
+            delayFillImage = qteVisual.DelayFillImage;
+            iconImage = qteVisual.InputIconImage;
+        }
+        else
+        {
+            // Compatibilité avec les anciens prefabs : recherche par nom
+            delayFillImage = qteVisualGO.transform.Find("Circle_Dynamic")?.GetComponent<UnityEngine.UI.Image>();
+            if (delayFillImage == null)
+                delayFillImage = qteVisualGO.transform.Find("ShrinkingCircle")?.GetComponent<UnityEngine.UI.Image>();
+        }
 
         // Valeur initiale à 0 pour remplir progressivement sur la durée du QTE.
         if (delayFillImage != null)
@@ -573,17 +585,27 @@ public class RhythmQTEManager : MonoBehaviour
             delayFillImage.fillAmount = 0f;
         }
 
-        // Ajoute dynamiquement l'icône si fournie
+        // Applique l'icône si fournie
         if (icon != null)
         {
-            var iconGO = new GameObject("InputIcon", typeof(RectTransform), typeof(CanvasRenderer), typeof(UnityEngine.UI.Image));
-            iconGO.transform.SetParent(qteVisual.transform, false);
-            var rect = iconGO.GetComponent<RectTransform>();
-            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
-            rect.anchoredPosition = Vector2.zero;
-            rect.sizeDelta = new Vector2(64f, 64f);
-            var img = iconGO.GetComponent<UnityEngine.UI.Image>();
-            img.sprite = icon;
+            if (iconImage != null)
+            {
+                iconImage.gameObject.SetActive(true);
+                iconImage.sprite = icon;
+            }
+            else
+            {
+                // Fallback si aucun Image n'est référencé
+                var iconGO = new GameObject("InputIcon", typeof(RectTransform), typeof(CanvasRenderer), typeof(UnityEngine.UI.Image));
+                iconGO.transform.SetParent(qteVisualGO.transform, false);
+                var rect = iconGO.GetComponent<RectTransform>();
+                rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+                rect.anchoredPosition = Vector2.zero;
+                rect.sizeDelta = new Vector2(64f, 64f);
+                var img = iconGO.GetComponent<UnityEngine.UI.Image>();
+                img.sprite = icon;
+                iconImage = img;
+            }
         }
 
         float elapsed = 0f;
@@ -613,7 +635,7 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         confirm.Disable();
-        Destroy(qteVisual);
+        Destroy(qteVisualGO);
 
         callback?.Invoke(success);
 


### PR DESCRIPTION
## Résumé
- ajout d'un composant **QTECircleUI** pour référencer les images du prefab
- utilisation de ce composant dans `RhythmQTEManager` afin d'éviter la recherche par nom

## Test
- `No tests present`

------
https://chatgpt.com/codex/tasks/task_e_68860fddec088325a12e62abd351feee