### PR TITLE
Assurer la réception du signal de longue portée

### DIFF
--- a/Assets/TimelineLauncher.cs
+++ b/Assets/TimelineLauncher.cs
@@ -67,7 +67,7 @@ public class TimelineLauncher : MonoBehaviour
             }
             else if (type != null && typeof(Component).IsAssignableFrom(type) && type.Name.Contains("SignalReceiver"))
             {
-                // R�cup�re le SignalReceiver pr�sent sur le m�me GameObject que le PlayableDirector
+                // Récupère le SignalReceiver présent sur le même GameObject que le PlayableDirector
                 Component receiver = director.GetComponent(type);
                 if (receiver != null)
                 {
@@ -82,6 +82,15 @@ public class TimelineLauncher : MonoBehaviour
             {
                 Debug.LogWarning($"[TimelineLauncher] Aucun binding pour la track : {trackName}");
             }
+        }
+
+        // Établit également le binding pour le MarkerTrack afin que les signaux
+        // placés directement sur la timeline sans track dédiée soient reçus.
+        SignalReceiver markerReceiver = director.GetComponent<SignalReceiver>();
+        if (markerReceiver != null && timelineAsset.markerTrack != null)
+        {
+            // Associe le MarkerTrack au SignalReceiver présent sur le PlayableDirector
+            director.SetGenericBinding(timelineAsset.markerTrack, markerReceiver);
         }
 
         director.Play();


### PR DESCRIPTION
## Résumé
- Lie le MarkerTrack au SignalReceiver dans `TimelineLauncher` pour recevoir les signaux sans track dédiée.
- Ajoute des commentaires pour faciliter la maintenance.

## Tests
- `dotnet build` *(échec : dotnet non installé)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_688fbd9b3f388325b3718a1e2bbd31de