### PR TITLE
Fix battle intro timeline and cleanup enemy detection

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -317,13 +317,16 @@ public class BattleTransitionManager : MonoBehaviour
         NewBattleManager.Instance.SpawnAll();
 
         CharacterUnit firstUnit = NewBattleManager.Instance.ReturnFirstStrikeCharacter();
-        GameObject introCam = GameObject.Find("BattleScene/Camera_BattleIntro");
+        GameObject introCam = GameObject.Find("BattleScene_Camera_BattleIntro");
         if (introCam != null)
         {
+            introCam.SetActive(true); // Active explicitement la caméra d'intro si elle était désactivée
+
             if (firstUnit != null)
                 introCam.transform.position = firstUnit.transform.position;
 
-            PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>();
+            // Recherche du PlayableDirector même si le composant est sur un enfant inactif
+            PlayableDirector introDirector = introCam.GetComponentInChildren<PlayableDirector>(true);
             if (introDirector != null)
             {
                 // On joue la Timeline d'introduction
@@ -333,7 +336,7 @@ public class BattleTransitionManager : MonoBehaviour
             }
             else
             {
-                Debug.LogWarning("[BattleTransitionManager] Timeline d'intro introuvable.");
+                Debug.LogWarning("[BattleTransitionManager] Timeline d'intro introuvable sur la battleCamera.");
             }
         }
         else
@@ -383,6 +386,7 @@ public class BattleTransitionManager : MonoBehaviour
 
         // Par sécurité, on vide la liste au cas où il resterait des références
         playerDetection.enemiesInFight.Clear();
+        playerDetection.detectedEnemies.Clear(); // Nettoyage complet des ennemis détectés
 
         GameManager.Instance.ChangeGameState(GameState.Exploration);
 

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -173,6 +173,7 @@ public class PlayerDetection : MonoBehaviour
         currentDetectionRadius = baseDetectionRadius;
         battleEngaged = false;
         detectedEnemies.Clear();
+        enemiesInFight.Clear(); // On s'assure qu'aucun ennemi du combat prcédent ne reste enregistré
         detectionOn = false;
         firstEnemyDetected = false;
 


### PR DESCRIPTION
## Summary
- Ensure enemy lists are cleared when exiting battle
- Properly find and activate intro battle camera timeline

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eebc7822c8325ac33218a26370740