### PR TITLE
Ajout du coup critique via QTE

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -17,6 +17,12 @@ public class ItemData : ScriptableObject
     public float moveSpeed;
     public float castDistance;
 
+    [Header("Coup Critique")]
+    [Tooltip("Active une variante lorsque le QTE est réussi")]
+    public bool useCriticalVariant = false;
+    public ItemEffectType criticalEffectType = ItemEffectType.Damage;
+    public int criticalEffectValue = 20;
+
     [Tooltip("Si vrai, le lanceur reste à la position cible après l'action")] public bool stayInPlace;
 
     public AnimationClip itemTargetingAnimation;
@@ -80,7 +86,21 @@ public class ItemData : ScriptableObject
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {
-        switch (effectType)
+        ApplyEffect(caster, target, false);
+    }
+
+    public void ApplyEffect(CharacterUnit caster, CharacterUnit target, bool isCritical)
+    {
+        ItemEffectType type = effectType;
+        int value = effectValue;
+
+        if (isCritical && useCriticalVariant)
+        {
+            type = criticalEffectType;
+            value = criticalEffectValue;
+        }
+
+        switch (type)
         {
             case ItemEffectType.Heal:
                 ApplyHeal(target);
@@ -98,10 +118,10 @@ public class ItemData : ScriptableObject
                 Debug.Log("[ItemData] Effet BoostTiming non implémenté.");
                 break;
             case ItemEffectType.Damage:
-                ApplyDamage(caster, target);
+                ApplyDamage(caster, target, value);
                 break;
             case ItemEffectType.IncreaseRange:
-                ApplyIncreaseRange(target);
+                ApplyIncreaseRange(target, value);
                 break;
             case ItemEffectType.PreventInterception:
                 ApplyInterceptionImmunity(target);
@@ -155,11 +175,11 @@ public class ItemData : ScriptableObject
         InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, buffDuration, buffIsPercentage);
     }
 
-    private void ApplyDamage(CharacterUnit caster, CharacterUnit target)
+    private void ApplyDamage(CharacterUnit caster, CharacterUnit target, float value)
     {
         if (target != null)
         {
-            float damage = effectValue;
+            float damage = value;
             if (caster != null)
                 damage *= caster.GetAttackMultiplier();
             // Précise la source pour jouer l'animation adéquate
@@ -167,10 +187,10 @@ public class ItemData : ScriptableObject
         }
     }
 
-    private void ApplyIncreaseRange(CharacterUnit target)
+    private void ApplyIncreaseRange(CharacterUnit target, float value)
     {
         if (target != null)
-            target.Data.currentRange += effectValue;
+            target.Data.currentRange += value;
     }
 
     private void ApplyInterceptionImmunity(CharacterUnit target)

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -36,6 +36,15 @@ public class MusicalMoveSO : ScriptableObject
     public int harmonicCost = 1;
     public int harmonicGeneration = 0;
 
+    [Header("Coup Critique")]
+    [Tooltip("Active une variante lorsque le QTE est réussi")]
+    public bool useCriticalVariant = false;
+    public MusicalEffectType criticalEffectType = MusicalEffectType.Damage;
+    public int criticalEffectValue = 20;
+    public float criticalFatigueCost = 1f;
+    public int criticalHarmonicCost = 1;
+    public int criticalHarmonicGeneration = 0;
+
     [Header("Temps de recharge")]
     [Tooltip("Nombre de tours avant de pouvoir réutiliser le move")]
     public int cooldown = 0;
@@ -90,45 +99,58 @@ public class MusicalMoveSO : ScriptableObject
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target, bool isCritical)
     {
-        float finalValue = effectValue;
+        // Choix de l'effet et de la valeur en fonction du résultat du QTE
+        MusicalEffectType typeToUse = effectType;
+        int baseValue = effectValue;
+        float fatigueToApply = fatigueCost;
+
+        if (isCritical && useCriticalVariant)
+        {
+            typeToUse = criticalEffectType;
+            baseValue = criticalEffectValue;
+            fatigueToApply = criticalFatigueCost;
+        }
+
+        float finalValue = baseValue;
         if (caster != null)
         {
             finalValue += caster.currentPower;
             finalValue *= caster.GetAttackMultiplier();
         }
 
-        if (isCritical)
+        // Ancien comportement : simple multiplicateur si aucune variante
+        if (isCritical && !useCriticalVariant)
             finalValue *= 2f;
 
-        if (effectType == MusicalEffectType.Damage && target.Data.characterType == CharacterType.EnemyUnit)
+        if (typeToUse == MusicalEffectType.Damage && target.Data.characterType == CharacterType.EnemyUnit)
         {
             // Transmission de la source pour déclencher l'animation directionnelle
             target.TakeDamage(finalValue, caster != null ? caster.transform : null);
             NewBattleManager.Instance?.RegisterDamage(caster, finalValue);
         }
-        else if (effectType == MusicalEffectType.Heal && target.Data.characterType == CharacterType.SquadUnit)
+        else if (typeToUse == MusicalEffectType.Heal && target.Data.characterType == CharacterType.SquadUnit)
         {
             target.Heal(finalValue);
         }
-        else if (effectType == MusicalEffectType.Sleep)
+        else if (typeToUse == MusicalEffectType.Sleep)
         {
             InventoryManager.Instance?.ApplySleep(target);
         }
-        else if (effectType == MusicalEffectType.WakeUpAll)
+        else if (typeToUse == MusicalEffectType.WakeUpAll)
         {
             foreach (var unit in NewBattleManager.Instance.activeCharacterUnits)
             {
                 InventoryManager.Instance?.RemoveSleep(unit);
             }
         }
-        else if (effectType == MusicalEffectType.LoyaltyMark)
+        else if (typeToUse == MusicalEffectType.LoyaltyMark)
         {
             var mark = target.GetComponent<LoyaltyMark>();
             if (mark == null)
                 mark = target.gameObject.AddComponent<LoyaltyMark>();
             mark.SetProtector(caster);
         }
-        else if (effectType == MusicalEffectType.LinkMark)
+        else if (typeToUse == MusicalEffectType.LinkMark)
         {
             if (target.GetComponent<LinkMark>() == null)
                 target.gameObject.AddComponent<LinkMark>();
@@ -136,7 +158,7 @@ public class MusicalMoveSO : ScriptableObject
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
-            caster.GetComponent<FatigueSystem>()?.OnActionPerformed(fatigueCost);
+            caster.GetComponent<FatigueSystem>()?.OnActionPerformed(fatigueToApply);
         }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -51,7 +51,7 @@ public class InventoryManager : MonoBehaviour
     /// <summary>
     /// Utilise un item (et l'enlève de l'inventaire). La cible doit être définie à l'avance.
     /// </summary>
-    public void UseItem(ItemData item, CharacterUnit caster, CharacterUnit target)
+    public void UseItem(ItemData item, CharacterUnit caster, CharacterUnit target, bool isCritical)
     {
         if (!inventoryItems.Contains(item))
         {
@@ -61,7 +61,7 @@ public class InventoryManager : MonoBehaviour
 
         Debug.Log($"[Inventory] Utilisation de l'objet : {item.itemName} sur {target.Data.characterName}");
 
-        item.ApplyEffect(caster, target);
+        item.ApplyEffect(caster, target, isCritical);
         inventoryItems.Remove(item);
     }
 
@@ -71,7 +71,7 @@ public class InventoryManager : MonoBehaviour
     public void PreviewItemEffect(ItemData item, CharacterUnit target)
     {
         Debug.Log($"[Inventory] Aperçu de l'effet de {item.itemName} sur {target.Data.characterName}");
-        item.ApplyEffect(null, target);
+        item.ApplyEffect(null, target, false);
     }
 
     public void ApplyBuff(CharacterUnit target, BuffStatType stat, int amount, float duration, bool isPercentage)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -916,10 +916,20 @@ public class NewBattleManager : MonoBehaviour
         // Animation ou Timeline d'utilisation
         yield return RhythmQTEManager.Instance.ItemRoutine(item, caster, target);
 
-        InventoryManager.Instance.UseItem(item, caster, target);
-        if (item.effectType == ItemEffectType.Damage)
+        bool crit = RhythmQTEManager.Instance.LastItemSuccess;
+        InventoryManager.Instance.UseItem(item, caster, target, crit);
+
+        ItemEffectType finalType = item.effectType;
+        float dmgVal = item.effectValue;
+        if (crit && item.useCriticalVariant)
         {
-            RegisterDamage(caster, item.effectValue);
+            finalType = item.criticalEffectType;
+            dmgVal = item.criticalEffectValue;
+        }
+
+        if (finalType == ItemEffectType.Damage)
+        {
+            RegisterDamage(caster, dmgVal);
         }
         caster.GetComponent<FatigueSystem>()?.OnActionPerformed();
         // L'utilisation d'un objet ne met plus fin immédiatement au tour
@@ -1144,12 +1154,21 @@ public class NewBattleManager : MonoBehaviour
         PassTurnUI.Instance.Hide(); // Bouclage
     }
 
-    public void AfterMusicalMove(MusicalMoveSO move, CharacterUnit caster)
+    public void AfterMusicalMove(MusicalMoveSO move, CharacterUnit caster, bool wasCritical)
     {
         if (caster != null)
         {
-            caster.ConsumeHarmonic(caster.Data.harmonicType, move.harmonicCost);
-            caster.AddHarmonic(caster.Data.harmonicType, move.harmonicGeneration);
+            int cost = move.harmonicCost;
+            int generation = move.harmonicGeneration;
+
+            if (wasCritical && move.useCriticalVariant)
+            {
+                cost = move.criticalHarmonicCost;
+                generation = move.criticalHarmonicGeneration;
+            }
+
+            caster.ConsumeHarmonic(caster.Data.harmonicType, cost);
+            caster.AddHarmonic(caster.Data.harmonicType, generation);
             caster.SetMoveCooldown(move);
 
             // Activation du mode Awake si le move le permet

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -16,6 +16,9 @@ public class RhythmQTEManager : MonoBehaviour
     private bool isActive = false;
     private List<bool> successResults;
 
+    // Dernier résultat enregistré pour un QTE d'objet
+    public bool LastItemSuccess { get; private set; }
+
     // QTE
     private Coroutine beatRoutine;
 
@@ -68,6 +71,7 @@ public class RhythmQTEManager : MonoBehaviour
     {
         Debug.Log("Début de la séquence du MusicalMove: " + move + " de " + caster.name);
         isActive = true;
+        successResults = new List<bool>();
 
         bool tauntPlayed = false;
         System.Action<CharacterUnit> deathHandler = null;
@@ -139,7 +143,8 @@ public class RhythmQTEManager : MonoBehaviour
             yield return ReturnToInitialPosition(move, caster, target);
 
         isActive = false;
-        NewBattleManager.Instance.AfterMusicalMove(move, caster);
+        bool critical = successResults != null && successResults.Count > 0 && successResults.All(s => s);
+        NewBattleManager.Instance.AfterMusicalMove(move, caster, critical);
 
         if (target != null)
             target.OnDeath -= deathHandler;
@@ -198,6 +203,20 @@ public class RhythmQTEManager : MonoBehaviour
             yield return null;
             float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
             yield return new WaitForSeconds(clipDuration);
+        }
+
+        // Phase de QTE propre à l'objet
+        LastItemSuccess = true;
+        if (item.beatPattern != null && item.beatPattern.Count > 0)
+        {
+            successResults = new List<bool>();
+            foreach (float beat in item.beatPattern)
+            {
+                bool s = false;
+                yield return WaitForQTE(beat, null, Vector2.zero, r => s = r);
+                successResults.Add(s);
+            }
+            LastItemSuccess = successResults.All(v => v);
         }
 
         // Retour à la position d'origine si l'objet ne demande pas de rester en place
@@ -502,6 +521,7 @@ public class RhythmQTEManager : MonoBehaviour
         StartCoroutine(WaitForQTE(note.rhythm, null, Vector2.zero, success =>
         {
             currentMove.ApplyEffect(currentCaster, currentTarget, success);
+            successResults.Add(success);
             pendingNotes = Mathf.Max(0, pendingNotes - 1);
         }));
     }


### PR DESCRIPTION
## Résumé
- prise en charge d'une variante critique dans `MusicalMoveSO` et `ItemData`
- application des valeurs critiques si le QTE est réussi
- gestion du résultat critique pour l'utilisation d'objets
- consommation d'harmoniques ajustée en cas de critique

## Tests
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_68863b92138c83259b39524baf1962d9