### PR TITLE
Amélioration du feedback visuel et du rythme des QTE

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
@@ -13,6 +13,11 @@ public class QTEBar : MonoBehaviour
     [SerializeField] private RectTransform validationZone; // Zone de validation à l'extrémité
     [SerializeField] private Image notePrefab;             // Préfab d'icône à instancier pour chaque QTE
 
+    /// <summary>
+    /// Accès à la zone de validation pour placer les effets de résultat.
+    /// </summary>
+    public RectTransform ValidationZone => validationZone;
+
     // Notes directement visibles actuellement
     private readonly List<Image> activeNotes = new();
     // Notes planifiées pour apparaître dans le futur

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -51,6 +51,9 @@ public class RhythmQTEManager : MonoBehaviour
     // QTE Effect
     public AudioClip successSFX;
     public AudioClip failSFX;
+    // Effets visuels pour indiquer le résultat du QTE
+    public GameObject successEffectPrefab;
+    public GameObject failEffectPrefab;
 
     private CharacterUnit currentCaster;
     private CharacterUnit currentTarget;
@@ -219,17 +222,16 @@ public class RhythmQTEManager : MonoBehaviour
             }
         }
 
-        // Si une Timeline a été jouée, on attend sa durée avant de poursuivre
+        // Si une Timeline a été jouée, on attend simplement sa fin sans délai supplémentaire
         if (hasTimeline && move.performingTimeline != null)
         {
-            yield return new WaitForSeconds((float)move.performingTimeline.duration);
+            if (TimelineLauncher.Instance != null)
+                yield return new WaitUntil(() => !TimelineLauncher.Instance.IsTimelineActive);
         }
         else
         {
-            // Sinon on attend simplement la fin de l'animation actuelle
-            float animLength = caster.GetComponentInChildren<Animator>()
-                .GetCurrentAnimatorStateInfo(0).length;
-            yield return new WaitForSeconds(animLength);
+            // Suppression de l'attente fixe afin de garder un rythme fluide
+            yield return null;
         }
 
         if (!move.stayInPlace)
@@ -854,6 +856,21 @@ public class RhythmQTEManager : MonoBehaviour
             Destroy(noteImage.gameObject);
 
         callback?.Invoke(success);
+
+        // Affichage visuel du résultat directement sur la zone de validation
+        if (activeQTEBar != null)
+        {
+            var zone = activeQTEBar.ValidationZone;
+            GameObject effect = success ? successEffectPrefab : failEffectPrefab;
+            if (effect != null && zone != null)
+                Instantiate(effect, zone.position, Quaternion.identity, qteUIParent);
+        }
+
+        // Lecture du son de réussite ou d'échec si disponible
+        if (success)
+            AudioManager.Instance?.PlaySound(successSFX);
+        else
+            AudioManager.Instance?.PlaySound(failSFX);
 
         // 🔺 Retour au temps normal uniquement si le temps a été modifié
         if (easyMode)


### PR DESCRIPTION
## Résumé
- ajout d'un accès public à la zone de validation dans `QTEBar`
- ajout de prefabs d'effets visuels et sonores pour le résultat des QTE
- affichage et son de réussite/échec déclenchés à la fin d'un QTE
- attente finale du `MusicalMove` supprimée pour garder le rythme

## Tests
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68871e6f50408325a8a39c5a42034cdb