### PR TITLE
feat: ajouter caméra d'édition

### DIFF
--- a/Assets/Camera/EditionCamera.cs
+++ b/Assets/Camera/EditionCamera.cs
@@ -1,0 +1,77 @@
+#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Caméra d’édition permettant de prévisualiser
+/// différents points de vue sans lancer le jeu.
+/// Inspirée par Munin, l’observateur silencieux de l’histoire.
+/// </summary>
+[ExecuteAlways]
+[AddComponentMenu("Camera/Edition Camera")]
+public class EditionCamera : MonoBehaviour
+{
+    [Header("Caméras de référence")]
+    [Tooltip("Liste des caméras de la scène à prévisualiser.")]
+    public Camera[] referenceCameras;
+
+    [Tooltip("Index de la caméra actuellement affichée.")]
+    public int currentIndex = 0;
+
+    private Camera self;
+
+    void OnEnable()
+    {
+        self = GetComponent<Camera>();
+
+        // En mode Play, on masque immédiatement la caméra d’édition
+        if (Application.isPlaying)
+        {
+            if (self != null) self.enabled = false;
+            return;
+        }
+
+        // En édition, on affiche la caméra et on applique la vue courante
+        if (self != null) self.enabled = true;
+        ApplyCurrentView();
+    }
+
+    void Update()
+    {
+        // Si le jeu se lance pendant que la caméra est active, on la désactive
+        if (Application.isPlaying)
+        {
+            if (self != null && self.enabled)
+                self.enabled = false;
+        }
+    }
+
+    /// <summary>
+    /// Permet de changer de vue via l’inspector.
+    /// </summary>
+    /// <param name="index">Index de la caméra à afficher</param>
+    public void SwitchToCamera(int index)
+    {
+        if (referenceCameras == null || index < 0 || index >= referenceCameras.Length)
+            return;
+
+        currentIndex = index;
+        ApplyCurrentView();
+    }
+
+    /// <summary>
+    /// Copie la position et la rotation de la caméra sélectionnée.
+    /// </summary>
+    void ApplyCurrentView()
+    {
+        if (referenceCameras == null || currentIndex < 0 || currentIndex >= referenceCameras.Length)
+            return;
+
+        Camera target = referenceCameras[currentIndex];
+        if (target == null) return;
+
+        transform.position = target.transform.position;
+        transform.rotation = target.transform.rotation;
+    }
+}
+#endif

--- a/Assets/Camera/EditionCamera.cs.meta
+++ b/Assets/Camera/EditionCamera.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be5c2783e98042d3ae360e47ef808721

--- a/Assets/Editor/EditionCameraEditor.cs
+++ b/Assets/Editor/EditionCameraEditor.cs
@@ -1,0 +1,41 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Inspecteur personnalisé pour EditionCamera.
+/// Affiche des boutons permettant de basculer rapidement entre les vues.
+/// </summary>
+[CustomEditor(typeof(EditionCamera))]
+public class EditionCameraEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        EditionCamera editionCam = (EditionCamera)target;
+
+        GUILayout.Space(10);
+        EditorGUILayout.LabelField("Prévisualisation rapide", EditorStyles.boldLabel);
+
+        if (editionCam.referenceCameras != null)
+        {
+            for (int i = 0; i < editionCam.referenceCameras.Length; i++)
+            {
+                Camera cam = editionCam.referenceCameras[i];
+                string name = cam != null ? cam.name : $"Caméra {i}";
+
+                if (GUILayout.Button($"Voir {name}"))
+                {
+                    editionCam.SwitchToCamera(i);
+                }
+            }
+        }
+
+        if (Application.isPlaying)
+        {
+            EditorGUILayout.HelpBox("La caméra d’édition est masquée pendant l’exécution.", MessageType.Info);
+        }
+    }
+}
+#endif

--- a/Assets/Editor/EditionCameraEditor.cs.meta
+++ b/Assets/Editor/EditionCameraEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45e899d08b0242eeb5cb2a391f99b221


### PR DESCRIPTION
## Résumé
- ajouter une caméra d'édition pour prévisualiser les vues
- fournir un inspecteur avec boutons pour changer de caméra

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `apt-get update` *(échoue : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68986d94a19883258b2d8fb20932f378