### PR TITLE
Add critical hit display

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ActionUIDisplayManager.cs
@@ -154,6 +154,14 @@ public class ActionUIDisplayManager : MonoBehaviour
         ShowMessage(message);
     }
 
+    /// <summary>
+    /// Indique qu'un coup critique vient d'être réalisé.
+    /// </summary>
+    public void DisplayCriticalHit()
+    {
+        ShowMessage("Coup critique !");
+    }
+
     public void DisplayInterceptionResult(bool success)
     {
         string message = success ? "Interception réussie !" : "Interception échouée";

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -917,6 +917,8 @@ public class NewBattleManager : MonoBehaviour
         yield return RhythmQTEManager.Instance.ItemRoutine(item, caster, target);
 
         bool crit = RhythmQTEManager.Instance.LastItemSuccess;
+        if (crit)
+            ActionUIDisplayManager.Instance?.DisplayCriticalHit();
         InventoryManager.Instance.UseItem(item, caster, target, crit);
 
         ItemEffectType finalType = item.effectType;
@@ -1156,6 +1158,10 @@ public class NewBattleManager : MonoBehaviour
 
     public void AfterMusicalMove(MusicalMoveSO move, CharacterUnit caster, bool wasCritical)
     {
+        // Affiche un message si toutes les notes du QTE ont été réussies
+        if (wasCritical)
+            ActionUIDisplayManager.Instance?.DisplayCriticalHit();
+
         if (caster != null)
         {
             int cost = move.harmonicCost;


### PR DESCRIPTION
## Summary
- afficher "Coup critique" via `ActionUIDisplayManager`
- notifier les coups critiques pour les compétences et les objets

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68864c5f414483259e07406698bb7c06