### PR TITLE
Ajout animation distorsion avant affichage combat

### DIFF
--- a/Assets/Prefabs/PostProcessManager.prefab
+++ b/Assets/Prefabs/PostProcessManager.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 719114894367732357}
+  - component: {fileID: 1845183541234567890}
   m_Layer: 0
   m_Name: PostProcessManager
   m_TagString: Untagged
@@ -33,6 +34,19 @@ Transform:
   - {fileID: 5335345875442710055}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1845183541234567890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4780225887106794448}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 177d11120cb345dd8ee47d318e7f8090, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  volume: {fileID: 7302210234449089507}
 --- !u!1 &4893570298488046060
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -209,6 +209,10 @@ public class BattleTransitionManager : MonoBehaviour
         int battlefieldIndex = playerDetection.detectedEnemies[0].battlefieldIndex;
         BattlefieldManager.Instance.SetBattlefield(battlefieldIndex);
 
+        // Effet de distorsion pour accentuer le passage en mode combat
+        if (PostProcessManager.Instance != null)
+            yield return StartCoroutine(PostProcessManager.Instance.PulseLensDistortion(1f, 1f));
+
         battleView.SetActive(true);
         versusCamera.SetActive(true);
 

--- a/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// Gère les effets de post-traitement globaux.
+/// Actuellement utilisé pour appliquer une distorsion lors des transitions.
+/// </summary>
+public class PostProcessManager : MonoBehaviour
+{
+    /// <summary>
+    /// Instance unique du gestionnaire de post-traitement.
+    /// </summary>
+    public static PostProcessManager Instance { get; private set; }
+
+    [Tooltip("Volume global contenant les effets de post-processing")]
+    [SerializeField] private Volume volume;
+
+    private LensDistortion lensDistortion;
+    private float baseLensIntensity;
+
+    private void Awake()
+    {
+        // Mise en place du singleton
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        // Récupération du LensDistortion pour sauvegarder son intensité de base
+        if (volume != null && volume.profile != null)
+        {
+            volume.profile.TryGet(out lensDistortion);
+            if (lensDistortion != null)
+                baseLensIntensity = lensDistortion.intensity.value;
+        }
+    }
+
+    /// <summary>
+    /// Fait varier l'intensité du LensDistortion jusqu'à <paramref name="peakIntensity"/>
+    /// puis la ramène à son niveau de base sur la même durée.
+    /// </summary>
+    /// <param name="peakIntensity">Intensité maximale à atteindre.</param>
+    /// <param name="duration">Durée de montée puis de descente en secondes.</param>
+    public IEnumerator PulseLensDistortion(float peakIntensity, float duration)
+    {
+        if (lensDistortion == null)
+            yield break;
+
+        // Montée progressive jusqu'à l'intensité souhaitée
+        float timer = 0f;
+        while (timer < duration)
+        {
+            lensDistortion.intensity.value = Mathf.Lerp(baseLensIntensity, peakIntensity, timer / duration);
+            timer += Time.deltaTime;
+            yield return null;
+        }
+        lensDistortion.intensity.value = peakIntensity;
+
+        // Retour à l'intensité d'origine
+        timer = 0f;
+        while (timer < duration)
+        {
+            lensDistortion.intensity.value = Mathf.Lerp(peakIntensity, baseLensIntensity, timer / duration);
+            timer += Time.deltaTime;
+            yield return null;
+        }
+        lensDistortion.intensity.value = baseLensIntensity;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 177d11120cb345dd8ee47d318e7f8090


### PR DESCRIPTION
## Résumé
- Ajoute un `PostProcessManager` gérant les effets de Lens Distortion
- Déclenche une impulsion de distorsion avant l'activation de la vue de combat

## Tests
- `dotnet test` *(échec : commande introuvable, dépendances non installées)*
- `apt-get update` *(échec : dépôts non signés)*
- `apt-get install -y dotnet-sdk-6.0` *(échec : paquet introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688e3386a2f48325aabfcbc5da0cbc6f