### PR TITLE
Empêcher Dash_Battle après une Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -261,7 +261,8 @@ public class RhythmQTEManager : MonoBehaviour
             yield return null;
         }
 
-        if (!move.stayInPlace)
+        // 📝 Si aucune Timeline ne gère déjà le retour, on replace manuellement
+        if (!move.stayInPlace && !hasTimeline)
             // Retourne le lanceur à sa position de départ enregistrée
             yield return ReturnToInitialPosition(move, caster, target, originPosition);
 
@@ -374,8 +375,8 @@ public class RhythmQTEManager : MonoBehaviour
             LastItemSuccess = successResults.All(v => v);
         }
 
-        // Retour à la position d'origine si l'objet ne demande pas de rester en place
-        if (caster != null && !item.stayInPlace)
+        // 📝 Retour à la position d'origine uniquement si aucune Timeline ne gère le retour
+        if (!hasTimeline && caster != null && !item.stayInPlace)
         {
             // Revenir exactement à la position occupée au lancement de l'objet
             yield return SimpleReturnToInitialPosition(caster, target, item, originPosition);


### PR DESCRIPTION
## Résumé
- Évite de relancer `Dash_Battle` lorsque la Timeline contrôle déjà le retour d'un MusicalMove
- Empêche l'animation `Dash_Battle` après une Timeline d'utilisation d'objet

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés/403)*

------
https://chatgpt.com/codex/tasks/task_e_689e4281c5a08325b552900965e9537b