### PR TITLE
Fix instanciation du VFX Longue Portée

### DIFF
--- a/Assets/Scripts/UnusedScripts/InstantiateGameObject.cs
+++ b/Assets/Scripts/UnusedScripts/InstantiateGameObject.cs
@@ -15,6 +15,28 @@ public class InstantiateGameObject : MonoBehaviour
 
     public void InstantiateFromTimeline(GameObject gameObjectToInstantiate)
     {
-        Instantiate(gameObjectToInstantiate, NewBattleManager.Instance.currentCharacterUnit.transform.position, Quaternion.identity);
+        // Vérifie les références avant d'instancier pour éviter les NullReferenceException
+        Vector3 spawnPosition; // Position d'apparition du VFX
+
+        if (NewBattleManager.Instance != null && NewBattleManager.Instance.currentCharacterUnit != null)
+        {
+            // Positionne le VFX sur l'unité actuellement active
+            spawnPosition = NewBattleManager.Instance.currentCharacterUnit.transform.position;
+        }
+        else
+        {
+            // En cas d'absence du gestionnaire ou de l'unité, on le place sur le lanceur de timeline
+            spawnPosition = transform.position;
+            Debug.LogWarning("[InstantiateGameObject] NewBattleManager ou currentCharacterUnit introuvable, instanciation au niveau du TimelineLauncher.");
+        }
+
+        if (gameObjectToInstantiate != null)
+        {
+            Instantiate(gameObjectToInstantiate, spawnPosition, Quaternion.identity);
+        }
+        else
+        {
+            Debug.LogWarning("[InstantiateGameObject] Aucun GameObject fourni pour l'instanciation.");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Sécurise l'instanciation des VFX déclenchés par Timeline en gérant les références nulles

## Testing
- `dotnet test` *(commande introuvable)*
- `apt-get update` *(échec de la mise à jour des dépôts)*

------
https://chatgpt.com/codex/tasks/task_e_688fb9a11f948325b227ca7b9090a609