### PR TITLE
Fix: suppression des ennemis vaincus dans le World

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -344,8 +344,10 @@ public class BattleTransitionManager : MonoBehaviour
         {
             // On retire l'ennemi de la liste afin qu'il ne puisse plus être redétecté
             playerDetection.enemiesInFight.Remove(enemy);
-
-            Destroy(enemy);
+            // Destruction complète de l'objet ennemi dans le World pour
+            // éviter qu'il ne persiste après la victoire du joueur
+            if (enemy != null)
+                Destroy(enemy.gameObject);
         }
 
         // Par sécurité, on vide la liste au cas où il resterait des références


### PR DESCRIPTION
## Résumé
- détruit complètement les ennemis vaincus dans le World après une victoire

## Test
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_688e6db15f908325b9ab8fae40a842d9