### PR TITLE
Ajout variation contraste pendant distorsion

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
@@ -20,6 +20,10 @@ public class PostProcessManager : MonoBehaviour
     private LensDistortion lensDistortion;
     private float baseLensIntensity;
 
+    // Réglages de couleur
+    private ColorAdjustments colorAdjustments; // composant pour gérer contraste/saturation/etc.
+    private float baseContrast;               // contraste de base pour revenir à l'état initial
+
     private void Awake()
     {
         // Mise en place du singleton
@@ -31,12 +35,17 @@ public class PostProcessManager : MonoBehaviour
         Instance = this;
         DontDestroyOnLoad(gameObject);
 
-        // Récupération du LensDistortion pour sauvegarder son intensité de base
+        // Récupération des effets pour sauvegarder leurs valeurs de base
         if (volume != null && volume.profile != null)
         {
             volume.profile.TryGet(out lensDistortion);
             if (lensDistortion != null)
                 baseLensIntensity = lensDistortion.intensity.value;
+
+            // On récupère également le ColorAdjustments pour pouvoir faire varier le contraste
+            volume.profile.TryGet(out colorAdjustments);
+            if (colorAdjustments != null)
+                baseContrast = colorAdjustments.contrast.value;
         }
     }
 
@@ -48,27 +57,44 @@ public class PostProcessManager : MonoBehaviour
     /// <param name="duration">Durée de montée puis de descente en secondes.</param>
     public IEnumerator PulseLensDistortion(float peakIntensity, float duration)
     {
-        if (lensDistortion == null)
+        // Si aucun effet n'est disponible, on quitte la coroutine
+        if (lensDistortion == null && colorAdjustments == null)
             yield break;
 
         // Montée progressive jusqu'à l'intensité souhaitée
         float timer = 0f;
         while (timer < duration)
         {
-            lensDistortion.intensity.value = Mathf.Lerp(baseLensIntensity, peakIntensity, timer / duration);
+            // Interpolation de l'intensité de la distorsion
+            if (lensDistortion != null)
+                lensDistortion.intensity.value = Mathf.Lerp(baseLensIntensity, peakIntensity, timer / duration);
+
+            // Interpolation du contraste jusqu'à 100
+            if (colorAdjustments != null)
+                colorAdjustments.contrast.value = Mathf.Lerp(baseContrast, 100f, timer / duration);
+
             timer += Time.deltaTime;
             yield return null;
         }
-        lensDistortion.intensity.value = peakIntensity;
+        if (lensDistortion != null)
+            lensDistortion.intensity.value = peakIntensity;
+        if (colorAdjustments != null)
+            colorAdjustments.contrast.value = 100f;
 
         // Retour à l'intensité d'origine
         timer = 0f;
         while (timer < duration)
         {
-            lensDistortion.intensity.value = Mathf.Lerp(peakIntensity, baseLensIntensity, timer / duration);
+            if (lensDistortion != null)
+                lensDistortion.intensity.value = Mathf.Lerp(peakIntensity, baseLensIntensity, timer / duration);
+            if (colorAdjustments != null)
+                colorAdjustments.contrast.value = Mathf.Lerp(100f, baseContrast, timer / duration);
             timer += Time.deltaTime;
             yield return null;
         }
-        lensDistortion.intensity.value = baseLensIntensity;
+        if (lensDistortion != null)
+            lensDistortion.intensity.value = baseLensIntensity;
+        if (colorAdjustments != null)
+            colorAdjustments.contrast.value = baseContrast;
     }
 }


### PR DESCRIPTION
## Résumé
- Anime le contraste du Color Adjustments jusqu'à 100 lors de l'effet de Lens Distortion
- Retour progressif aux valeurs de base après l'impulsion

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_688e3a83d9dc8325aeeb16641bf8537c