### PR TITLE
Ajout du suivi pour les popups de dégâts

### DIFF
--- a/Assets/Prefabs/DamagePopup.prefab
+++ b/Assets/Prefabs/DamagePopup.prefab
@@ -235,3 +235,18 @@ MonoBehaviour:
   duration: 1
   offset: {x: 0, y: 2, z: 0}
   textMesh: {fileID: 7337991163511607687}
+--- !u!114 &3333333333333333333
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2485583884748655888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fcc8e39cbee22946bb25ccabddc8c81, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  cameraToSetup: BattleCamera_Cam
+  sortingLayerName: UI
+  sortingLayerIndex: 0

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -203,7 +203,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
-        DamagePopupManager.Instance?.ShowDamage(transform.position, Mathf.RoundToInt(amount));
+        // Affiche le nombre de dégâts au-dessus de cette unité
+        DamagePopupManager.Instance?.ShowDamage(transform, Mathf.RoundToInt(amount));
         PlayDamageFeedback();
 
         // Message indiquant la gravité des dégâts subis

--- a/Assets/Scripts/MonoBehavioursUsed/DamagePopup.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DamagePopup.cs
@@ -9,32 +9,37 @@ public class DamagePopup : MonoBehaviour
     public Vector3 offset = new Vector3(0, 2f, 0);
 
     [Header("Références")]
-    public TextMeshProUGUI textMesh;
+    public TextMeshProUGUI textMesh; // Référence au texte affichant le montant
 
-    private float elapsed = 0f;
-    private Camera mainCam;
-    private CanvasGroup canvasGroup;
+    private float elapsed = 0f;      // Temps écoulé depuis l'initialisation
+    private float floatOffset = 0f;   // Décalage vertical cumulé
+    private Camera mainCam;           // Caméra principale utilisée pour la conversion
+    private CanvasGroup canvasGroup;  // Permet de faire disparaître progressivement le popup
+    private Transform target;         // Unité suivie
 
-    public void Initialize(int amount)
+    /// <summary>
+    /// Initialise le popup avec un montant et la cible à suivre.
+    /// </summary>
+    /// <param name="amount">Montant de dégâts à afficher.</param>
+    /// <param name="followTarget">Transform de l'unité concernée.</param>
+    public void Initialize(int amount, Transform followTarget)
     {
         textMesh.text = amount.ToString();
         mainCam = Camera.main;
         canvasGroup = GetComponent<CanvasGroup>();
 
-        // Position de départ + offset vertical
-        transform.position += offset;
+        target = followTarget;
+        // Position initiale sur l'écran
+        UpdatePosition();
     }
 
     void Update()
     {
-        if (mainCam != null)
-        {
-            // Toujours face à la caméra
-            transform.rotation = Quaternion.LookRotation(transform.position - mainCam.transform.position);
-        }
+        // Avancement de l'animation verticale
+        floatOffset += floatSpeed * Time.deltaTime;
 
-        // Animation vers le haut
-        transform.position += Vector3.up * floatSpeed * Time.deltaTime;
+        // Met à jour la position à chaque frame
+        UpdatePosition();
 
         // Fade out après 'duration'
         elapsed += Time.deltaTime;
@@ -44,5 +49,27 @@ public class DamagePopup : MonoBehaviour
             if (canvasGroup.alpha <= 0f)
                 Destroy(gameObject);
         }
+    }
+
+    /// <summary>
+    /// Calcule la position à l'écran en fonction de la cible suivie.
+    /// </summary>
+    private void UpdatePosition()
+    {
+        if (mainCam == null || target == null)
+            return;
+
+        // Position dans le monde avec l'offset animé
+        Vector3 worldPos = target.position + offset + Vector3.up * floatOffset;
+
+        // Conversion monde → écran
+        Vector3 screenPos = mainCam.WorldToScreenPoint(worldPos);
+
+        // Clamp pour rester visible même hors cadre
+        screenPos.x = Mathf.Clamp(screenPos.x, 0f, Screen.width);
+        screenPos.y = Mathf.Clamp(screenPos.y, 0f, Screen.height);
+
+        // Affecte directement la position de la RectTransform (Canvas en Screen Space)
+        transform.position = screenPos;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/DamagePopupManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DamagePopupManager.cs
@@ -17,7 +17,12 @@ public class DamagePopupManager : MonoBehaviour
         Instance = this;
     }
 
-    public void ShowDamage(Vector3 position, int amount)
+    /// <summary>
+    /// Crée un popup de dégâts au-dessus de la cible donnée.
+    /// </summary>
+    /// <param name="target">Transform à suivre.</param>
+    /// <param name="amount">Montant de dégâts.</param>
+    public void ShowDamage(Transform target, int amount)
     {
         if (damagePopupPrefab == null)
         {
@@ -25,7 +30,8 @@ public class DamagePopupManager : MonoBehaviour
             return;
         }
 
-        GameObject popup = Instantiate(damagePopupPrefab, NewBattleManager.Instance.currentTargetCharacter.transform.position, Quaternion.identity);
-        popup.GetComponent<DamagePopup>().Initialize(amount);
+        // Instancie le prefab comme enfant pour garder une hiérarchie propre
+        GameObject popup = Instantiate(damagePopupPrefab, transform);
+        popup.GetComponent<DamagePopup>().Initialize(amount, target);
     }
 }


### PR DESCRIPTION
## Résumé
- ajout d'un suivi de cible pour `DamagePopup`
- mise à jour de `DamagePopupManager` pour passer la cible à suivre
- ajustement de `CharacterUnit` pour utiliser la nouvelle signature
- ajout de `SetCameraToCanvas` sur le prefab `DamagePopup` pour régler la caméra

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68862fe91eb48325b3fba32e3c2f37a8