### PR TITLE
Correction de l'affichage du DamagePopup

### DIFF
--- a/Assets/Prefabs/DamagePopup.prefab
+++ b/Assets/Prefabs/DamagePopup.prefab
@@ -165,7 +165,7 @@ RectTransform:
   m_GameObject: {fileID: 2485583884748655888}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 3}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2228482764609775607}


### PR DESCRIPTION
## Résumé
- mise à l'échelle correcte du prefab `DamagePopup` pour qu'il soit visible

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863e8589388325970158758f247f77