### PR TITLE
Implémentation effets critiques cumulés

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -91,15 +91,21 @@ public class ItemData : ScriptableObject
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target, bool isCritical)
     {
-        ItemEffectType type = effectType;
-        int value = effectValue;
+        // Applique d'abord l'effet principal de l'objet
+        ApplySingleEffect(effectType, caster, target, effectValue);
 
+        // Ajoute l'effet critique si nécessaire
         if (isCritical && useCriticalVariant)
         {
-            type = criticalEffectType;
-            value = criticalEffectValue;
+            ApplySingleEffect(criticalEffectType, caster, target, criticalEffectValue);
         }
+    }
 
+    /// <summary>
+    /// Applique un effet unique selon son type.
+    /// </summary>
+    private void ApplySingleEffect(ItemEffectType type, CharacterUnit caster, CharacterUnit target, float value = 0f)
+    {
         switch (type)
         {
             case ItemEffectType.Heal:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -99,18 +99,23 @@ public class MusicalMoveSO : ScriptableObject
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target, bool isCritical)
     {
-        // Choix de l'effet et de la valeur en fonction du résultat du QTE
-        MusicalEffectType typeToUse = effectType;
-        int baseValue = effectValue;
-        float fatigueToApply = fatigueCost;
+        // Applique d'abord l'effet de base
+        ApplySingleEffect(effectType, caster, target, effectValue, fatigueCost, isCritical && !useCriticalVariant);
 
+        // Ajoute l'effet critique si nécessaire
         if (isCritical && useCriticalVariant)
         {
-            typeToUse = criticalEffectType;
-            baseValue = criticalEffectValue;
-            fatigueToApply = criticalFatigueCost;
+            ApplySingleEffect(criticalEffectType, caster, target, criticalEffectValue, criticalFatigueCost, false);
         }
+    }
 
+    /// <summary>
+    /// Applique un effet unique en tenant compte de la puissance du lanceur et
+    /// du système de fatigue éventuel.
+    /// </summary>
+    private void ApplySingleEffect(MusicalEffectType typeToUse, CharacterUnit caster,
+        CharacterUnit target, int baseValue, float fatigueToApply, bool doubleValue)
+    {
         float finalValue = baseValue;
         if (caster != null)
         {
@@ -119,7 +124,7 @@ public class MusicalMoveSO : ScriptableObject
         }
 
         // Ancien comportement : simple multiplicateur si aucune variante
-        if (isCritical && !useCriticalVariant)
+        if (doubleValue)
             finalValue *= 2f;
 
         if (typeToUse == MusicalEffectType.Damage && target.Data.characterType == CharacterType.EnemyUnit)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -921,15 +921,14 @@ public class NewBattleManager : MonoBehaviour
             ActionUIDisplayManager.Instance?.DisplayCriticalHit();
         InventoryManager.Instance.UseItem(item, caster, target, crit);
 
-        ItemEffectType finalType = item.effectType;
-        float dmgVal = item.effectValue;
-        if (crit && item.useCriticalVariant)
-        {
-            finalType = item.criticalEffectType;
-            dmgVal = item.criticalEffectValue;
-        }
+        // Calcule les dégâts totaux infligés par l'objet
+        float dmgVal = 0f;
+        if (item.effectType == ItemEffectType.Damage)
+            dmgVal += item.effectValue;
+        if (crit && item.useCriticalVariant && item.criticalEffectType == ItemEffectType.Damage)
+            dmgVal += item.criticalEffectValue;
 
-        if (finalType == ItemEffectType.Damage)
+        if (dmgVal > 0f)
         {
             RegisterDamage(caster, dmgVal);
         }
@@ -1169,8 +1168,9 @@ public class NewBattleManager : MonoBehaviour
 
             if (wasCritical && move.useCriticalVariant)
             {
-                cost = move.criticalHarmonicCost;
-                generation = move.criticalHarmonicGeneration;
+                // Ajoute les valeurs spécifiées pour le coup critique
+                cost += move.criticalHarmonicCost;
+                generation += move.criticalHarmonicGeneration;
             }
 
             caster.ConsumeHarmonic(caster.Data.harmonicType, cost);


### PR DESCRIPTION
## Résumé
- Les effets critiques s'ajoutent désormais aux effets normaux pour les attaques et les objets.
- Ajout d'une méthode interne `ApplySingleEffect` dans `MusicalMoveSO` pour appliquer séparément l'effet de base et l'effet critique.
- Refonte similaire dans `ItemData` avec `ApplySingleEffect`.
- Ajustement du calcul des dégâts et des coûts d'harmonique dans `NewBattleManager`.

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68864e4e314083258d24313bf0a71725