### PR TITLE
Nettoyage des champs visuels remplacés par les Timelines

### DIFF
--- a/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
+++ b/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
@@ -25,7 +25,6 @@ MonoBehaviour:
   criticalEffectType: 6
   criticalEffectValue: 20
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 8
   healAmount: 0
   healIsPercentage: 0
@@ -41,12 +40,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 3
   targetTypes: 03000000
-  introVFXPrefab: {fileID: 0}
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: d9b9aa0fa4a491f4b95a097b3a08818f, type: 2}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_BombeSonique/Item_BombeSonique.asset
+++ b/Assets/Items/Item_BombeSonique/Item_BombeSonique.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 6
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 2
   targetTypes: 02000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_ClefDuCourage/Item_ClefDuCourage.asset
+++ b/Assets/Items/Item_ClefDuCourage/Item_ClefDuCourage.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 3
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 3
   targetTypes: 03000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_ElixirRevitalisant/Item_ElixirRevitalisant.asset
+++ b/Assets/Items/Item_ElixirRevitalisant/Item_ElixirRevitalisant.asset
@@ -24,7 +24,6 @@ MonoBehaviour:
   criticalEffectType: 6
   criticalEffectValue: 20
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 2
   healAmount: 0
   healIsPercentage: 0
@@ -40,12 +39,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 3
   targetTypes: 03000000
-  introVFXPrefab: {fileID: 0}
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 9ba735de2dc708841855bf78afa002b1, type: 2}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_Endormissement/Item_Endormissement.asset
+++ b/Assets/Items/Item_Endormissement/Item_Endormissement.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 500
   stayInPlace: 1
-  itemTargetingAnimation: {fileID: 0}
   effectType: 10
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 1
   targetTypes: 0100000003000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 132371f140add7b44bb629233ff86ec1, type: 2}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
+++ b/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 9
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 5
   targetTypes: 05000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -24,7 +24,6 @@ MonoBehaviour:
   criticalEffectType: 6
   criticalEffectValue: 20
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 7400000, guid: 340c7ecb981d9884c882afeca7561142, type: 2}
   effectType: 7
   healAmount: 0
   healIsPercentage: 0
@@ -40,12 +39,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 0
   targetTypes: 00000000
-  introVFXPrefab: {fileID: 0}
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 7e17f404f19e47b49bd3243893e2e70d, type: 2}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 7400000, guid: c0549798d5c8142449bdf09838c79aea, type: 3}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
+++ b/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 5
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 2
   defaultTargetType: 4
   targetTypes: 04000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
+++ b/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 1
   healAmount: 50
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 3
   targetTypes: 03000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/Items/Item_Reveil/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil/Item_Reveil.asset
@@ -21,7 +21,6 @@ MonoBehaviour:
   moveSpeed: 0
   castDistance: 0
   stayInPlace: 0
-  itemTargetingAnimation: {fileID: 0}
   effectType: 11
   healAmount: 0
   healIsPercentage: 0
@@ -37,12 +36,7 @@ MonoBehaviour:
   timingDuration: 0
   defaultTargetType: 3
   targetTypes: 03000000
-  introVFXPrefab: {fileID: 0}
   performingTimeline: {fileID: 0}
   preparingTimeline: {fileID: 0}
   beatPattern: []
   notes: []
-  introAnimationClip: {fileID: 0}
-  animationClip: {fileID: 0}
-  visualEffect: {fileID: 0}
-  introClip: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
+++ b/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Soigne légèrement un allié et augmente sa Défense pour deux tours."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
+++ b/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Soigne tous les alli\xE9s d'une petite quantit\xE9."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 50
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
+++ b/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Inflige de lourds d\xE9g\xE2ts \xE0 une cible unique apr\xE8s un court d\xE9lai."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes:
   - noteInput: {fileID: 21300000, guid: f450c5a75855c3e4e89f8acf1545fa52, type: 3}
@@ -45,8 +44,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 10
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 1
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
+++ b/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -16,7 +16,6 @@ MonoBehaviour:
   moveType: 1
   moveIcon: {fileID: 0}
   description:
-  musicalMoveTargetingAnimationName:
   musicalMoveRunAnimationName:
   maxRunDuration: 0.5
   stayFaceToTarget: 0
@@ -34,5 +33,3 @@ MonoBehaviour:
   castDistance: 0
   stayInPlace: 0
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Se place devant l'unit\xE9 cible."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 0}
   description: "Fusionne l'\xE2me du lanceur avec celui de son ange gardien."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 0
   relativePosition: 4
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 0}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: Applique une marque sur un ennemi.
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 1
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Applique une marque de loyaut\xE9 sur un alli\xE9."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 1
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes: []
   power: 10
@@ -41,8 +40,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 1
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
   tpVfx_End: {fileID: 0}
   tpSFx_Start: {fileID: 8300000, guid: c013e2c53abacf64caa2b97855ff09da, type: 3}

--- a/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
+++ b/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Inflige des dégâts et réduit la Défense de la cible."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 10
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 1
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 1
   notes: []
   power: 10
@@ -41,8 +40,6 @@ MonoBehaviour:
   stayInPlace: 1
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
   tpVfx_End: {fileID: 0}
   tpSFx_Start: {fileID: 8300000, guid: c013e2c53abacf64caa2b97855ff09da, type: 3}

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: "Endort un ennemi pendant un tour."
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -17,7 +17,6 @@ MonoBehaviour:
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: f507f03eb80bcbf49bb458bd6a54bd9a, type: 3}
   description: 
-  musicalMoveTargetingAnimation: {fileID: 0}
   stayFaceToTarget: 0
   notes: []
   power: 0
@@ -35,8 +34,6 @@ MonoBehaviour:
   stayInPlace: 0
   interceptable: 1
   relativePosition: 0
-  introVFXPrefab: {fileID: 0}
-  hitVFXPrefab: {fileID: 0}
   useTeleportation: 1
   teleportStartVFXPrefab: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
   teleportEndVFXPrefab: {fileID: 0}

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -25,8 +25,7 @@ public class ItemData : ScriptableObject
 
     [Tooltip("Si vrai, le lanceur reste à la position cible après l'action")] public bool stayInPlace;
 
-    public AnimationClip itemTargetingAnimation;
-
+    // Le ciblage visuel est désormais géré par la Timeline de préparation
     public ItemEffectType effectType;
 
     [Header("Heal Settings")]
@@ -52,9 +51,6 @@ public class ItemData : ScriptableObject
     [Header("Ciblage")]
     public TargetType defaultTargetType = TargetType.SingleAlly;
     public List<TargetType> targetTypes = new List<TargetType>() { TargetType.SingleAlly };
-
-    [Header("VFX")]
-    public GameObject introVFXPrefab;
 
     [Header("Téléportation")]
     // Effet visuel déclenché au départ du téléport
@@ -87,12 +83,6 @@ public class ItemData : ScriptableObject
 
     [Header("Notes avec Variantes Sonores")]
     public List<NoteVariant> notes;
-
-    [Header("Visuel et FX")]
-    public AnimationClip introAnimationClip;
-    public AnimationClip animationClip;
-    public GameObject visualEffect;
-    public AudioClip introClip;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -16,7 +16,7 @@ public class MusicalMoveSO : ScriptableObject
     public bool onlyAwake = false;
     public Sprite moveIcon;
     [TextArea] public string description;
-    public AnimationClip musicalMoveTargetingAnimation;
+    // L'animation de ciblage est désormais pilotée par la Timeline de préparation
     public bool stayFaceToTarget = true;
 
     [System.Serializable]
@@ -69,10 +69,6 @@ public class MusicalMoveSO : ScriptableObject
 
     [Header("Placement autour de la cible")]
     public RelativePosition relativePosition = RelativePosition.Front;
-
-    [Header("VFX")]
-    public GameObject introVFXPrefab;
-    public GameObject hitVFXPrefab;
 
     [Header("Téléportation")]
     // Effet visuel déclenché au départ du téléport

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -244,9 +244,7 @@ public class InputsManager : MonoBehaviour
                 }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
+                // Les animations de visée sont désormais intégrées dans la Timeline de préparation
             }
             else
             {
@@ -260,11 +258,7 @@ public class InputsManager : MonoBehaviour
                 bm.currentItem = bm.itemChoices[0];
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation != null)
-                {
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
-                }
+                // La Timeline de préparation gère maintenant les animations liées à l'objet
             }
             else
             {
@@ -302,9 +296,6 @@ public class InputsManager : MonoBehaviour
                 }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
             }
             else
             {
@@ -318,11 +309,6 @@ public class InputsManager : MonoBehaviour
                 bm.currentItem = bm.itemChoices[1];
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation)
-                {
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
-                }
             }
             else
             {
@@ -356,9 +342,6 @@ public class InputsManager : MonoBehaviour
                 }
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentMove);
-
-                if (bm.currentMove.musicalMoveTargetingAnimation != null)
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>().Play(bm.currentMove.musicalMoveTargetingAnimation.name);
             }
             else
             {
@@ -372,11 +355,6 @@ public class InputsManager : MonoBehaviour
                 bm.currentItem = bm.itemChoices[2];
                 bm.ToggleMenuContainers(false, false, false);
                 bm.HandleTargetSelection(bm.currentItem);
-
-                if (bm.currentItem.itemTargetingAnimation != null)
-                {
-                    bm.currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(bm.currentItem.itemTargetingAnimation.name);
-                }
             }
             else
             {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1273,9 +1273,7 @@ public class NewBattleManager : MonoBehaviour
         {
             ToggleMenuContainers(false, false, false);
             HandleTargetSelection(move);
-
-            if (move.musicalMoveTargetingAnimation != null)
-                currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(move.musicalMoveTargetingAnimation.name);
+            // La Timeline de préparation prend en charge l'animation de ciblage
         }
         else
         {
@@ -1294,12 +1292,7 @@ public class NewBattleManager : MonoBehaviour
         {
             ToggleMenuContainers(false, false, false);
             HandleTargetSelection(item);
-
-            // L'animation spécifique à l'objet prend le relais une fois la Timeline arrêtée
-            if (item.itemTargetingAnimation != null)
-            {
-                currentCharacterUnit.GetComponentInChildren<Animator>()?.Play(item.itemTargetingAnimation.name);
-            }
+            // L'animation de ciblage est désormais gérée par la Timeline de préparation
         }
         else
         {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -338,27 +338,11 @@ public class RhythmQTEManager : MonoBehaviour
                 Debug.LogWarning($"[ItemRoutine] Timeline '{item.performingTimeline.name}' encore active après {maxTimelineDuration}s. Suite forcée.");
             }
         }
-        else if (item.introAnimationClip != null && animator != null && !caster.IsDead)
-        {
-            animator.Play(item.introAnimationClip.name);
-            yield return null;
-            float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
-            yield return new WaitForSeconds(clipDuration);
-        }
-
+        // Sans Timeline, aucun visuel n'est joué et l'objet passe directement à l'application de l'effet
         // Téléportation jusqu'à la cible si aucune Timeline ne gère déjà le mouvement
         if (!hasTimeline && caster != null && target != null)
         {
             yield return SimpleMoveTo(caster, target, item);
-        }
-
-        // Animation principale si pas de Timeline
-        if (!hasTimeline && item.animationClip != null && animator != null && !caster.IsDead)
-        {
-            animator.Play(item.animationClip.name);
-            yield return null;
-            float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
-            yield return new WaitForSeconds(clipDuration);
         }
 
         // Phase de QTE propre à l'objet uniquement sans Timeline


### PR DESCRIPTION
## Résumé
- Supprime les propriétés d'animation et de VFX devenues obsolètes sur les Items et MusicalMoves
- Redirige la sélection et l'exécution vers les Timelines de préparation et de performance
- Nettoie les assets ScriptableObject associés

## Tests
- `dotnet test` *(échec : dotnet non installé dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_689ed91b53d4832598d0789f8478c3b5