### PR TITLE
Fix: permettre plusieurs actions par tour

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -903,7 +903,10 @@ public class NewBattleManager : MonoBehaviour
             }
         }
 
-        currentCharacterUnit.currentATB = 0f;
+        // L'ATB n'est plus remis à zéro afin de permettre l'enchaînement de plusieurs
+        // actions (compétence ou objet) dans le même tour tant que le joueur dispose des
+        // ressources nécessaires.
+        //currentCharacterUnit.currentATB = 0f;
     }
 
     public IEnumerator UseItemOnTarget(ItemData item, CharacterUnit caster, CharacterUnit target)


### PR DESCRIPTION
## Summary
- empêche la remise à zéro de l'ATB après un MusicalMove
- permet d'enchaîner plusieurs actions dans le même tour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688674cb357083259d2829e558333ad5