### PR TITLE
Gestion temporaire des ennemis en combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -333,12 +333,22 @@ public class BattleTransitionManager : MonoBehaviour
         if (NewBattleManager.Instance != null && NewBattleManager.Instance.enemyTemplates.Count > 0)
             battlefieldIndex = NewBattleManager.Instance.enemyTemplates[0].battlefieldIndex;
 
+        // Nous récupérons ici le composant PlayerDetection afin de pouvoir
+        // manipuler la liste temporaire des ennemis en combat.
+        playerDetection ??= FindFirstObjectByType<PlayerDetection>();
+
         // Suppression des ennemis vaincus présents dans le monde
         var worldEnemies = FindObjectsOfType<Enemy>().Where(e => e.wasPartOfLastBattle).ToList();
         foreach (var enemy in worldEnemies)
         {
+            // On retire l'ennemi de la liste afin qu'il ne puisse plus être redétecté
+            playerDetection.enemiesInFight.Remove(enemy);
+
             Destroy(enemy);
         }
+
+        // Par sécurité, on vide la liste au cas où il resterait des références
+        playerDetection.enemiesInFight.Clear();
 
         // Réinstanciation des battlefields pour revenir à un état propre et
         // conservation uniquement de celui correspondant au combat effectué
@@ -346,7 +356,7 @@ public class BattleTransitionManager : MonoBehaviour
 
         GameManager.Instance.ChangeGameState(GameState.Exploration);
 
-        playerDetection ??= FindFirstObjectByType<PlayerDetection>();
+        // Réactive la détection après un court délai
         playerDetection.ResetDetection(1f);
 
         //Switch Battle vers World

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -25,6 +25,13 @@ public class PlayerDetection : MonoBehaviour
     [Tooltip("Tag utilisé pour identifier les ennemis (par exemple : \"Enemy\").")]
     public string enemyTag = "Enemy";
 
+    // ------------------------------------------------------------------
+    // Liste temporaire des ennemis actuellement engagés dans un combat
+    // Permet d'éviter de redétecter en boucle les mêmes ennemis tant
+    // qu'ils ne sont pas définitivement retirés du monde.
+    // ------------------------------------------------------------------
+    public List<Enemy> enemiesInFight = new List<Enemy>();
+
     public List<CharacterData> detectedEnemies = new List<CharacterData>();
     public bool detectionOn = true;
 
@@ -50,7 +57,9 @@ public class PlayerDetection : MonoBehaviour
 
     private void CleanupInvalidFields()
     {
+        // Nettoie les références invalides pour éviter les fuites d'objets
         detectedEnemies.RemoveAll(c => c == null);
+        enemiesInFight.RemoveAll(e => e == null);
     }
 
     private void HandleEnemyDetection()
@@ -96,7 +105,8 @@ public class PlayerDetection : MonoBehaviour
         // 6) On récupère le composant Enemy (ou le parent contenant Enemy), en évitant les doublons
         var enemies = allHits
             .Select(c => c.GetComponentInParent<Enemy>())
-            .Where(e => e != null)
+            // On ignore les ennemis déjà engagés dans un combat
+            .Where(e => e != null && !enemiesInFight.Contains(e))
             .Distinct()
             .ToList();
 
@@ -114,6 +124,9 @@ public class PlayerDetection : MonoBehaviour
 
             // On marque l'ennemi comme ayant participé à la dernière bataille
             e.wasPartOfLastBattle = true;
+
+            // Ajout à la liste temporaire pour empêcher une redétection
+            enemiesInFight.Add(e);
         }
 
         // 9) On déclenche ou termine le combat


### PR DESCRIPTION
## Résumé
- Empêche la redétection des ennemis déjà engagés grâce à une liste `enemiesInFight`.
- Nettoie et détruit les ennemis vaincus lors du retour au monde après une victoire.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : 403 Forbidden lors de la tentative d'installation de dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_688e64f7444c8325bb4f83d68f67cf77