### PR TITLE
Afficher les stats runtime dans l'inspecteur

### DIFF
--- a/Assets/Scripts/Editor/CharacterUnitEditor.cs
+++ b/Assets/Scripts/Editor/CharacterUnitEditor.cs
@@ -1,0 +1,78 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(CharacterUnit))]
+[CanEditMultipleObjects]
+public class CharacterUnitEditor : Editor
+{
+    private void OnEnable()
+    {
+        // Actualise l'inspecteur en temps réel pendant le Play Mode
+        EditorApplication.update += RepaintInspector;
+    }
+
+    private void OnDisable()
+    {
+        EditorApplication.update -= RepaintInspector;
+    }
+
+    private void RepaintInspector()
+    {
+        Repaint();
+    }
+
+    public override void OnInspectorGUI()
+    {
+        // Sécurité : on vérifie que l'objet sérialisé existe toujours
+        if (serializedObject == null)
+            return;
+
+        serializedObject.Update();
+
+        // Affiche l'inspecteur par défaut
+        DrawDefaultInspector();
+
+        EditorGUILayout.Space();
+
+        if (EditorApplication.isPlaying)
+        {
+            EditorGUILayout.LabelField("--- Valeurs Runtime ---", EditorStyles.boldLabel);
+
+            foreach (var obj in targets)
+            {
+                if (obj == null) continue;
+                var unit = obj as CharacterUnit;
+                if (unit == null) continue;
+
+                EditorGUILayout.LabelField(unit.gameObject.name, EditorStyles.miniBoldLabel);
+                EditorGUI.indentLevel++;
+                EditorGUILayout.FloatField("HP", unit.currentHP);
+                EditorGUILayout.FloatField("MP", unit.currentMP);
+                EditorGUILayout.FloatField("Rage", unit.currentRage);
+                EditorGUILayout.FloatField("Force", unit.currentStrength);
+                EditorGUILayout.FloatField("Défense", unit.currentDefense);
+                EditorGUILayout.FloatField("Réflexe", unit.currentReflex);
+                EditorGUILayout.FloatField("Mobilité", unit.currentMobility);
+                EditorGUILayout.FloatField("Puissance", unit.currentPower);
+                EditorGUILayout.FloatField("Stabilité", unit.currentStability);
+                EditorGUILayout.FloatField("Vitalité", unit.currentVitality);
+                EditorGUILayout.FloatField("Sagacité", unit.currentSagacity);
+                EditorGUILayout.FloatField("Fatigue", unit.currentFatigue);
+                EditorGUILayout.FloatField("Initiative", unit.currentInitiative);
+                EditorGUI.indentLevel--;
+                EditorGUILayout.Space();
+            }
+        }
+        else
+        {
+            EditorGUILayout.HelpBox(
+                "Passez en Play Mode pour voir les valeurs runtime.",
+                MessageType.Info
+            );
+        }
+
+        serializedObject.ApplyModifiedProperties();
+    }
+}
+#endif

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -83,8 +83,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public bool IsDead => deathTriggered || currentHP <= 0f;
     public event System.Action<CharacterUnit> OnDeath;
     public bool isReadyToParry;
-    [HideInInspector] public bool isInterceptionImmune = false;
-    [HideInInspector] public int interceptionImmunityTurns = 0;
+    // Indique si l'unité est immunisée à l'interception. Visible pour faciliter
+    // le débogage pendant le combat.
+    public bool isInterceptionImmune = false;
+    // Nombre de tours restants pour l'immunité à l'interception. Visible pour
+    // suivre précisément la durée de l'effet.
+    public int interceptionImmunityTurns = 0;
 
     [Header("Récompenses de combat")]
     public List<ItemData> lootItems = new();


### PR DESCRIPTION
## Résumé
- ajouter un éditeur personnalisé pour `CharacterUnit`
- affichage en temps réel des statistiques (HP, Rage...) pendant le Play Mode

## Tests
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688663ac3a58832590bcfccfbe779c57