### PR TITLE
Ajout d'un avertissement sonore lors des attaques ennemies

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -78,6 +78,10 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("VFX joué au point d'arrivée de la téléportation")]
     public GameObject teleportEndVFXPrefab;
 
+    [Header("Effets sonores")]
+    [Tooltip("Indice sonore lancé avant l'attaque pour avertir le joueur")]
+    public AudioClip warningClip;
+
     [Header("Timing")]
     [Tooltip("Temps en secondes à attendre après la téléportation avant d'exécuter le move")]
     public float startDelay = 2f;

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -831,6 +831,10 @@ public class NewBattleManager : MonoBehaviour
         // Affiche le move que l'ennemi prépare
         ActionUIDisplayManager.Instance.DisplayEnemyPreparation(enemy.Data.characterName, alreadyKnown ? move.moveName : null);
 
+        // Joue un indice sonore associé à l'attaque pour prévenir le joueur
+        if (move.warningClip != null)
+            AudioManager.Instance?.PlayVoice(move.warningClip);
+
         // Laisse un délai pour que le joueur prenne connaissance de l'action
         // On utilise ici un temps réel pour éviter tout blocage si le jeu est en pause
         yield return new WaitForSecondsRealtime(ENEMY_MOVE_DELAY);


### PR DESCRIPTION
## Résumé
- ajout d'un champ `warningClip` dans `MusicalMoveSO` pour stocker le clip d'annonce
- lecture de ce clip au début de la coroutine `EnemyTurnWithQTE`

## Tests
- Aucun test automatique présent dans le projet

------
https://chatgpt.com/codex/tasks/task_e_68867bc5435883259edc6743c246a469