### PR TITLE
feat: refonte simple du déplacement en monde

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonCameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonCameraController.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Contrôleur de caméra simple permettant à Munin (la caméra) de pivoter autour de Lucian.
+/// Utilise la souris ou le stick droit pour orienter la vue.
+/// </summary>
+public class ThirdPersonCameraController : MonoBehaviour
+{
+    [Header("Cible à suivre")]
+    [Tooltip("Transform du joueur (Lucian) autour duquel la caméra orbite.")]
+    public Transform target;
+
+    [Header("Paramètres d'orbite")]
+    [Tooltip("Distance entre la caméra et la cible.")]
+    public float distance = 5f;
+    [Tooltip("Sensibilité de la caméra sur les axes horizontal et vertical.")]
+    public Vector2 sensitivity = new Vector2(120f, 120f);
+    [Tooltip("Limites de l'angle vertical en degrés.")]
+    public Vector2 pitchLimits = new Vector2(-20f, 60f);
+
+    private float yaw;
+    private float pitch;
+
+    void Start()
+    {
+        if (target == null)
+        {
+            Debug.LogWarning("[ThirdPersonCameraController] Aucune cible assignée, recherche d'un objet tagué 'Player'.");
+            var playerObj = GameObject.FindGameObjectWithTag("Player");
+            if (playerObj != null) target = playerObj.transform;
+        }
+
+        // Initialisation des angles à partir de la rotation actuelle de la caméra.
+        Vector3 angles = transform.eulerAngles;
+        yaw = angles.y;
+        pitch = angles.x;
+    }
+
+    void LateUpdate()
+    {
+        if (target == null) return;
+
+        // Récupération des entrées souris / manette via le nouveau système d'input.
+        Vector2 lookInput = Vector2.zero;
+        if (Mouse.current != null)
+        {
+            lookInput += Mouse.current.delta.ReadValue();
+        }
+        if (Gamepad.current != null)
+        {
+            lookInput += Gamepad.current.rightStick.ReadValue();
+        }
+
+        // Application de la sensibilité et du delta temps pour une rotation fluide.
+        yaw += lookInput.x * sensitivity.x * Time.deltaTime;
+        pitch -= lookInput.y * sensitivity.y * Time.deltaTime;
+        pitch = Mathf.Clamp(pitch, pitchLimits.x, pitchLimits.y);
+
+        // Calcul de la nouvelle position de la caméra autour de la cible.
+        Quaternion rotation = Quaternion.Euler(pitch, yaw, 0f);
+        Vector3 offset = rotation * new Vector3(0f, 0f, -distance);
+        transform.position = target.position + offset;
+        transform.LookAt(target.position);
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonCameraController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonCameraController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 880178e0e34d4749805f699b651d0a59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -1,0 +1,91 @@
+using UnityEngine;
+
+/// <summary>
+/// Contrôleur simple à la troisième personne pour Lucian en mode exploration.
+/// Gère le déplacement de base (marche/course) et l'orientation du personnage.
+/// La caméra (Munin) peut pivoter autour de Lucian grâce au script <see cref="ThirdPersonCameraController"/>.
+/// </summary>
+[RequireComponent(typeof(CharacterController))]
+public class ThirdPersonPlayerController : MonoBehaviour
+{
+    [Header("Références")]
+    [Tooltip("Transform de la caméra utilisée pour orienter le déplacement.")]
+    public Transform cameraTransform;
+
+    private CharacterController controller;
+    private Vector3 velocity;
+
+    [Header("Mouvement")]
+    [Tooltip("Vitesse de marche en unités/seconde.")]
+    public float walkSpeed = 5f;
+    [Tooltip("Vitesse de course en unités/seconde.")]
+    public float runSpeed = 8f;
+    [Tooltip("Hauteur du saut en unités.")]
+    public float jumpHeight = 2f;
+    [Tooltip("Gravité appliquée au personnage.")]
+    public float gravity = -9.81f;
+
+    void Awake()
+    {
+        controller = GetComponent<CharacterController>();
+        // Si aucune caméra n'est assignée, on prend la caméra principale.
+        if (cameraTransform == null && Camera.main != null)
+        {
+            cameraTransform = Camera.main.transform;
+        }
+    }
+
+    void Update()
+    {
+        HandleMovement();
+        ApplyGravity();
+    }
+
+    /// <summary>
+    /// Lit les entrées et déplace Lucian dans le monde.
+    /// </summary>
+    void HandleMovement()
+    {
+        // Lecture des axes de déplacement (WASD / stick gauche).
+        Vector2 input = InputsManager.Instance.playerInputs.World.Move.ReadValue<Vector2>();
+        bool isRunning = InputsManager.Instance.playerInputs.World.Run.IsPressed();
+
+        // Conversion de l'entrée en vecteur 3D relatif à l'orientation de la caméra (Munin).
+        Vector3 camForward = Vector3.ProjectOnPlane(cameraTransform.forward, Vector3.up).normalized;
+        Vector3 camRight = Vector3.ProjectOnPlane(cameraTransform.right, Vector3.up).normalized;
+        Vector3 move = camForward * input.y + camRight * input.x;
+
+        // Vitesse selon marche/course.
+        float speed = isRunning ? runSpeed : walkSpeed;
+        controller.Move(move * speed * Time.deltaTime);
+
+        // Oriente le personnage dans la direction du mouvement pour rester cohérent avec l'histoire (Lucian fait face à son chemin).
+        if (move.sqrMagnitude > 0.0001f)
+        {
+            Quaternion targetRot = Quaternion.LookRotation(move);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRot, Time.deltaTime * 10f);
+        }
+
+        // Gestion du saut simple.
+        if (InputsManager.Instance.playerInputs.World.Jump.triggered && controller.isGrounded)
+        {
+            velocity.y = Mathf.Sqrt(jumpHeight * -2f * gravity);
+        }
+    }
+
+    /// <summary>
+    /// Applique une gravité simple sur le CharacterController.
+    /// </summary>
+    void ApplyGravity()
+    {
+        if (controller.isGrounded && velocity.y < 0f)
+        {
+            // Petite valeur négative pour ancrer le personnage au sol.
+            velocity.y = -2f;
+        }
+
+        velocity.y += gravity * Time.deltaTime;
+        controller.Move(velocity * Time.deltaTime);
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f10e825adf345b7956d7de3a2402c72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- ajout d'un contrôleur ThirdPersonPlayerController gérant marche, course et saut orientés par la caméra
- ajout d'un contrôleur ThirdPersonCameraController pour pivoter la caméra autour du joueur via souris ou stick droit

## Tests
- `dotnet test` *(échec: commande introuvable)*
- `apt-get update` *(échec: dépôts non signés 403)*

------
https://chatgpt.com/codex/tasks/task_e_68924f5be8508325904fc542aec393fc