### PR TITLE
Permettre le réglage du volume et la sélection aléatoire de firstDetectionVoice

### DIFF
--- a/Assets/Characters/Lucian/Lucian_World_Mannequin.prefab
+++ b/Assets/Characters/Lucian/Lucian_World_Mannequin.prefab
@@ -262,7 +262,8 @@ MonoBehaviour:
   enemyTag: Enemy
   detectedEnemies: []
   detectionOn: 1
-  firstDetectionVoice: {fileID: 0}
+  firstDetectionVoices: []
+  firstDetectionVoiceVolume: 1
   battleEngaged: 0
 --- !u!114 &6698838017724509974
 MonoBehaviour:

--- a/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
@@ -275,9 +275,9 @@ public class AudioManager : MonoBehaviour
         sfxSource.PlayOneShot(clip, factor);
     }
 
-    public void PlayVoice(int index) => PlayVoice(voiceEffects[index]);
+    public void PlayVoice(int index, float volume = 1f) => PlayVoice(voiceEffects[index], volume);
 
-    public void PlayVoice(AudioClip clip)
+    public void PlayVoice(AudioClip clip, float volume = 1f)
     {
         if (clip == null) return;
 
@@ -285,7 +285,10 @@ public class AudioManager : MonoBehaviour
         AudioSource tempSource = Instantiate(voiceSource, transform);
         tempSource.playOnAwake = false;
         tempSource.clip = clip;
-        tempSource.volume = voiceVolume * GetNormalizationFactor(clip);
+
+        // Application du volume global des voix, du volume personnalisé et de la normalisation
+        tempSource.volume = voiceVolume * volume * GetNormalizationFactor(clip);
+
         tempSource.Play();
         Destroy(tempSource.gameObject, clip.length);
     }

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -36,8 +36,13 @@ public class PlayerDetection : MonoBehaviour
     public bool detectionOn = true;
 
     [Header("Effets sonores")]
-    [Tooltip("Clip vocal joué lors de la première détection d'un ennemi")]
-    public AudioClip firstDetectionVoice;
+    [Tooltip("Clips vocaux joués lors de la première détection d'un ennemi")]
+    public List<AudioClip> firstDetectionVoices = new List<AudioClip>();
+
+    [Tooltip("Volume appliqué au clip de première détection")]
+    [Range(0f, 1f)]
+    public float firstDetectionVoiceVolume = 1f;
+
     private bool firstEnemyDetected;
 
     [Header("State")]
@@ -67,9 +72,14 @@ public class PlayerDetection : MonoBehaviour
         if (!detectionOn)
             return;
 
-        if (!firstEnemyDetected && firstDetectionVoice != null)
+        if (!firstEnemyDetected && firstDetectionVoices.Count > 0)
         {
-            AudioManager.Instance?.PlayVoice(firstDetectionVoice);
+            // Sélection aléatoire d'un clip parmi la liste disponible
+            AudioClip clip = firstDetectionVoices[UnityEngine.Random.Range(0, firstDetectionVoices.Count)];
+
+            // Lecture du clip avec le volume choisi dans l'inspecteur
+            AudioManager.Instance?.PlayVoice(clip, firstDetectionVoiceVolume);
+
             firstEnemyDetected = true;
         }
 


### PR DESCRIPTION
## Résumé
- Autorise le paramétrage du volume de la voix de première détection via l'inspecteur
- Sélectionne un clip vocal aléatoire lors de la première détection d'un ennemi
- Ajoute un paramètre de volume optionnel aux lectures de voix dans l'AudioManager

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b1f25208325a933f01c44244d54