### PR TITLE
Corriger l'appel de décals pour HDRP 17

### DIFF
--- a/Assets/VFX/0 - Vefects/Easy Shockwaves VFX HDRP/Demo/Resources/Shaders/SH_Vefects_URP_VFX_Character_Showoff.shader
+++ b/Assets/VFX/0 - Vefects/Easy Shockwaves VFX HDRP/Demo/Resources/Shaders/SH_Vefects_URP_VFX_Character_Showoff.shader
@@ -698,7 +698,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
 				#endif
@@ -1436,7 +1436,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -2104,7 +2104,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -2725,7 +2725,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -3319,7 +3319,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -3985,7 +3985,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -4776,7 +4776,7 @@ Shader "Vefects/SH_Vefects_URP_VFX_Character_Showoff"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif

--- a/Assets/VFX/0 - Vefects/Easy Shockwaves VFX HDRP/_ Extra/Shaders/SH_Vefects_Extra_Grid_01_HDRP.shader
+++ b/Assets/VFX/0 - Vefects/Easy Shockwaves VFX HDRP/_ Extra/Shaders/SH_Vefects_Extra_Grid_01_HDRP.shader
@@ -668,7 +668,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
 				#endif
@@ -1378,7 +1378,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -2014,7 +2014,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -2621,7 +2621,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -3201,7 +3201,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -3853,7 +3853,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif
@@ -4624,7 +4624,7 @@ Shader "/Vefects/SH_Vefects_Extra_Grid_01_HDRP"
 				if (_EnableDecals)
 				{
 					DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, fragInputs, surfaceDescription.Alpha);
-					ApplyDecalToSurfaceData(decalSurfaceData, fragInputs.tangentToWorld[2], surfaceData);
+					ApplyDecalToSurfaceData(decalSurfaceData, surfaceData); // Mise à jour HDRP 17 : l'argument de normale est retiré
 				}
 				#endif
                 #endif


### PR DESCRIPTION
## Résumé
- Met à jour `ApplyDecalToSurfaceData` dans les shaders Vefects pour correspondre à l'API HDRP 17.

## Tests
- `dotnet test` *(échoué : dotnet manquant)*
- `npm test` *(échoué : package.json absent)*

------
https://chatgpt.com/codex/tasks/task_e_689f5d301e4883259d1d67020ac65626