### PR TITLE
Intégration de la vision révélée dans le MasterShader HDRP

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Gère la vision révélée à la manière d'un viseur spécial.
+// Cette fonction s'intègre au récit de l'Histoire de Symphonie en permettant de dévoiler des secrets cachés.
+/// Lors de l'appui sur l'action "ReveVisionToggle", seules les textures
+/// prévues pour cette vision sont affichées.
+/// </summary>
+public class ReveVisionController : MonoBehaviour
+{
+    [Tooltip("Action Input System utilisée pour activer la vision révélée.")]
+    public string actionName = "ReveVisionToggle"; // Nom logique de l'action.
+
+    [Tooltip("Action d'entrée réellement écoutée. Si null, une action par défaut sera créée.")]
+    public InputAction toggleAction;
+
+    // État actuel de la vision révélée.
+    private bool reveActive = false;
+
+    private void Awake()
+    {
+        // Crée une action par défaut si rien n'est assigné dans l'inspecteur.
+        if (toggleAction == null)
+        {
+            // Par défaut on associe la touche R du clavier.
+            toggleAction = new InputAction(actionName, binding: "<Keyboard>/r");
+        }
+
+        // Abonnement au déclenchement de l'action.
+        toggleAction.performed += OnTogglePerformed;
+        toggleAction.Enable();
+    }
+
+    private void OnDestroy()
+    {
+        // Nettoie proprement l'action pour éviter les fuites mémoire.
+        if (toggleAction != null)
+        {
+            toggleAction.performed -= OnTogglePerformed;
+            toggleAction.Disable();
+        }
+    }
+
+    // Callback interne appelé lors de l'appui sur l'action.
+    private void OnTogglePerformed(InputAction.CallbackContext ctx)
+    {
+        ToggleVision();
+    }
+
+    /// <summary>
+    /// Bascule l'état de la vision révélée et met à jour le shader global.
+    /// </summary>
+    private void ToggleVision()
+    {
+        reveActive = !reveActive;
+        // Informe le shader de l'état courant via une propriété globale.
+        Shader.SetGlobalFloat("_ReveVision", reveActive ? 1f : 0f);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: deab2e3933844c999e5f385a479f0361
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/MasterShader_HDRP.shadergraph
+++ b/Assets/Shaders/MasterShader_HDRP.shadergraph
@@ -2,7 +2,10 @@
     "m_SGVersion": 3,
     "m_Type": "UnityEditor.ShaderGraph.GraphData",
     "m_ObjectId": "99c9d2502326450798eab900f93d941d",
-    "m_Properties": [],
+    "m_Properties": [
+        { "m_Id": "7f48d6e9a8c44585b96fe76e27d56852" },
+        { "m_Id": "46635d69d8134d5591bd86369a4a6a10" }
+    ],
     "m_Keywords": [],
     "m_Dropdowns": [],
     "m_CategoryData": [
@@ -851,5 +854,53 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.BentNormal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "7f48d6e9a8c44585b96fe76e27d56852",
+    "m_Guid": { "m_GuidSerialized": "f6e9a379-e013-4208-bc8e-19eeb108a636" },
+    "m_Name": "RevealTexture",
+    "m_DefaultRefNameVersion": 0,
+    "m_RefNameGeneratedByDisplayName": "",
+    "m_DefaultReferenceName": "Texture2D_7f48d6e9a8c44585b96fe76e27d56852",
+    "m_OverrideReferenceName": "_RevealTex",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": { "m_SerializedTexture": "", "m_Guid": "" },
+    "isMainTexture": false,
+    "useTilingAndOffset": false,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "46635d69d8134d5591bd86369a4a6a10",
+    "m_Guid": { "m_GuidSerialized": "2529b0f5-d991-4a3a-bd81-087abb1cc203" },
+    "m_Name": "ReveVision",
+    "m_DefaultRefNameVersion": 0,
+    "m_RefNameGeneratedByDisplayName": "",
+    "m_DefaultReferenceName": "Vector1_46635d69d8134d5591bd86369a4a6a10",
+    "m_OverrideReferenceName": "_ReveVision",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 1,
+    "m_RangeValues": { "x": 0.0, "y": 1.0 }
 }
 


### PR DESCRIPTION
## Résumé
- Ajout des propriétés `_RevealTex` et `_ReveVision` dans `MasterShader_HDRP.shadergraph` afin de gérer la vision révélée directement dans le ShaderGraph existant.
- Suppression du shader HLSL redondant pour ne conserver que le ShaderGraph maître.
- Script `ReveVisionController` conservé pour basculer l'affichage via l'input `ReveVisionToggle`.

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_6890f85488f8832591540de6e176e08c