### PR TITLE
Réorganisation des caméras

### DIFF
--- a/Assets/Prefabs/CameraSystem.prefab
+++ b/Assets/Prefabs/CameraSystem.prefab
@@ -781,6 +781,227 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+# Caméra dédiée à l'écran Versus.
+--- !u!1 &9000000000000000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9000000000000000001}
+  m_Layer: 0
+  m_Name: VersusCamera_Origin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9000000000000000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000000000000000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9000000000000000003}
+  m_Father: {fileID: 8880738752486701099}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9000000000000000002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9000000000000000003}
+  - component: {fileID: 9000000000000000004}
+  - component: {fileID: 9000000000000000005}
+  m_Layer: 0
+  m_Name: VersusCamera_Cam
+  m_TagString: VersusCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &9000000000000000003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000000000000000002}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9000000000000000001}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &9000000000000000004
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000000000000000002}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 1
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 20.78461
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60.000004
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 32768
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 8400000, guid: 7b71ed7b05dae8248a3cd98e50f3fb59, type: 2}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &9000000000000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9000000000000000002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  clearColorMode: 0
+  backgroundColorHDR: {r: 0.24622889, g: 0.6894409, b: 1.8713396, a: 1}
+  clearDepth: 1
+  volumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  volumeAnchorOverride: {fileID: 0}
+  antialiasing: 0
+  SMAAQuality: 2
+  dithering: 0
+  stopNaNs: 0
+  taaSharpenStrength: 0.5
+  TAAQuality: 1
+  taaSharpenMode: 0
+  taaRingingReduction: 0
+  taaHistorySharpening: 0.35
+  taaAntiFlicker: 0.5
+  taaMotionVectorRejection: 0
+  taaAntiHistoryRinging: 0
+  taaBaseBlendFactor: 0.875
+  taaJitterScale: 1
+  physicalParameters:
+    m_Iso: 200
+    m_ShutterSpeed: 0.005
+    m_Aperture: 16
+    m_FocusDistance: 10
+    m_BladeCount: 5
+    m_Curvature: {x: 2, y: 11}
+    m_BarrelClipping: 0.25
+    m_Anamorphism: 0
+  flipYMode: 0
+  xrRendering: 1
+  fullscreenPassthrough: 0
+  allowDynamicResolution: 1
+  customRenderingSettings: 0
+  invertFaceCulling: 0
+  probeLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  hasPersistentHistory: 0
+  screenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  screenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  allowDeepLearningSuperSampling: 1
+  deepLearningSuperSamplingUseCustomQualitySettings: 0
+  deepLearningSuperSamplingQuality: 0
+  deepLearningSuperSamplingUseCustomAttributes: 0
+  deepLearningSuperSamplingUseOptimalSettings: 1
+  deepLearningSuperSamplingSharpening: 0
+  allowFidelityFX2SuperResolution: 1
+  fidelityFX2SuperResolutionUseCustomQualitySettings: 0
+  fidelityFX2SuperResolutionQuality: 0
+  fidelityFX2SuperResolutionUseCustomAttributes: 0
+  fidelityFX2SuperResolutionUseOptimalSettings: 1
+  fidelityFX2SuperResolutionEnableSharpening: 0
+  fidelityFX2SuperResolutionSharpening: 0
+  fsrOverrideSharpness: 0
+  fsrSharpness: 0.92
+  exposureTarget: {fileID: 0}
+  materialMipBias: 0
+  m_RenderingPathCustomFrameSettings:
+    bitDatas:
+      data1: 5770166122053453
+      data2: 12934340311651418136
+    lodBias: 1
+    lodBiasMode: 0
+    lodBiasQualityLevel: 0
+    maximumLODLevel: 0
+    maximumLODLevelMode: 0
+    maximumLODLevelQualityLevel: 0
+    sssQualityMode: 0
+    sssQualityLevel: 0
+    sssCustomSampleBudget: 20
+    sssCustomDownsampleSteps: 0
+    msaaMode: 1
+    materialQuality: 0
+  renderingPathCustomFrameSettingsOverrideMask:
+    mask:
+      data1: 0
+      data2: 0
+  defaultFrameSettings: 0
+  m_Version: 9
+  m_ObsoleteRenderingPath: 0
+  m_ObsoleteFrameSettings:
+    overrides: 0
+    enableShadow: 0
+    enableContactShadows: 0
+    enableShadowMask: 0
+    enableSSR: 0
+    enableSSAO: 0
+    enableSubsurfaceScattering: 0
+    enableTransmission: 0
+    enableAtmosphericScattering: 0
 --- !u!1 &485965472886689120
 GameObject:
   m_ObjectHideFlags: 0
@@ -3265,7 +3486,7 @@ GameObject:
   - component: {fileID: 4363371865259279654}
   m_Layer: 0
   m_Name: WorldCam_Cam
-  m_TagString: MainCamera
+  m_TagString: WorldCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15940,7 +16161,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1003267776368270276}
-  m_Father: {fileID: 8880738752486701099}
+  m_Father: {fileID: 9000000000000000011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &572623006689659917
 Animator:
@@ -16761,8 +16982,41 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
---- !u!1 &7114451846626177786
-GameObject:
+ # Racine de la caméra principale affichant les RenderTextures.
+ --- !u!1 &9000000000000000010
+ GameObject:
+   m_ObjectHideFlags: 0
+   m_CorrespondingSourceObject: {fileID: 0}
+   m_PrefabInstance: {fileID: 0}
+   m_PrefabAsset: {fileID: 0}
+   serializedVersion: 6
+   m_Component:
+   - component: {fileID: 9000000000000000011}
+   m_Layer: 0
+   m_Name: MainCam_Origin
+   m_TagString: Untagged
+   m_Icon: {fileID: 0}
+   m_NavMeshLayer: 0
+   m_StaticEditorFlags: 0
+   m_IsActive: 1
+ --- !u!4 &9000000000000000011
+ Transform:
+   m_ObjectHideFlags: 0
+   m_CorrespondingSourceObject: {fileID: 0}
+   m_PrefabInstance: {fileID: 0}
+   m_PrefabAsset: {fileID: 0}
+   m_GameObject: {fileID: 9000000000000000010}
+   serializedVersion: 2
+   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+   m_LocalPosition: {x: 0, y: 0, z: 0}
+   m_LocalScale: {x: 1, y: 1, z: 1}
+   m_ConstrainProportionsScale: 0
+   m_Children:
+   - {fileID: 6564914095726041747}
+   m_Father: {fileID: 8880738752486701099}
+   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+ --- !u!1 &7114451846626177786
+ GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -16794,7 +17048,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8516352136087659374}
-  m_Father: {fileID: 8880738752486701099}
+  m_Father: {fileID: 9000000000000000011}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &5679955348845280201
 Camera:
@@ -17247,9 +17501,10 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6564914095726041747}
+  - {fileID: 9000000000000000011}
   - {fileID: 4404067103561339277}
   - {fileID: 8597106134693971932}
+  - {fileID: 9000000000000000001}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8018669232544184903
@@ -17268,6 +17523,7 @@ MonoBehaviour:
   - {fileID: 5679955348845280201}
   - {fileID: 4605328247781518619}
   - {fileID: 7190180004927539597}
+  - {fileID: 9000000000000000004}
   currentWorldCameraState: 0
   pathPosition: 0
   isFollowingPath: 0

--- a/Docs/CameraHierarchy.md
+++ b/Docs/CameraHierarchy.md
@@ -1,0 +1,42 @@
+# Hiérarchie des caméras
+
+Ce document décrit la nouvelle organisation des quatre caméras utilisées dans le jeu. Chaque caméra possède un objet *Origin* servant de pivot et un objet *Cam* contenant le composant `Camera`. Cette structure homogène facilite la lecture et la maintenance.
+
+## Caméra principale
+- **MainCam_Origin**
+  - Parent commun pour la caméra finale qui affiche à l'écran les différents `RenderTexture`.
+- **MainCam_Cam** (`tag` : `MainCamera`)
+  - Caméra affichée à l'écran.
+  - Elle sélectionne dynamiquement la `RenderTexture` à présenter selon le contexte (monde, combat, versus).
+
+## Caméra du monde
+- **WorldCam_Origin**
+  - Pivot de la caméra explorant l'overworld.
+- **WorldCam_Cam** (`tag` : `WorldCamera`)
+  - Rend vers `RT_WorldView`.
+  - Contrôlée par `CameraController` pour suivre le joueur.
+
+## Caméra de combat
+- **BattleCamera_Origin**
+  - Point de base pour les déplacements de la caméra de combat.
+- **BattleCamera_Cam** (`tag` : `BattleCamera`)
+  - Rend vers `RT_BattleView`.
+  - Activée lors des confrontations sur le champ de bataille.
+
+## Caméra Versus
+- **VersusCamera_Origin**
+  - Pivot de la caméra utilisée pour l'animation 2D de l'écran *Versus*.
+- **VersusCamera_Cam** (`tag` : `VersusCamera`)
+  - Rend vers `RT_VersusScreenView`.
+  - Généralement désactivée en dehors des écrans de transition.
+
+## Résumé des `RenderTexture`
+| Caméra          | `RenderTexture`            | Usage principal                                    |
+|-----------------|---------------------------|----------------------------------------------------|
+| WorldCam_Cam    | `RT_WorldView`             | Exploration du monde                               |
+| BattleCamera_Cam| `RT_BattleView`            | Scènes de combat                                   |
+| VersusCamera_Cam| `RT_VersusScreenView`      | Animation de l'écran Versus                        |
+| MainCam_Cam     | Affichage dynamique        | Affiche la texture pertinente à l'écran            |
+
+> **Note :** la présence d'un `Origin` pour chaque caméra offre une base commune pour appliquer des animations ou des transitions sans perturber le composant `Camera`.
+

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,7 @@ TagManager:
   tags:
   - UICamera
   - BattleCamera
+  - WorldCamera
   - UIMenuButton
   - Enemy
   - PlayerSpawn


### PR DESCRIPTION
## Résumé
- Ajout du tag `WorldCamera` pour distinguer la caméra d'exploration du monde
- Restructuration du prefab `CameraSystem` avec un parent `MainCam_Origin` et intégration de la `VersusCamera`
- Documentation de la nouvelle hiérarchie des caméras

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_688f4185f2848325bf99ca2ff372e880