### PR TITLE
Force BattleCamera dans CameraController

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -40,6 +40,7 @@ public class CameraController : MonoBehaviour
     private bool forceLookAt;
     private Transform forcedLookTarget;
     private Camera activeCamera;
+    private Camera battleCamera; // Référence directe à la BattleCamera
 
     [Header("---------- World Camera ----------")]
 
@@ -91,6 +92,10 @@ public class CameraController : MonoBehaviour
         Instance = this;
         player = GameObject.FindGameObjectWithTag("Player")?.transform;
         if (player == null) Debug.LogError("[CameraController] Player not found!");
+
+        // Récupération de la BattleCamera pour pouvoir la forcer indépendamment de la MainCamera
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
+        if (battleCamera == null) Debug.LogWarning("[CameraController] BattleCamera introuvable !");
 
         cameraTargetName = FindChildRecursive(player, "Point_Chest")?.name;
         eventsManager = FindFirstObjectByType<EventsManager>();
@@ -446,6 +451,15 @@ public class CameraController : MonoBehaviour
         // Plus de SmoothMoveAndLook pour Forced : on va suivre direct
         if (currentTransition != null) StopCoroutine(currentTransition);
 
+        // Active la BattleCamera et désactive la MainCamera pour ce mode forcé
+        if (battleCamera != null)
+        {
+            activeCamera = battleCamera;
+            battleCamera.enabled = true;
+        }
+        if (Camera.main != null && Camera.main != battleCamera)
+            Camera.main.enabled = false;
+
         currentWorldCameraState = WorldCameraState.Forced;
         cameraHandlerEnabled = false;
 
@@ -459,6 +473,13 @@ public class CameraController : MonoBehaviour
     {
         currentWorldCameraState = WorldCameraState.ResearchClosestCamPoint;
         cameraHandlerEnabled = true;
+
+        // Restaure l'état des caméras : MainCamera active, BattleCamera désactivée
+        if (Camera.main != null)
+            Camera.main.enabled = true;
+        if (battleCamera != null && battleCamera != Camera.main)
+            battleCamera.enabled = false;
+        activeCamera = Camera.main;
         Debug.Log("[CameraController] ForcedCam DISABLED");
     }
 
@@ -491,9 +512,10 @@ public class CameraController : MonoBehaviour
     /// </summary>
     void FollowForcedCameraPoint()
     {
-        if (forcedCameraPoint == null || forceLookPoint == null || Camera.main == null) return;
+        // Utilise la BattleCamera pour le suivi forcé
+        if (forcedCameraPoint == null || forceLookPoint == null || battleCamera == null) return;
 
-        Transform cam = Camera.main.transform;
+        Transform cam = battleCamera.transform;
 
         // Suivi direct (aucun blocage, aucun retard)
         cam.position = Vector3.Lerp(cam.position, forcedCameraPoint.position, 10f * Time.deltaTime);

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterController3D.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterController3D.cs
@@ -10,6 +10,9 @@ public class CharacterController3D : MonoBehaviour
         TPSOverShoulder
     }
 
+    // ⚠️ Ce contrôleur s'appuie sur Camera.main pour orienter le déplacement.
+    // Si aucune caméra n'est taguée "MainCamera" (par exemple avant d'activer la BattleCamera),
+    // les vecteurs de mouvement ne peuvent pas être calculés et le joueur reste immobile.
     public MovementMode movementMode = MovementMode.FixedCamera;
 
     [HideInInspector] public CharacterController controller;


### PR DESCRIPTION
## Résumé
- Référence directe à la BattleCamera pour pouvoir la forcer indépendamment de la MainCamera.
- Activation/désactivation de la BattleCamera lors du forçage et du relâchement, avec suivi du point forcé sur cette caméra.
- Documenté l'utilisation obligatoire de `Camera.main` dans `CharacterController3D`, ce qui explique l'immobilité du joueur avant le forçage.

## Tests
- `dotnet test` *(échoué : command not found)*
- `apt-get update` *(échoué : 403 Forbidden lors de la récupération des dépôts)*


------
https://chatgpt.com/codex/tasks/task_e_688f5928786c83259f7192b95db8f4d0