### PR TITLE
Amélioration des transitions World/Battle

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -230,10 +230,10 @@ public class BattleTransitionManager : MonoBehaviour
     /// </summary>
     private IEnumerator TransitionRoutine()
     {
-        // Prépare le champ de bataille sans instanciation coûteuse
+        // Détermine quel champ de bataille doit être chargé en fonction de
+        // l'ennemi détecté par le joueur.
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
         int battlefieldIndex = playerDetection.detectedEnemies[0].battlefieldIndex;
-        BattlefieldManager.Instance.SetBattlefield(battlefieldIndex);
 
         // Effet de distorsion pour accentuer le passage en mode combat
         if (PostProcessManager.Instance != null)
@@ -259,9 +259,16 @@ public class BattleTransitionManager : MonoBehaviour
         UpdateVersusPortraits();
         unitSpawnPointsAnimator?.Play("VersusLaunched");
 
+        // Pendant que l'écran de Versus est affiché, on charge uniquement le
+        // champ de bataille correspondant à l'ennemi rencontré. L'action
+        // "Confirm" ne sera disponible qu'une fois ce chargement terminé afin
+        // d'éviter toute validation prématurée.
+        yield return StartCoroutine(BattlefieldManager.Instance.LoadBattlefield(battlefieldIndex));
+
         // --- Attente de la confirmation du joueur ---
-        // On active temporairement l'action "Confirm" afin de laisser le joueur
-        // valider l'écran de Versus à son rythme avant de poursuivre la transition.
+        // L'écran de Versus reste jusqu'à ce que le joueur appuie sur
+        // "Confirm". Cette action vient d'être rendue disponible car le
+        // battlefield est prêt.
         InputAction confirmAction = InputsManager.Instance.playerInputs.Battle.Confirm;
         confirmAction.Enable();
         yield return new WaitUntil(() => confirmAction.triggered);
@@ -328,11 +335,6 @@ public class BattleTransitionManager : MonoBehaviour
 
         //yield return FadeToBlack(2f);
 
-        // On récupère l'indice du champ de bataille utilisé pendant ce combat
-        int battlefieldIndex = 0;
-        if (NewBattleManager.Instance != null && NewBattleManager.Instance.enemyTemplates.Count > 0)
-            battlefieldIndex = NewBattleManager.Instance.enemyTemplates[0].battlefieldIndex;
-
         // Nous récupérons ici le composant PlayerDetection afin de pouvoir
         // manipuler la liste temporaire des ennemis en combat.
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
@@ -352,10 +354,6 @@ public class BattleTransitionManager : MonoBehaviour
 
         // Par sécurité, on vide la liste au cas où il resterait des références
         playerDetection.enemiesInFight.Clear();
-
-        // Réinstanciation des battlefields pour revenir à un état propre et
-        // conservation uniquement de celui correspondant au combat effectué
-        BattlefieldManager.Instance?.RebuildBattlefieldsKeeping(battlefieldIndex);
 
         GameManager.Instance.ChangeGameState(GameState.Exploration);
 
@@ -377,7 +375,6 @@ public class BattleTransitionManager : MonoBehaviour
 
         HideVictoryPanel();
         HideGameOverPanel();
-        NewBattleManager.Instance.ResetBattleInfos();
 
         AudioManager.Instance.ReturnFromBattle();
 
@@ -393,6 +390,14 @@ public class BattleTransitionManager : MonoBehaviour
         {
             SaveAndLoadManager.Instance.AutoSave();
         }
+
+        // Attente avant de supprimer le champ de bataille pour laisser le temps
+        // au joueur de revenir visuellement dans le monde.
+        yield return new WaitForSecondsRealtime(1f);
+
+        // Destruction complète du battlefield et remise à zéro des infos du combat
+        BattlefieldManager.Instance?.UnloadCurrentBattlefield();
+        NewBattleManager.Instance?.ResetBattleInfos();
 
         //yield return FadeToTransparent(1f);
 

--- a/Assets/Scripts/MonoBehavioursUsed/BattlefieldManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattlefieldManager.cs
@@ -1,6 +1,12 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
+using UnityEngine;
+using System.Collections;
 
+/// <summary>
+/// Gère le champ de bataille actuellement utilisé. Contrairement à l'ancien
+/// fonctionnement, un seul battlefield est instancié à la fois et uniquement
+/// lorsque le combat débute. Cette approche limite la consommation mémoire et
+/// évite des destructions inutiles.
+/// </summary>
 public class BattlefieldManager : MonoBehaviour
 {
     public static BattlefieldManager Instance { get; private set; }
@@ -8,11 +14,10 @@ public class BattlefieldManager : MonoBehaviour
     [Header("Zone active (copiée depuis ZoneManager)")]
     public ZoneSO currentZone;
 
-    // Références instanciées des battlefields courants pour éviter la création
-    // pendant la transition de combat
-    private readonly List<GameObject> instantiatedBattlefields = new();
+    // Référence vers le battlefield actuellement instancié
+    private GameObject currentBattlefield;
 
-    // Parent dans la hiérarchie pour accueillir les battlefields instanciés
+    // Parent dans la hiérarchie pour accueillir le battlefield instancié
     [SerializeField] private Transform battlefieldParent;
 
     private void Awake()
@@ -25,15 +30,14 @@ public class BattlefieldManager : MonoBehaviour
         Instance = this;
         DontDestroyOnLoad(gameObject);
 
-        // Tente de trouver le parent des battlefields si non assigné dans
-        // l'inspecteur pour garantir la cohérence en jeu.
+        // Recherche automatique du parent si besoin pour éviter les erreurs
         if (battlefieldParent == null)
-            battlefieldParent = GameObject
-                .Find("BattleScene/Battlefields")?.transform;
+            battlefieldParent = GameObject.Find("BattleScene/Battlefields")?.transform;
     }
 
     /// <summary>
-    /// Appelée par ZoneManager quand la zone change.
+    /// Appelée par le <see cref="ZoneManager"/> lorsque la zone change.
+    /// Détruit le battlefield courant et mémorise la nouvelle zone.
     /// </summary>
     public void SetCurrentZone(ZoneSO zone)
     {
@@ -45,125 +49,59 @@ public class BattlefieldManager : MonoBehaviour
 
         currentZone = zone;
 
-        // Détruit les battlefields précédemment instanciés pour libérer la mémoire
-        foreach (var bf in instantiatedBattlefields)
-            if (bf != null)
-                Destroy(bf);
-        instantiatedBattlefields.Clear();
+        // Si un battlefield était encore présent, on le retire pour repartir propre
+        UnloadCurrentBattlefield();
 
         if (battlefieldParent == null)
-            battlefieldParent = GameObject
-                .Find("BattleScene/Battlefields")?.transform;
-
-        // Instancie tous les battlefields dès le changement de zone pour éviter
-        // un chargement brutal lors de l'entrée en combat
-        foreach (var prefab in currentZone.battlefields)
-        {
-            if (prefab == null) continue;
-
-            var instance = Instantiate(prefab, battlefieldParent.position,
-                Quaternion.identity, battlefieldParent);
-            instance.SetActive(false);
-            instantiatedBattlefields.Add(instance);
-        }
-
-        ActivateFirstBattlefieldInZone();
+            battlefieldParent = GameObject.Find("BattleScene/Battlefields")?.transform;
     }
 
     /// <summary>
-    /// Active le premier battlefield de la zone active, désactive les autres.
+    /// Instancie le battlefield correspondant à l'indice fourni. Cette méthode
+    /// est appelée pendant l'écran de Versus, avant que le joueur ne confirme le
+    /// début du combat.
     /// </summary>
-    private void ActivateFirstBattlefieldInZone()
-    {
-        if (currentZone == null || currentZone.battlefields.Count == 0)
-        {
-            Debug.LogWarning("[BattlefieldManager] Pas de battlefield pour cette zone !");
-            return;
-        }
-
-        for (int i = 0; i < instantiatedBattlefields.Count; i++)
-        {
-            if (instantiatedBattlefields[i] != null)
-                instantiatedBattlefields[i].SetActive(i == 0);
-        }
-
-        Debug.Log($"[BattlefieldManager] Premier battlefield activé pour : {currentZone.zoneName}");
-    }
-
-    /// <summary>
-    /// Active un battlefield spécifique dans la zone active.
-    /// </summary>
-    public void SetBattlefield(int index)
-    {
-        if (currentZone == null || instantiatedBattlefields.Count == 0)
-        {
-            Debug.LogWarning("[BattlefieldManager] Zone invalide ou vide !");
-            return;
-        }
-
-        if (index < 0 || index >= instantiatedBattlefields.Count)
-        {
-            Debug.LogWarning($"[BattlefieldManager] Index {index} invalide pour {currentZone.zoneName}");
-            return;
-        }
-
-        for (int i = 0; i < instantiatedBattlefields.Count; i++)
-        {
-            if (instantiatedBattlefields[i] != null)
-                instantiatedBattlefields[i].SetActive(i == index);
-        }
-
-        Debug.Log($"[BattlefieldManager] Battlefield #{index} activé pour {currentZone.zoneName}");
-    }
-
-    /// <summary>
-    /// Réinstancie tous les battlefields de la zone pour revenir à un état
-    /// propre, puis ne conserve que celui correspondant à l'indice fourni.
-    /// Cette méthode est pensée pour être appelée en fin de combat afin de
-    /// libérer la mémoire des champs non utilisés sans impacter les performances.
-    /// </summary>
-    /// <param name="index">Indice du battlefield à conserver actif.</param>
-    public void RebuildBattlefieldsKeeping(int index)
+    public IEnumerator LoadBattlefield(int index)
     {
         if (currentZone == null)
         {
-            Debug.LogWarning("[BattlefieldManager] Aucune zone active, impossible de réinstancier les battlefields.");
-            return;
+            Debug.LogWarning("[BattlefieldManager] Aucune zone active, impossible de charger un battlefield.");
+            yield break;
         }
 
-        // On détruit les anciennes instances pour repartir sur des versions neuves
-        foreach (var bf in instantiatedBattlefields)
-            if (bf != null)
-                Destroy(bf);
-        instantiatedBattlefields.Clear();
+        if (index < 0 || index >= currentZone.battlefields.Count)
+        {
+            Debug.LogWarning($"[BattlefieldManager] Index {index} invalide pour {currentZone.zoneName}");
+            yield break;
+        }
 
         if (battlefieldParent == null)
-            battlefieldParent = GameObject
-                .Find("BattleScene/Battlefields")?.transform;
+            battlefieldParent = GameObject.Find("BattleScene/Battlefields")?.transform;
 
-        // On recrée chaque battlefield de la zone mais on ne garde en mémoire
-        // que celui utilisé lors du combat pour limiter la consommation.
-        for (int i = 0; i < currentZone.battlefields.Count; i++)
+        // Détruit l'ancien champ de bataille s'il existe déjà
+        UnloadCurrentBattlefield();
+
+        // Instanciation du prefab voulu et activation immédiate
+        var prefab = currentZone.battlefields[index];
+        currentBattlefield = Instantiate(prefab, battlefieldParent.position, Quaternion.identity, battlefieldParent);
+        currentBattlefield.SetActive(true);
+
+        // On laisse une frame pour s'assurer que tous les éléments sont correctement initialisés
+        yield return null;
+
+        Debug.Log($"[BattlefieldManager] Battlefield #{index} chargé pour {currentZone.zoneName}.");
+    }
+
+    /// <summary>
+    /// Détruit le battlefield actuellement chargé, s'il existe.
+    /// </summary>
+    public void UnloadCurrentBattlefield()
+    {
+        if (currentBattlefield != null)
         {
-            var prefab = currentZone.battlefields[i];
-            if (prefab == null) continue;
-
-            var instance = Instantiate(prefab, battlefieldParent.position,
-                Quaternion.identity, battlefieldParent);
-
-            if (i == index)
-            {
-                // On conserve l'instance et on l'active immédiatement
-                instance.SetActive(true);
-                instantiatedBattlefields.Add(instance);
-            }
-            else
-            {
-                // Les autres ne sont pas nécessaires et sont détruits aussitôt
-                Destroy(instance);
-            }
+            Destroy(currentBattlefield);
+            currentBattlefield = null;
+            Debug.Log("[BattlefieldManager] Battlefield courant détruit.");
         }
-
-        Debug.Log($"[BattlefieldManager] Battlefields réinstanciés, conservation de l'index {index}.");
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1637,8 +1637,10 @@ public class NewBattleManager : MonoBehaviour
 
         GameObject continueButton = FindChildRecursive(victoryScreen.transform.GetChild(0), "BattleScene_UI_VictoryPanel_Continue").gameObject;
 
-        CleanupAllSpawnedUnits();
-
+        // Les unités restent désormais en place durant l'écran de victoire afin
+        // que le joueur puisse admirer le champ de bataille tel qu'il était au
+        // moment de la victoire. Leur suppression se fera plus tard, au retour
+        // dans le monde.
         ChangeBattleState(BattleState.VictoryScreen_CanContinue);
     }
 


### PR DESCRIPTION
## Résumé
- Conserve désormais les unités visibles sur l'écran de victoire pour préserver la mise en scène
- Charge le champ de bataille pendant l'écran de Versus et n'active la confirmation qu'une fois le chargement terminé
- Lors du retour dans le monde, attend une seconde avant de supprimer le champ de bataille

## Tests
- `dotnet test` *(échec : command not found)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_688efb0836008325a3bf35852d12726a