### PR TITLE
feat: sprites Versus aléatoires

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -1,11 +1,15 @@
 using UnityEngine;
+using System.Collections.Generic; // Permet l'utilisation de listes génériques
 
 [CreateAssetMenu(fileName = "CharacterData", menuName = "Symphonie/CharacterData")]
 public class CharacterData : ScriptableObject, ITargetable
 {
-    [Header("General Info")]    
+    [Header("General Info")]
     public string characterName;
     public Sprite portrait;
+    // Liste de sprites utilisés pour l'écran Versus et les points d'apparition
+    // Un sprite est choisi aléatoirement lors de l'affichage de l'écran Versus
+    public List<Sprite> versusSprites = new();
     public CharacterType characterType;
     public GameplayType gameplayType = GameplayType.Rage;
     public HarmonicType harmonicType = HarmonicType.Lumiere;

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -108,12 +108,20 @@ public class BattleTransitionManager : MonoBehaviour
         Image[] squadImages = { SU1, SU2, SU3 };
         for (int i = 0; i < squadImages.Length; i++)
         {
-            if (i < squad.Count && squad[i] != null && squad[i].portrait != null)
+            if (i < squad.Count && squad[i] != null)
             {
-                // Affecte le portrait du personnage
-                squadImages[i].sprite = squad[i].portrait;
-                // Assure une opacité totale
-                Color c = squadImages[i].color; c.a = 1f; squadImages[i].color = c;
+                // Récupère la liste des sprites de Versus définie dans le CharacterData
+                List<Sprite> sprites = squad[i].versusSprites;
+                if (sprites != null && sprites.Count > 0)
+                {
+                    // Choisit un sprite aléatoire parmi la liste fournie
+                    squadImages[i].sprite = sprites[Random.Range(0, sprites.Count)];
+                    // Assure une opacité totale pour le sprite sélectionné
+                    Color c = squadImages[i].color; c.a = 1f; squadImages[i].color = c;
+                }
+                // Si la liste est vide ou nulle, on ne modifie pas l'image :
+                // le point d'apparition conserve son sprite actuel
+                // afin d'éviter d'afficher un portrait non désiré.
             }
             else
             {
@@ -127,10 +135,15 @@ public class BattleTransitionManager : MonoBehaviour
         Image[] enemyImages = { EU1, EU2, EU3 };
         for (int i = 0; i < enemyImages.Length; i++)
         {
-            if (i < enemies.Count && enemies[i] != null && enemies[i].portrait != null)
+            if (i < enemies.Count && enemies[i] != null)
             {
-                enemyImages[i].sprite = enemies[i].portrait;
-                Color c = enemyImages[i].color; c.a = 1f; enemyImages[i].color = c;
+                List<Sprite> sprites = enemies[i].versusSprites;
+                if (sprites != null && sprites.Count > 0)
+                {
+                    enemyImages[i].sprite = sprites[Random.Range(0, sprites.Count)];
+                    Color c = enemyImages[i].color; c.a = 1f; enemyImages[i].color = c;
+                }
+                // Liste vide : ne rien affecter pour laisser le sprite existant
             }
             else
             {


### PR DESCRIPTION
## Résumé
- ajoute une liste `versusSprites` dans `CharacterData`
- affiche un sprite aléatoire aux points d'apparition lors de l'écran Versus

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : référentiels non signés)*

------
https://chatgpt.com/codex/tasks/task_e_688e59adc850832597677f69a0d75be9