### PR TITLE
Prépare la barre QTE dès le ciblage

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -836,6 +836,8 @@ public class NewBattleManager : MonoBehaviour
         float delay = ENEMY_MOVE_DELAY;
         if (move.warningClip != null)
         {
+            // Affiche immédiatement la barre de QTE avec les notes
+            RhythmQTEManager.Instance?.PrepareQTEBar(move.notes);
             // Les indices sonores sont joués via la nouvelle source dédiée
             AudioManager.Instance?.PlayWarningClip(move.warningClip);
             // On attend au moins la durée du clip pour conserver la cohérence musicale
@@ -892,6 +894,7 @@ public class NewBattleManager : MonoBehaviour
         // Lecture d'un avertissement sonore si le mouvement en possède un
         if (move.warningClip != null)
         {
+            RhythmQTEManager.Instance?.PrepareQTEBar(move.notes);
             // Les indices sonores sont joués via la nouvelle source dédiée
             AudioManager.Instance?.PlayWarningClip(move.warningClip);
             // On attend la fin du clip pour conserver la cohérence musicale

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -31,6 +31,10 @@ public class RhythmQTEManager : MonoBehaviour
     [Header("QTE Barre")]
     public GameObject qteBarPrefab; // Prefab de la barre façon Guitar Hero
 
+    // Instance actuellement affichée de la barre et file d'attente des notes
+    private QTEBar activeQTEBar;
+    private readonly Queue<Image> preparedNotes = new();
+
     private DefenseResult defenseResult;
     public DefenseResult GetDefenseResult() => defenseResult;
 
@@ -62,6 +66,62 @@ public class RhythmQTEManager : MonoBehaviour
         if (Instance != null && Instance != this) { Destroy(gameObject); return; }
         Instance = this;
         defaultFixedDeltaTime = Time.fixedDeltaTime;
+    }
+
+    /// <summary>
+    /// Prépare la barre de QTE en l'affichant et en créant toutes les notes à l'avance.
+    /// </summary>
+    /// <param name="notes">Liste des données de notes à afficher</param>
+    public void PrepareQTEBar(IList<MusicalMoveSO.NoteData> notes)
+    {
+        if (qteBarPrefab == null || notes == null || notes.Count == 0)
+            return;
+
+        // Nettoie une éventuelle barre précédente
+        ClearQTEBar();
+
+        var go = Instantiate(qteBarPrefab, qteUIParent);
+        activeQTEBar = go.GetComponent<QTEBar>();
+
+        preparedNotes.Clear();
+        foreach (var n in notes)
+        {
+            var img = activeQTEBar.CreateNote(n.noteInput);
+            preparedNotes.Enqueue(img);
+        }
+    }
+
+    /// <summary>
+    /// Variante pour un motif simple d'item sans icônes spécifiques.
+    /// </summary>
+    public void PrepareQTEBar(IList<float> beatPattern)
+    {
+        if (qteBarPrefab == null || beatPattern == null || beatPattern.Count == 0)
+            return;
+
+        ClearQTEBar();
+        var go = Instantiate(qteBarPrefab, qteUIParent);
+        activeQTEBar = go.GetComponent<QTEBar>();
+
+        preparedNotes.Clear();
+        // Notes anonymes, pas d'icône
+        for (int i = 0; i < beatPattern.Count; i++)
+        {
+            var img = activeQTEBar.CreateNote(null);
+            preparedNotes.Enqueue(img);
+        }
+    }
+
+    /// <summary>
+    /// Détruit la barre de QTE active et vide la file des notes.
+    /// </summary>
+    public void ClearQTEBar()
+    {
+        if (activeQTEBar != null)
+            Destroy(activeQTEBar.gameObject);
+
+        activeQTEBar = null;
+        preparedNotes.Clear();
     }
 
     // Séquence du Musicalmove - Ajouter autant de méthodes que d'effets durant le move
@@ -157,6 +217,9 @@ public class RhythmQTEManager : MonoBehaviour
         currentCaster = null;
         currentTarget = null;
 
+        // Nettoie la barre de QTE une fois la séquence terminée
+        ClearQTEBar();
+
         // Si le caster a été détruit durant la séquence, on évite une exception
         casterName = caster != null ? caster.name : "(caster nul)";
         Debug.Log("Fin de la séquence du MusicalMove: " + move + " de " + casterName);
@@ -174,6 +237,10 @@ public class RhythmQTEManager : MonoBehaviour
         string itemCasterName = caster != null ? caster.name : "(caster nul)";
         Debug.Log($"Début de la séquence d'utilisation de l'objet: {item.itemName} par {itemCasterName}");
         isActive = true;
+
+        // Prépare la barre de QTE correspondant au motif de l'objet
+        if (item.beatPattern != null && item.beatPattern.Count > 0)
+            PrepareQTEBar(item.beatPattern);
 
         if (caster == null || caster.IsDead)
         {
@@ -237,6 +304,9 @@ public class RhythmQTEManager : MonoBehaviour
         // Protection en cas de destruction du lanceur avant la fin de la séquence
         itemCasterName = caster != null ? caster.name : "(caster nul)";
         Debug.Log($"Fin de la séquence d'utilisation de l'objet: {item.itemName} par {itemCasterName}");
+
+        // Nettoie la barre de QTE utilisée pour l'objet
+        ClearQTEBar();
     }
 
     private IEnumerator SimpleMoveTo(CharacterUnit caster, CharacterUnit target, ItemData item)
@@ -646,16 +716,28 @@ public class RhythmQTEManager : MonoBehaviour
         UnityEngine.UI.Image delayFillImage = null;
         UnityEngine.UI.Image iconImage = null;
 
-        // Préférence : utiliser la barre Guitar Hero si un prefab est fourni
-        if (qteBarPrefab != null)
+        // Préférence : utiliser la barre Guitar Hero si une barre est préparée ou un prefab fourni
+        if (activeQTEBar != null || qteBarPrefab != null)
         {
-            qteVisualGO = Instantiate(qteBarPrefab, qteUIParent);
-            var rect = qteVisualGO.GetComponent<RectTransform>();
-            if (rect != null)
-                rect.anchoredPosition = position;
+            qteBar = activeQTEBar;
+            if (qteBar == null)
+            {
+                qteVisualGO = Instantiate(qteBarPrefab, qteUIParent);
+                var rect = qteVisualGO.GetComponent<RectTransform>();
+                if (rect != null)
+                    rect.anchoredPosition = position;
 
-            qteBar = qteVisualGO.GetComponent<QTEBar>();
-            if (qteBar != null)
+                qteBar = qteVisualGO.GetComponent<QTEBar>();
+                activeQTEBar = qteBar;
+            }
+            else
+            {
+                qteVisualGO = qteBar.gameObject;
+            }
+
+            if (preparedNotes.Count > 0)
+                noteImage = preparedNotes.Dequeue();
+            else if (qteBar != null)
                 noteImage = qteBar.CreateNote(icon);
         }
         else
@@ -739,7 +821,14 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         confirm.Disable();
-        Destroy(qteVisualGO);
+
+        // Détruit uniquement la barre si elle n'est pas réutilisée
+        if (qteVisualGO != null && (activeQTEBar == null || qteVisualGO != activeQTEBar.gameObject))
+            Destroy(qteVisualGO);
+
+        // Supprime la note utilisée pour libérer l'espace
+        if (noteImage != null)
+            Destroy(noteImage.gameObject);
 
         callback?.Invoke(success);
 
@@ -794,11 +883,28 @@ public class RhythmQTEManager : MonoBehaviour
             Time.fixedDeltaTime = defaultFixedDeltaTime * slowestTimeScale;
         }
 
-        GameObject qteVisualGO = Instantiate(qteCirclePrefab, qteUIParent);
-        QTECircleUI qteVisual = qteVisualGO.GetComponent<QTECircleUI>();
-        UnityEngine.UI.Image delayFillImage = qteVisual != null ? qteVisual.DelayFillImage : null;
-        if (delayFillImage != null)
-            delayFillImage.fillAmount = 0f;
+        GameObject qteVisualGO;
+        QTEBar qteBar = null;
+        UnityEngine.UI.Image noteImage = null;
+        UnityEngine.UI.Image delayFillImage = null;
+
+        if (activeQTEBar != null)
+        {
+            qteBar = activeQTEBar;
+            qteVisualGO = qteBar.gameObject;
+            if (preparedNotes.Count > 0)
+                noteImage = preparedNotes.Dequeue();
+            else
+                noteImage = qteBar.CreateNote(null);
+        }
+        else
+        {
+            qteVisualGO = Instantiate(qteCirclePrefab, qteUIParent);
+            QTECircleUI qteVisual = qteVisualGO.GetComponent<QTECircleUI>();
+            delayFillImage = qteVisual != null ? qteVisual.DelayFillImage : null;
+            if (delayFillImage != null)
+                delayFillImage.fillAmount = 0f;
+        }
 
         float elapsed = 0f;
         bool pressed = false;
@@ -813,6 +919,12 @@ public class RhythmQTEManager : MonoBehaviour
             if (delayFillImage != null)
                 delayFillImage.fillAmount = Mathf.Clamp01(elapsed / dodgeWindow);
 
+            if (qteBar != null && noteImage != null)
+            {
+                float progress = Mathf.Clamp01(elapsed / dodgeWindow);
+                qteBar.UpdateNotePosition(noteImage, progress);
+            }
+
             if (confirm.triggered)
             {
                 pressed = true;
@@ -823,7 +935,12 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         confirm.Disable();
-        Destroy(qteVisualGO);
+
+        if (qteVisualGO != null && (activeQTEBar == null || qteVisualGO != activeQTEBar.gameObject))
+            Destroy(qteVisualGO);
+
+        if (noteImage != null)
+            Destroy(noteImage.gameObject);
 
         DefenseResult result;
         if (!pressed)


### PR DESCRIPTION
## Résumé
- instancie la barre de QTE à l'avance avec `PrepareQTEBar`
- ajoute une file de notes préchargées
- utilise la barre unique pour les QTE d'attaque et de défense
- joue le warning clip et affiche la barre simultanément
- nettoyage automatique de la barre en fin de séquence

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688690d9ede88325b4465fc9c77856d6