### PR TITLE
Corrige les propriétés de SplitToning

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PostProcessManager.cs
@@ -252,8 +252,14 @@ public class PostProcessManager : MonoBehaviour
         if (splitToning != null)
         {
             splitToning.active = true;
-            splitToning.shadowColor.value = new Color(0.2f, 0.2f, 0.25f);
-            splitToning.highlightColor.value = new Color(1f, 0.95f, 0.8f);
+
+            // Depuis les versions récentes de l'HDRP, les propriétés "shadowColor" et
+            // "highlightColor" ont été remplacées par "shadows" et "highlights".
+            // L'ancien code provoquait une erreur de compilation. On utilise désormais
+            // les nouveaux noms de propriétés tout en conservant les teintes voulues.
+            splitToning.shadows.value = new Color(0.2f, 0.2f, 0.25f);    // teinte appliquée aux zones d'ombre
+            splitToning.highlights.value = new Color(1f, 0.95f, 0.8f);   // teinte appliquée aux zones lumineuses
+
             splitToning.balance.value = -20f; // ombres légèrement privilégiées
         }
 


### PR DESCRIPTION
## Résumé
- Remplace les propriétés obsolètes `shadowColor` et `highlightColor` par `shadows` et `highlights` dans `PostProcessManager`
- Ajoute des commentaires détaillant la mise à jour d'HDRP

## Tests
- `dotnet build` *(échoue : command not found)*
- `apt-get update` *(échoue : repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68950bd8103883258163b9953bffa099