### PR TITLE
Gestion des sons de dégâts critiques et d'interception

### DIFF
--- a/Assets/Characters/Kael/Character_Kael.asset
+++ b/Assets/Characters/Kael/Character_Kael.asset
@@ -66,6 +66,7 @@ MonoBehaviour:
   hitSound: {fileID: 0}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Kael/Character_Kael.asset
+++ b/Assets/Characters/Kael/Character_Kael.asset
@@ -64,6 +64,7 @@ MonoBehaviour:
   currentInterceptionRange: 1
   currentInterceptionChance: 0
   hitSound: {fileID: 0}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}

--- a/Assets/Characters/Link/Character_Link.asset
+++ b/Assets/Characters/Link/Character_Link.asset
@@ -66,6 +66,7 @@ MonoBehaviour:
   hitSound: {fileID: 0}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Link/Character_Link.asset
+++ b/Assets/Characters/Link/Character_Link.asset
@@ -64,6 +64,7 @@ MonoBehaviour:
   currentInterceptionRange: 1
   currentInterceptionChance: 0
   hitSound: {fileID: 0}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}

--- a/Assets/Characters/Lucian/Character_Lucian.asset
+++ b/Assets/Characters/Lucian/Character_Lucian.asset
@@ -66,6 +66,7 @@ MonoBehaviour:
   hitSound: {fileID: 8300000, guid: 495e81bd8d7f10b46a1a310b84a331be, type: 3}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 8300000, guid: 16a49b678baf55746aeaa953585418ce, type: 3}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Lucian/Character_Lucian.asset
+++ b/Assets/Characters/Lucian/Character_Lucian.asset
@@ -64,6 +64,7 @@ MonoBehaviour:
   currentInterceptionRange: 0
   currentInterceptionChance: 0
   hitSound: {fileID: 8300000, guid: 495e81bd8d7f10b46a1a310b84a331be, type: 3}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 8300000, guid: 16a49b678baf55746aeaa953585418ce, type: 3}
   hitEffect: {fileID: 0}

--- a/Assets/Characters/Luna/Character_Luna.asset
+++ b/Assets/Characters/Luna/Character_Luna.asset
@@ -60,6 +60,7 @@ MonoBehaviour:
   hitSound: {fileID: 0}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}
   owner: {fileID: 0}

--- a/Assets/Characters/Luna/Character_Luna.asset
+++ b/Assets/Characters/Luna/Character_Luna.asset
@@ -58,6 +58,7 @@ MonoBehaviour:
   currentInterceptionRange: 1
   currentInterceptionChance: 0
   hitSound: {fileID: 0}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Perfecteur/Character_Perfecteur.asset
+++ b/Assets/Characters/Perfecteur/Character_Perfecteur.asset
@@ -65,6 +65,7 @@ MonoBehaviour:
   hitSound: {fileID: 8300000, guid: 495e81bd8d7f10b46a1a310b84a331be, type: 3}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Perfecteur/Character_Perfecteur.asset
+++ b/Assets/Characters/Perfecteur/Character_Perfecteur.asset
@@ -63,6 +63,7 @@ MonoBehaviour:
   currentInterceptionRange: 0
   currentInterceptionChance: 0
   hitSound: {fileID: 8300000, guid: 495e81bd8d7f10b46a1a310b84a331be, type: 3}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}

--- a/Assets/Characters/Thalia/Character_Thalia.asset
+++ b/Assets/Characters/Thalia/Character_Thalia.asset
@@ -61,6 +61,7 @@ MonoBehaviour:
   hitSound: {fileID: 0}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Characters/Thalia/Character_Thalia.asset
+++ b/Assets/Characters/Thalia/Character_Thalia.asset
@@ -59,6 +59,7 @@ MonoBehaviour:
   currentInterceptionRange: 0
   currentInterceptionChance: 0
   hitSound: {fileID: 0}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   prematureDeathTaunt: {fileID: 0}
   hitEffect: {fileID: 0}

--- a/Assets/Characters/Velum/Character_Velum.asset
+++ b/Assets/Characters/Velum/Character_Velum.asset
@@ -61,6 +61,7 @@ MonoBehaviour:
   hitSound: {fileID: 0}
   criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
+  interceptionSound: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}
   owner: {fileID: 0}

--- a/Assets/Characters/Velum/Character_Velum.asset
+++ b/Assets/Characters/Velum/Character_Velum.asset
@@ -59,6 +59,7 @@ MonoBehaviour:
   currentInterceptionRange: 0
   currentInterceptionChance: 0
   hitSound: {fileID: 0}
+  criticalHitSound: {fileID: 0}
   interceptedSound: {fileID: 0}
   hitEffect: {fileID: 0}
   deathEffect: {fileID: 0}

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -79,7 +79,10 @@ public class CharacterData : ScriptableObject, ITargetable
     public AudioClip hitSound;
     // Voix jouée lors d'un coup dévastateur
     public AudioClip criticalHitSound;
+    // Voix jouée lorsque l'unité est interceptée
     public AudioClip interceptedSound;
+    // Voix jouée lorsque l'unité intercepte une autre unité
+    public AudioClip interceptionSound;
     [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClip prematureDeathTaunt;
     public GameObject hitEffect;
     public GameObject deathEffect;

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -77,6 +77,8 @@ public class CharacterData : ScriptableObject, ITargetable
 
     [Header("Effets visuels et sonores")]
     public AudioClip hitSound;
+    // Voix jouée lors d'un coup dévastateur
+    public AudioClip criticalHitSound;
     public AudioClip interceptedSound;
     [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClip prematureDeathTaunt;
     public GameObject hitEffect;

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -207,15 +207,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         currentHP = Mathf.Max(currentHP - amount, 0);
         if (hpBar != null) hpBar.SetValue(currentHP);
+
+        // Calcul de la gravité du coup pour déterminer le son et le message
+        float maxHP = Data.baseHP + currentVitality;
+        bool devastating = amount > maxHP * 0.2f;
+
         // Affiche le nombre de dégâts au-dessus de cette unité
         DamagePopupManager.Instance?.ShowDamage(transform, Mathf.RoundToInt(amount));
-        PlayDamageFeedback();
+        PlayDamageFeedback(devastating);
 
         // Message indiquant la gravité des dégâts subis
         if (ActionUIDisplayManager.Instance != null)
         {
-            float maxHP = Data.baseHP + currentVitality;
-            bool devastating = amount > maxHP * 0.2f;
             ActionUIDisplayManager.Instance.DisplayDamage(Data.characterName, devastating);
         }
 
@@ -359,12 +362,28 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
     }
 
-    public void PlayHitSound()
+    /// <summary>
+    /// Joue le son d'impact. Utilise une voix différente si le coup est
+    /// considéré comme dévastateur.
+    /// </summary>
+    /// <param name="isDevastating">True si le coup est dévastateur.</param>
+    public void PlayHitSound(bool isDevastating = false)
     {
-        if (Data.hitSound != null && audioSource != null)
-            audioSource.PlayOneShot(Data.hitSound);
+        if (audioSource == null)
+            return;
+
+        // Sélection du clip approprié
+        AudioClip clip = (isDevastating && Data.criticalHitSound != null)
+            ? Data.criticalHitSound
+            : Data.hitSound;
+
+        if (clip != null)
+            audioSource.PlayOneShot(clip);
     }
 
+    /// <summary>
+    /// Joue le son spécifique lorsqu'une interception touche cette unité.
+    /// </summary>
     public void PlayInterceptedSound()
     {
         if (Data.interceptedSound != null && audioSource != null)
@@ -486,9 +505,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         }
     }
 
-    void PlayDamageFeedback()
+    void PlayDamageFeedback(bool isDevastating)
     {
-        PlayHitSound();
+        // Joue le son correspondant à la gravité du coup
+        PlayHitSound(isDevastating);
 
         if (Data.hitEffect != null)
             Instantiate(Data.hitEffect, transform.position, Quaternion.identity);

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -390,6 +390,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             audioSource.PlayOneShot(Data.interceptedSound);
     }
 
+    /// <summary>
+    /// Joue le son spécifique lorsqu'une interception réussit et que
+    /// cette unité est celle qui intercepte.
+    /// </summary>
+    public void PlayInterceptionSound()
+    {
+        if (Data.interceptionSound != null && audioSource != null)
+            audioSource.PlayOneShot(Data.interceptionSound);
+    }
+
     public void PlayMoveStartSound()
     {
         if (Data.moveStartClip != null)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1150,6 +1150,8 @@ public class NewBattleManager : MonoBehaviour
         caster?.PlayInterceptedSound();
         caster?.ClearAllHarmonics();
         interceptor?.PlayInterceptionAnimation();
+        // Son joué par l'unité qui intercepte
+        interceptor?.PlayInterceptionSound();
 
         var move = interceptor.GetRandomMusicalAttack();
         if (move != null)


### PR DESCRIPTION
## Résumé
- Ajout d'un champ `criticalHitSound` aux données de personnage et aux assets associés.
- Lecture conditionnelle de `hitSound` ou `criticalHitSound` selon la gravité des dégâts.
- Clarification du son joué lors des interceptions via `interceptedSound`.

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `npm test` *(échoue : fichier `package.json` absent)*

------
https://chatgpt.com/codex/tasks/task_e_6890dcd122308325a3bdf38391a1fb1f