### PR TITLE
Correction de la vérification des compétences disponibles

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1173,11 +1173,22 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
-        bool hasSkill = caster.Data.musicalAttacks.Any(m =>
+        //
+        // Vérifie si au moins une compétence reste utilisable pour le lanceur.
+        // On prend en compte les moves standards ainsi que le move spécial
+        // éventuel. On ignore ceux en cooldown pour éviter de terminer
+        // prématurément le tour.
+
+        IEnumerable<MusicalMoveSO> availableMoves = caster.Data.musicalAttacks;
+        if (caster.Data.specialMusicalMove != null)
+            availableMoves = availableMoves.Append(caster.Data.specialMusicalMove);
+
+        bool hasSkill = availableMoves.Any(m =>
             (!m.onlyAwake || caster.IsAwake) &&
             (!m.enterAwake || !caster.IsAwake) &&
             caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost &&
-            (!m.enterAwake || caster.GetHarmonicCount(caster.Data.harmonicType) >= caster.Data.resonancePoint));
+            (!m.enterAwake || caster.GetHarmonicCount(caster.Data.harmonicType) >= caster.Data.resonancePoint) &&
+            !caster.IsMoveOnCooldown(m));
         bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
 
         if (!hasSkill && !hasItem)


### PR DESCRIPTION
## Résumé
- prise en compte du move spécial et du cooldown lors de la vérification des compétences restantes

## Tests
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6886359c9f94832587e0a990d10b5da4