### PR TITLE
Filtrage des Rendering Layers par LayerMask

### DIFF
--- a/Assets/Editor/SetRenderingLayerEditor.cs
+++ b/Assets/Editor/SetRenderingLayerEditor.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEditor;
 using UnityEngine;
+using UnityEditorInternal; // Pour accéder aux noms de couches Unity
 
 [CustomEditor(typeof(SetRenderingLayer))]
 public class SetRenderingLayerEditor : Editor
 {
-    private string[] layerNames;
-    private int selectedIndex;
+    private string[] layerNames; // Liste des Rendering Layers disponibles
+    private int selectedIndex; // Index du Rendering Layer sélectionné
 
     private void OnEnable()
     {
@@ -20,12 +21,23 @@ public class SetRenderingLayerEditor : Editor
     {
         var script = (SetRenderingLayer)target;
 
+        // Sélection du Rendering Layer
         EditorGUI.BeginChangeCheck();
         selectedIndex = EditorGUILayout.Popup("Rendering Layer", selectedIndex, layerNames);
         if (EditorGUI.EndChangeCheck())
         {
             Undo.RecordObject(script, "Change Rendering Layer Index");
             script.renderingLayerIndex = selectedIndex;
+            EditorUtility.SetDirty(script);
+        }
+
+        // Sélection des LayerMask à affecter
+        EditorGUI.BeginChangeCheck();
+        int mask = EditorGUILayout.MaskField("Layer(s) concerné(s)", script.targetLayers, InternalEditorUtility.layers);
+        if (EditorGUI.EndChangeCheck())
+        {
+            Undo.RecordObject(script, "Change Target Layers");
+            script.targetLayers = mask;
             EditorUtility.SetDirty(script);
         }
 

--- a/Assets/Scripts/MonoBehavioursUsed/SetRenderingLayer.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SetRenderingLayer.cs
@@ -6,6 +6,9 @@ public class SetRenderingLayer : MonoBehaviour
     [HideInInspector]
     public int renderingLayerIndex = 0;
 
+    // Couches Unity auxquelles appliquer ce Rendering Layer
+    public LayerMask targetLayers = ~0; // Par défaut : toutes les couches
+
     public void ApplyToChildren()
     {
         uint mask = 1u << renderingLayerIndex;
@@ -13,10 +16,14 @@ public class SetRenderingLayer : MonoBehaviour
         int count = 0;
         foreach (var r in GetComponentsInChildren<Renderer>(true))
         {
-            r.renderingLayerMask = mask;
-            count++;
+            // Vérifie si la couche de l'objet correspond à l'un des LayerMask sélectionnés
+            if (((1 << r.gameObject.layer) & targetLayers.value) != 0)
+            {
+                r.renderingLayerMask = mask;
+                count++;
+            }
         }
 
-        Debug.Log($"✅ Rendering Layer '{renderingLayerIndex}' appliqué à {count} renderer(s).");
+        Debug.Log($"✅ Rendering Layer '{renderingLayerIndex}' appliqué à {count} renderer(s) correspondant aux LayerMask sélectionnés.");
     }
 }


### PR DESCRIPTION
## Résumé
- ajout d'une sélection de LayerMask pour cibler les objets lors de l'application d'un Rendering Layer
- mise à jour de l'inspecteur personnalisé pour choisir les couches visées et appliquer le Rendering Layer

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6895f17f91f483258549d719616fac9b