### PR TITLE
Gestion temporaire des ennemis en combat

### DIFF
--- a/Assets/Characters/Perfecteur/Enemy_Perfecteur_World.prefab
+++ b/Assets/Characters/Perfecteur/Enemy_Perfecteur_World.prefab
@@ -92,6 +92,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemyData: {fileID: 11400000, guid: 12f79091fcc9dac468a0b815f88bf248, type: 2}
-  wasPartOfLastBattle: 0
   isDead: 0
   allMats: []

--- a/Assets/Characters/Velum/Boss_Velum_World.prefab
+++ b/Assets/Characters/Velum/Boss_Velum_World.prefab
@@ -45,7 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemyData: {fileID: 11400000, guid: 6f5c94983e969874dbb5c017d8a5749e, type: 2}
-  wasPartOfLastBattle: 0
   isDead: 0
   allMats: []
 --- !u!1 &6879597562796817292

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -333,12 +333,23 @@ public class BattleTransitionManager : MonoBehaviour
         if (NewBattleManager.Instance != null && NewBattleManager.Instance.enemyTemplates.Count > 0)
             battlefieldIndex = NewBattleManager.Instance.enemyTemplates[0].battlefieldIndex;
 
+        // Nous récupérons ici le composant PlayerDetection afin de pouvoir
+        // manipuler la liste temporaire des ennemis en combat.
+        playerDetection ??= FindFirstObjectByType<PlayerDetection>();
+
         // Suppression des ennemis vaincus présents dans le monde
-        var worldEnemies = FindObjectsOfType<Enemy>().Where(e => e.wasPartOfLastBattle).ToList();
+        // La liste enemiesInFight contient déjà uniquement les ennemis engagés
+        var worldEnemies = playerDetection.enemiesInFight.ToList();
         foreach (var enemy in worldEnemies)
         {
+            // On retire l'ennemi de la liste afin qu'il ne puisse plus être redétecté
+            playerDetection.enemiesInFight.Remove(enemy);
+
             Destroy(enemy);
         }
+
+        // Par sécurité, on vide la liste au cas où il resterait des références
+        playerDetection.enemiesInFight.Clear();
 
         // Réinstanciation des battlefields pour revenir à un état propre et
         // conservation uniquement de celui correspondant au combat effectué
@@ -346,7 +357,7 @@ public class BattleTransitionManager : MonoBehaviour
 
         GameManager.Instance.ChangeGameState(GameState.Exploration);
 
-        playerDetection ??= FindFirstObjectByType<PlayerDetection>();
+        // Réactive la détection après un court délai
         playerDetection.ResetDetection(1f);
 
         //Switch Battle vers World
@@ -364,7 +375,6 @@ public class BattleTransitionManager : MonoBehaviour
 
         HideVictoryPanel();
         HideGameOverPanel();
-        ResetBattleFlagsOnAllEnemies();
         NewBattleManager.Instance.ResetBattleInfos();
 
         AudioManager.Instance.ReturnFromBattle();
@@ -576,15 +586,6 @@ public class BattleTransitionManager : MonoBehaviour
 
     private void HideVictoryPanel() => NewBattleManager.Instance.victoryScreen?.transform.GetChild(0).gameObject.SetActive(false);
     private void HideGameOverPanel() => NewBattleManager.Instance.gameOverScreen?.transform.GetChild(0).gameObject.SetActive(false);
-
-    /// <summary>
-    /// Nettoie le flag de participation au combat pour tous les ennemis.
-    /// </summary>
-    public void ResetBattleFlagsOnAllEnemies()
-    {
-        foreach (var enemy in FindObjectsOfType<Enemy>())
-            enemy.wasPartOfLastBattle = false;
-    }
 
     #endregion
 }

--- a/Assets/Scripts/MonoBehavioursUsed/Enemy.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/Enemy.cs
@@ -8,7 +8,6 @@ using System.Collections;
 public class Enemy : MonoBehaviour
 {
     public CharacterData enemyData;
-    public bool wasPartOfLastBattle;
     public bool isDead;
 
     private bool dissolveFadeOn;
@@ -41,22 +40,7 @@ public class Enemy : MonoBehaviour
         }
     }
 
-    void Update()
-    {
-        if (wasPartOfLastBattle)
-        {
-            // Lance la progression du dissolve tant que l'effet est activé
-            if (!dissolveFadeOn)
-            {
-                PlayDissolve();
 
-                if (!isDead)
-                {
-                    StartCoroutine(Die());
-                }
-            }
-        }
-    }
 
     public void DissolveFadeOn()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -25,6 +25,13 @@ public class PlayerDetection : MonoBehaviour
     [Tooltip("Tag utilisé pour identifier les ennemis (par exemple : \"Enemy\").")]
     public string enemyTag = "Enemy";
 
+    // ------------------------------------------------------------------
+    // Liste temporaire des ennemis actuellement engagés dans un combat
+    // Permet d'éviter de redétecter en boucle les mêmes ennemis tant
+    // qu'ils ne sont pas définitivement retirés du monde.
+    // ------------------------------------------------------------------
+    public List<Enemy> enemiesInFight = new List<Enemy>();
+
     public List<CharacterData> detectedEnemies = new List<CharacterData>();
     public bool detectionOn = true;
 
@@ -50,7 +57,9 @@ public class PlayerDetection : MonoBehaviour
 
     private void CleanupInvalidFields()
     {
+        // Nettoie les références invalides pour éviter les fuites d'objets
         detectedEnemies.RemoveAll(c => c == null);
+        enemiesInFight.RemoveAll(e => e == null);
     }
 
     private void HandleEnemyDetection()
@@ -96,7 +105,8 @@ public class PlayerDetection : MonoBehaviour
         // 6) On récupère le composant Enemy (ou le parent contenant Enemy), en évitant les doublons
         var enemies = allHits
             .Select(c => c.GetComponentInParent<Enemy>())
-            .Where(e => e != null)
+            // On ignore les ennemis déjà engagés dans un combat
+            .Where(e => e != null && !enemiesInFight.Contains(e))
             .Distinct()
             .ToList();
 
@@ -112,8 +122,9 @@ public class PlayerDetection : MonoBehaviour
         {
             detectedEnemies.Add(e.enemyData);
 
-            // On marque l'ennemi comme ayant participé à la dernière bataille
-            e.wasPartOfLastBattle = true;
+            // Ajout à la liste temporaire pour empêcher une redétection
+            // et indiquer que cet ennemi est actuellement engagé dans ce combat
+            enemiesInFight.Add(e);
         }
 
         // 9) On déclenche ou termine le combat


### PR DESCRIPTION
## Résumé
- Retire tout usage du flag `wasPartOfLastBattle` et s'appuie uniquement sur `enemiesInFight` pour suivre les ennemis engagés
- Nettoie les scripts et prefabs des références obsolètes

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e64f7444c8325bb4f83d68f67cf77