### PR TITLE
chore: isolate editor-only code

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -1,8 +1,9 @@
 ﻿using UnityEngine;
 using UnityEngine.Timeline;
 using System.Collections.Generic;
-using UnityEditor;
-using UnityEditor.Callbacks;
+// Les directives UnityEditor sont réservées à l'éditeur et ne doivent pas
+// être incluses dans le build du joueur. Elles ont été retirées pour éviter
+// les erreurs de compilation lors de l'export.
 
 [CreateAssetMenu(fileName = "NewMusicalMove", menuName = "Symphonie/Musical Move")]
 public class MusicalMoveSO : ScriptableObject

--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEditor;
 
 public enum WorldCameraState
 {

--- a/Assets/Scripts/MonoBehavioursUsed/CameraPath.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraPath.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
+
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 [ExecuteAlways]
 public class CameraPath : MonoBehaviour
@@ -99,6 +102,7 @@ public bool triggered;
     /// <summary>
     /// Dessine la trajectoire et les tangentes du chemin dans la scène.
     /// </summary>
+#if UNITY_EDITOR
     private void OnDrawGizmos()
     {
         if (points.Count < 2) return;
@@ -120,12 +124,11 @@ public bool triggered;
             Handles.SphereHandleCap(0, b, Quaternion.identity, 0.1f, EventType.Repaint);
             Handles.SphereHandleCap(0, c, Quaternion.identity, 0.1f, EventType.Repaint);
 
-#if UNITY_EDITOR
             Vector3 mid = (a + d) * 0.5f;
             Handles.Label(mid, $"⏱ {durations[i]:0.00}s");
-#endif
         }
     }
+#endif
     #endregion
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -1,7 +1,12 @@
 ﻿using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEditor;
 using System.Collections;
+
+#if UNITY_EDITOR
+// Directives réservées à l'éditeur pour l'inspecteur personnalisé.
+// En production, UnityEditor n'est pas disponible, d'où l'encapsulation.
+using UnityEditor;
+#endif
 
 public class InputsManager : MonoBehaviour
 {
@@ -626,12 +631,15 @@ public class InputsManager : MonoBehaviour
     #endregion
 }
 
+#if UNITY_EDITOR
+// ----- Inspecteur personnalisé pour InputsManager (éditeur uniquement) -----
 [CustomEditor(typeof(InputsManager))]
 [CanEditMultipleObjects]
 public class InputsManagerEditor : Editor
 {
     private void OnEnable()
     {
+        // Mise à jour régulière de l'inspector pour afficher l'état des maps.
         EditorApplication.update += OnEditorUpdate;
     }
 
@@ -703,3 +711,4 @@ public class InputsManagerEditor : Editor
         EditorGUILayout.LabelField(label, statusText, style);
     }
 }
+#endif

--- a/Assets/Scripts/UnusedScripts/DetachRotation.cs
+++ b/Assets/Scripts/UnusedScripts/DetachRotation.cs
@@ -1,18 +1,21 @@
 using UnityEngine;
+
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 /// <summary>
-/// Maintient la rotation globale fixe, indépendamment de la rotation du parent.
-/// Permet à l'objet de suivre la position du parent mais pas la rotation.
+/// Maintient la rotation globale fixe, indÃ©pendamment de la rotation du parent.
+/// Permet Ã  l'objet de suivre la position du parent mais pas la rotation.
 /// </summary>
 public class DetachRotation : MonoBehaviour
 {
-    [Tooltip("Rotation globale à maintenir (si laissé vide, la rotation initiale sera utilisée).")]
+    [Tooltip("Rotation globale Ã  maintenir (si laissÃ© vide, la rotation initiale sera utilisÃ©e).")]
     public Quaternion fixedWorldRotation;
 
     private void Start()
     {
-        // Si aucune rotation fixée manuellement, utilise la rotation initiale au démarrage
+        // Si aucune rotation fixÃ©e manuellement, utilise la rotation initiale au dÃ©marrage
         if (fixedWorldRotation == Quaternion.identity)
         {
             fixedWorldRotation = transform.rotation;
@@ -26,19 +29,21 @@ public class DetachRotation : MonoBehaviour
     }
 }
 
+#if UNITY_EDITOR
 [CustomEditor(typeof(DetachRotation))]
 [CanEditMultipleObjects]
 public class DetachRotationEditor : Editor
 {
     public override void OnInspectorGUI()
     {
-        // Affiche l'inspecteur par défaut
+        // Affiche l'inspecteur par dÃ©faut
         DrawDefaultInspector();
 
         EditorGUILayout.Space();
         EditorGUILayout.HelpBox(
-            "Ce composant force cet objet à ignorer la rotation de son parent.\nIl suit la position mais garde une rotation globale fixe.",
+            "Ce composant force cet objet Ã  ignorer la rotation de son parent.\nIl suit la position mais garde une rotation globale fixe.",
             MessageType.Info
         );
     }
 }
+#endif

--- a/Assets/Scripts/UnusedScripts/DetachTransform.cs
+++ b/Assets/Scripts/UnusedScripts/DetachTransform.cs
@@ -1,24 +1,27 @@
 using UnityEngine;
+
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 /// <summary>
 /// Permet de bloquer la position et/ou la rotation globale de cet objet,
-/// indépendamment des transformations du parent.
+/// indÃ©pendamment des transformations du parent.
 /// </summary>
 public class DetachTransform : MonoBehaviour
 {
     [Header("Detach Options")]
-    [Tooltip("Si activé, la position globale reste fixe.")]
+    [Tooltip("Si activÃ©, la position globale reste fixe.")]
     public bool detachPosition = true;
 
-    [Tooltip("Si activé, la rotation globale reste fixe.")]
+    [Tooltip("Si activÃ©, la rotation globale reste fixe.")]
     public bool detachRotation = true;
 
     [Header("Fixed Values")]
-    [Tooltip("Position globale à maintenir. Ignoré si 'Detach Position' est désactivé.")]
+    [Tooltip("Position globale Ã  maintenir. IgnorÃ© si 'Detach Position' est dÃ©sactivÃ©.")]
     public Vector3 fixedWorldPosition;
 
-    [Tooltip("Rotation globale à maintenir. Ignoré si 'Detach Rotation' est désactivé.")]
+    [Tooltip("Rotation globale Ã  maintenir. IgnorÃ© si 'Detach Rotation' est dÃ©sactivÃ©.")]
     public Quaternion fixedWorldRotation;
 
     private void Start()
@@ -46,7 +49,7 @@ public class DetachTransformEditor : Editor
 
         EditorGUILayout.Space();
         EditorGUILayout.HelpBox(
-            "Ce composant force la position et/ou la rotation globale de l'objet à rester fixe, " +
+            "Ce composant force la position et/ou la rotation globale de l'objet Ã  rester fixe, " +
             "peu importe les transformations de son parent.",
             MessageType.Info
         );

--- a/Assets/Scripts/UnusedScripts/SelectionFollower.cs
+++ b/Assets/Scripts/UnusedScripts/SelectionFollower.cs
@@ -1,10 +1,13 @@
 using UnityEngine;
+
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 [ExecuteAlways]
 public class SelectionFollower : MonoBehaviour
 {
-    [Tooltip("L'objet qui va suivre la sélection dans la hiérarchie.")]
+    [Tooltip("L'objet qui va suivre la sÃ©lection dans la hiÃ©rarchie.")]
     public Transform objectToMove;
 
     private Transform currentSelected;
@@ -16,26 +19,26 @@ public class SelectionFollower : MonoBehaviour
         #if UNITY_EDITOR
                 if (!Application.isPlaying)
                 {
-                    // Récupère la sélection actuelle
+                    // RÃ©cupÃ¨re la sÃ©lection actuelle
                     Transform selected = Selection.activeTransform;
 
-                    // S'il y a une sélection valide
+                    // S'il y a une sÃ©lection valide
                     if (selected != null)
                     {
-                        // Détecte un changement de sélection OU modification de position/rotation
+                        // DÃ©tecte un changement de sÃ©lection OU modification de position/rotation
                         bool selectionChanged = selected != currentSelected;
                         bool transformChanged = selected.position != lastPosition || selected.rotation != lastRotation;
 
                         if (selectionChanged || transformChanged)
                         {
-                            // Met à jour le suivi
+                            // Met Ã  jour le suivi
                             if (objectToMove != null)
                             {
                                 objectToMove.position = selected.position;
                                 objectToMove.rotation = selected.rotation;
                             }
 
-                            // Sauvegarde l'état actuel pour le prochain tour
+                            // Sauvegarde l'Ã©tat actuel pour le prochain tour
                             currentSelected = selected;
                             lastPosition = selected.position;
                             lastRotation = selected.rotation;


### PR DESCRIPTION
## Summary
- retire les références UnityEditor des scripts de jeu pour éviter les erreurs de build
- encapsule les inspecteurs personnalisés et les utilitaires dans `#if UNITY_EDITOR`
- convertit quelques scripts inutilisés en UTF-8 et les réserve à l'éditeur

## Testing
- `dotnet build` *(échec : dotnet absent dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_689ba0e8cf188325921889f7c36cd48b