### PR TITLE
Corrige l'erreur de compilation liée à GUILayout

### DIFF
--- a/Assets/Scripts/Editor/SetRenderingLayerEditor.cs
+++ b/Assets/Scripts/Editor/SetRenderingLayerEditor.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using UnityEditor;
+using UnityEngine; // Nécessaire pour l'utilisation de GUILayout dans l'inspecteur
 
 /// <summary>
 /// Inspecteur personnalisé pour <see cref="SetRenderingLayer"/>.


### PR DESCRIPTION
## Résumé
- Ajout de l'espace de noms UnityEngine pour permettre l'utilisation de GUILayout dans l'inspecteur personnalisé SetRenderingLayerEditor.

## Tests
- `dotnet build` *(échoue : command not found)*
- Tentative d'installation des dépendances via `apt-get update` *(échoue : repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68960b4bfc0c8325b7e98c24f057f2c0