### PR TITLE
Fix AddHarmonicPopup initialization

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
@@ -28,9 +28,26 @@ public class AddHarmonicPopup : MonoBehaviour
     /// <param name="followTarget">Transform de l'unité concernée.</param>
     public void Initialize(int amount, Transform followTarget)
     {
+        // Récupère automatiquement la référence du texte si elle n'a pas été assignée dans l'inspecteur.
+        if (textMesh == null)
+        {
+            textMesh = GetComponentInChildren<TextMeshProUGUI>();
+            if (textMesh == null)
+            {
+                // Impossible d'afficher le popup sans texte, on log l'erreur et on quitte.
+                Debug.LogError("[AddHarmonicPopup] Aucun TextMeshProUGUI trouvé sur le prefab.");
+                return;
+            }
+        }
+
         textMesh.text = "+" + amount.ToString();
+
         mainCam = Camera.main;
+
         canvasGroup = GetComponent<CanvasGroup>();
+        if (canvasGroup == null)
+            canvasGroup = gameObject.AddComponent<CanvasGroup>();
+
         target = followTarget;
         UpdatePosition();
     }


### PR DESCRIPTION
## Summary
- sécurise l'initialisation d'`AddHarmonicPopup` en récupérant le `TextMeshProUGUI` automatiquement s'il n'est pas renseigné
- ajoute la création d'un `CanvasGroup` si nécessaire

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866b3c00fc83259234149f655d9d1e