### PR TITLE
feat: ajouter shadergraph HDRP lit maitre

### DIFF
--- a/Assets/Shaders/ShaderGraph_Symphonie_MasterLit.shadergraph
+++ b/Assets/Shaders/ShaderGraph_Symphonie_MasterLit.shadergraph
@@ -1,0 +1,12 @@
+{
+    "//": "ShaderGraph HDRP Lit Maitre. Ce graph de base sera complété pour les effets de filtres.",
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "00000000000000000000000000000000",
+    "m_Properties": [],
+    "m_SerializableNodes": [],
+    "m_Edges": [],
+    "m_Groups": [],
+    "m_ActiveTargets": ["HDLitSubTarget"],
+    "m_Path": "Shader Graphs"
+}

--- a/Assets/Shaders/ShaderGraph_Symphonie_MasterLit.shadergraph.meta
+++ b/Assets/Shaders/ShaderGraph_Symphonie_MasterLit.shadergraph.meta
@@ -1,0 +1,11 @@
+# Meta file pour le ShaderGraph HDRP Lit Maitre.
+fileFormatVersion: 2
+guid: 3128d0b07ea14b5c91d0eabdc04a2c3a
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}


### PR DESCRIPTION
## Résumé
- ajouter un ShaderGraph HDRP Lit maître pour servir de base aux futurs filtres visuels

## Tests
- `dotnet test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6890ebefc0408325870cf128a2b811ed