### PR TITLE
Corrige le conflit de fusion dans Symphonie_Volume.asset

### DIFF
--- a/Assets/Settings/HDRPDefaultResources/Symphonie_Volume.asset
+++ b/Assets/Settings/HDRPDefaultResources/Symphonie_Volume.asset
@@ -40,17 +40,10 @@ MonoBehaviour:
   active: 0
   postExposure:
     m_OverrideState: 1
-<<<<<<< Updated upstream
     m_Value: -0.5
   contrast:
     m_OverrideState: 1
     m_Value: 60
-=======
-    m_Value: 1.95
-  contrast:
-    m_OverrideState: 1
-    m_Value: -50
->>>>>>> Stashed changes
   colorFilter:
     m_OverrideState: 1
     m_Value: {r: 0.99999994, g: 0.96615034, b: 0.90094334, a: 1}
@@ -59,11 +52,7 @@ MonoBehaviour:
     m_Value: 0
   saturation:
     m_OverrideState: 1
-<<<<<<< Updated upstream
     m_Value: -20
-=======
-    m_Value: 50
->>>>>>> Stashed changes
 --- !u!114 &-4183193969921306110
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -393,11 +382,7 @@ MonoBehaviour:
     m_Value: 3
   threshold:
     m_OverrideState: 1
-<<<<<<< Updated upstream
     m_Value: 1
-=======
-    m_Value: 5
->>>>>>> Stashed changes
   intensity:
     m_OverrideState: 1
     m_Value: 1.2


### PR DESCRIPTION
## Résumé
- Résout les conflits de fusion dans `Symphonie_Volume.asset` et conserve les valeurs voulues pour les réglages d'exposition, de contraste, de saturation et de seuil de Bloom.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68950ea5572c8325a8dc435cb74d1ace