### PR TITLE
Amélioration du timing des notes de QTE

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
@@ -24,6 +24,8 @@ public class QTEBar : MonoBehaviour
         public bool started;
     }
     private readonly List<ScheduledNote> scheduledNotes = new();
+    // Durée par défaut pour qu'une note parcoure toute la barre
+    private const float defaultTravelDuration = 2f;
     private float barWidth;
 
     private void Awake()
@@ -74,6 +76,9 @@ public class QTEBar : MonoBehaviour
         rect.anchoredPosition = new Vector2(barWidth / 2f, 0f);
         note.enabled = false;
 
+        if (travelDuration <= 0f)
+            travelDuration = defaultTravelDuration;
+
         scheduledNotes.Add(new ScheduledNote
         {
             image = note,
@@ -123,19 +128,45 @@ public class QTEBar : MonoBehaviour
             return;
 
         float now = Time.unscaledTime;
+        // Liste temporaire pour retirer proprement les notes terminées
+        List<ScheduledNote> toRemove = null;
+
         foreach (var n in scheduledNotes)
         {
+            // Ignore les notes dont l'affichage n'a pas encore commencé
             if (now < n.startTime)
                 continue;
 
             if (!n.started)
             {
                 n.started = true;
-                n.image.enabled = true;
+                if (n.image != null)
+                    n.image.enabled = true;
+            }
+
+            if (n.image == null)
+            {
+                // L'objet a été détruit ailleurs, on supprime la note de la liste
+                (toRemove ??= new List<ScheduledNote>()).Add(n);
+                continue;
             }
 
             float progress = Mathf.Clamp01((now - n.startTime) / (n.endTime - n.startTime));
             UpdateNotePosition(n.image, progress);
+
+            if (progress >= 1f)
+                (toRemove ??= new List<ScheduledNote>()).Add(n);
+        }
+
+        if (toRemove != null)
+        {
+            foreach (var rem in toRemove)
+            {
+                scheduledNotes.Remove(rem);
+                activeNotes.Remove(rem.image);
+                if (rem.image != null)
+                    Destroy(rem.image.gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -35,6 +35,9 @@ public class RhythmQTEManager : MonoBehaviour
     private QTEBar activeQTEBar;
     private readonly Queue<Image> preparedNotes = new();
 
+    // Temps d'avance avec lequel une note est affichée avant la zone de validation
+    private const float noteAdvanceTime = 2f;
+
     private DefenseResult defenseResult;
     public DefenseResult GetDefenseResult() => defenseResult;
 
@@ -88,9 +91,9 @@ public class RhythmQTEManager : MonoBehaviour
         foreach (var n in notes)
         {
             cumulative += n.rhythm;
-            // Les notes apparaissent 2 secondes avant d'arriver dans la zone
-            float delay = Mathf.Max(0f, cumulative - 2f);
-            var img = activeQTEBar.ScheduleNote(n.noteInput, delay, 2f);
+            // Les notes apparaissent noteAdvanceTime secondes avant d'arriver dans la zone
+            float delay = Mathf.Max(0f, cumulative - noteAdvanceTime);
+            var img = activeQTEBar.ScheduleNote(n.noteInput, delay, noteAdvanceTime);
             preparedNotes.Enqueue(img);
         }
     }
@@ -114,8 +117,8 @@ public class RhythmQTEManager : MonoBehaviour
         for (int i = 0; i < beatPattern.Count; i++)
         {
             cumulative += beatPattern[i];
-            float delay = Mathf.Max(0f, cumulative - 2f);
-            var img = activeQTEBar.ScheduleNote(null, delay, 2f);
+            float delay = Mathf.Max(0f, cumulative - noteAdvanceTime);
+            var img = activeQTEBar.ScheduleNote(null, delay, noteAdvanceTime);
             preparedNotes.Enqueue(img);
         }
     }
@@ -746,7 +749,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (preparedNotes.Count > 0)
                 noteImage = preparedNotes.Dequeue();
             else if (qteBar != null)
-                noteImage = qteBar.ScheduleNote(icon, 0f, 2f);
+                noteImage = qteBar.ScheduleNote(icon, 0f, noteAdvanceTime);
         }
         else
         {
@@ -897,7 +900,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (preparedNotes.Count > 0)
                 noteImage = preparedNotes.Dequeue();
             else
-                noteImage = qteBar.ScheduleNote(null, 0f, 2f);
+                noteImage = qteBar.ScheduleNote(null, 0f, noteAdvanceTime);
         }
         else
         {


### PR DESCRIPTION
## Résumé
- ajout d'un délai configurable pour l'affichage des notes dans `RhythmQTEManager`
- nettoyage automatique des notes terminées dans `QTEBar`
- centralisation de la durée de déplacement des notes

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688711aa1c9c8325b8a9b2ff3103016b