### PR TITLE
Améliore la fluidité en fixant le framerate

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Gestionnaire simple de performance.
+/// - Fixe un framerate cible pour améliorer la fluidité ressentie.
+/// - Affiche le nombre d'images par seconde pour aider au diagnostic.
+/// </summary>
+[DisallowMultipleComponent]
+public class PerformanceManager : MonoBehaviour
+{
+    [Tooltip("Framerate souhaité en mode jeu. 60 par défaut.")]
+    public int targetFrameRate = 60;
+
+    // Moyenne glissante du temps entre deux frames (utilisé pour calculer un FPS stable)
+    private float deltaTime = 0f;
+
+    private void Awake()
+    {
+        // Force Unity à viser le framerate défini
+        Application.targetFrameRate = targetFrameRate;
+    }
+
+    private void Update()
+    {
+        // Actualise le deltaTime non affecté par le timeScale pour obtenir un calcul d'FPS fiable
+        deltaTime += (Time.unscaledDeltaTime - deltaTime) * 0.1f;
+    }
+
+    private void OnGUI()
+    {
+        // Convertit le deltaTime en FPS et l'affiche en haut à gauche de l'écran
+        int fps = Mathf.CeilToInt(1f / deltaTime);
+        GUI.Label(new Rect(10, 10, 100, 20), fps + " FPS");
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbdc9c2098a8439dad2cda38f4eed911
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- Ajout d'un `PerformanceManager` qui fixe un framerate cible et affiche les FPS pour diagnostiquer les chutes de fluidité.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68964d179d948325bc4206deedc2a631