### PR TITLE
Ajout d'une source pour les avertissements sonores

### DIFF
--- a/Assets/Prefabs/AudioManager.prefab
+++ b/Assets/Prefabs/AudioManager.prefab
@@ -609,6 +609,139 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &8557997653065459154
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1233496464839933092}
+  - component: {fileID: 6152067128056661931}
+  m_Layer: 0
+  m_Name: AudioSource_Warning
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1233496464839933092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557997653065459154}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1647225499042316683}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!82 &6152067128056661931
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557997653065459154}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &3833345576927748889
 GameObject:
   m_ObjectHideFlags: 0
@@ -1076,6 +1209,7 @@ RectTransform:
   - {fileID: 3356540791805513454}
   - {fileID: 1604035809488865530}
   - {fileID: 4033893785394362570}
+  - {fileID: 1233496464839933092}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -1102,6 +1236,7 @@ MonoBehaviour:
   musicSourceB: {fileID: 3496672895916057710}
   sfxSource: {fileID: 7703095432394423678}
   voiceSource: {fileID: 4343329202395332393}
+  warningClipSource: {fileID: 6152067128056661931}
   fadeDuration: 2
 --- !u!1 &8555247583833438367
 GameObject:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -79,7 +79,7 @@ public class MusicalMoveSO : ScriptableObject
     public GameObject teleportEndVFXPrefab;
 
     [Header("Effets sonores")]
-    [Tooltip("Indice sonore lancé avant l'attaque pour avertir le joueur")]
+    [Tooltip("Son d'avertissement joué avant l'attaque pour prévenir le joueur")]
     public AudioClip warningClip;
 
     [Header("Timing")]

--- a/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
@@ -13,6 +13,8 @@ public class AudioManager : MonoBehaviour
     public AudioSource musicSourceB;
     public AudioSource sfxSource;
     public AudioSource voiceSource;
+    // Nouvelle source dédiée aux sons d'avertissement
+    public AudioSource warningClipSource;
 
     [Header("Fade Settings")]
     public float fadeDuration = 2f;
@@ -41,6 +43,15 @@ public class AudioManager : MonoBehaviour
     private Dictionary<AudioClip, float> explorationPlaybackPositions = new Dictionary<AudioClip, float>();
     private Dictionary<AudioClip, float> normalizationCache = new Dictionary<AudioClip, float>();
 
+    /// <summary>
+    /// Met à jour le volume de la source d'avertissement en fonction de la musique.
+    /// </summary>
+    private void UpdateWarningVolume()
+    {
+        // Volume deux fois plus élevé que celui des sources de musique
+        warningClipSource.volume = musicVolume * 2f;
+    }
+
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -63,10 +74,12 @@ public class AudioManager : MonoBehaviour
 
         sfxSource.playOnAwake = false;
         voiceSource.playOnAwake = false;
+        warningClipSource.playOnAwake = false;
 
         SetMusicVolume(musicVolume);
         SetSfxVolume(sfxVolume);
         SetVoiceVolume(voiceVolume);
+        UpdateWarningVolume();
     }
 
     private float GetNormalizationFactor(AudioClip clip)
@@ -107,6 +120,7 @@ public class AudioManager : MonoBehaviour
         float factorB = GetNormalizationFactor(musicSourceB.clip);
         musicSourceA.volume = musicVolume * factorA;
         musicSourceB.volume = musicVolume * factorB;
+        UpdateWarningVolume();
     }
 
     public void SetSfxVolume(float value)
@@ -267,6 +281,17 @@ public class AudioManager : MonoBehaviour
         tempSource.volume = voiceVolume * GetNormalizationFactor(clip);
         tempSource.Play();
         Destroy(tempSource.gameObject, clip.length);
+    }
+
+    /// <summary>
+    /// Joue un clip d'avertissement en utilisant la source dédiée.
+    /// </summary>
+    public void PlayWarningClip(AudioClip clip)
+    {
+        if (clip == null) return;
+
+        float factor = GetNormalizationFactor(clip);
+        warningClipSource.PlayOneShot(clip, factor);
     }
 
     public void PlaySound(AudioClip clip)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -833,7 +833,8 @@ public class NewBattleManager : MonoBehaviour
 
         // Joue un indice sonore associé à l'attaque pour prévenir le joueur
         if (move.warningClip != null)
-            AudioManager.Instance?.PlayVoice(move.warningClip);
+            // Les indices sonores sont joués via la nouvelle source dédiée
+            AudioManager.Instance?.PlayWarningClip(move.warningClip);
 
         // Laisse un délai pour que le joueur prenne connaissance de l'action
         // On utilise ici un temps réel pour éviter tout blocage si le jeu est en pause
@@ -884,7 +885,8 @@ public class NewBattleManager : MonoBehaviour
         }
         // Lecture d'un avertissement sonore si le mouvement en possède un
         if (move.warningClip != null)
-            AudioManager.Instance?.PlayVoice(move.warningClip);
+            // Les indices sonores sont joués via la nouvelle source dédiée
+            AudioManager.Instance?.PlayWarningClip(move.warningClip);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
 
         // Ajout du système de rage manuellement


### PR DESCRIPTION
## Résumé
- ajout d'une `warningClipSource` dans `AudioManager`
- volume automatique deux fois supérieur à la musique
- nouvelle méthode `PlayWarningClip`
- appel de cette méthode dans `NewBattleManager`
- mise à jour du commentaire dans `MusicalMoveSO`
- modification du prefab `AudioManager` pour inclure la nouvelle AudioSource

## Tests
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6886843063c4832598f72b7fc3d4d8e5