### PR TITLE
Ajout du warning sonore pour les unités alliées

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -882,6 +882,9 @@ public class NewBattleManager : MonoBehaviour
                 yield break;
             }
         }
+        // Lecture d'un avertissement sonore si le mouvement en possède un
+        if (move.warningClip != null)
+            AudioManager.Instance?.PlayVoice(move.warningClip);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
 
         // Ajout du système de rage manuellement


### PR DESCRIPTION
## Résumé
- joue désormais le `warningClip` des `MusicalMove` lorsque ce sont les unités du joueur qui attaquent

## Tests
- `git diff` pour vérifier les changements


------
https://chatgpt.com/codex/tasks/task_e_6886806667808325a1de520ae38901dd