### PR TITLE
Optimisations basiques de performance

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -41,6 +41,12 @@ public class CameraController : MonoBehaviour
     private Camera activeCamera;
     private Camera worldCamera; // Référence directe à la WorldCamera
 
+    // Rafraîchissement moins fréquent de la recherche du point de caméra
+    [Header("Optimisation")]
+    [Tooltip("Délai entre deux recherches du point de caméra le plus proche")]
+    [SerializeField] private float camPointRefreshInterval = 0.2f;
+    private float camPointRefreshTimer;
+
     [Header("---------- Effet de respiration ----------")]
     [Tooltip("Amplitude du mouvement vertical simulant la respiration.")]
     [SerializeField] private float breathingAmplitude = 0.05f;
@@ -439,7 +445,13 @@ public class CameraController : MonoBehaviour
                 break;
 
             case WorldCameraState.ResearchClosestCamPoint:
-                ApplyClosestCamera();
+                // ✅ Limite la recherche du point de caméra le plus proche
+                camPointRefreshTimer -= Time.deltaTime;
+                if (camPointRefreshTimer <= 0f)
+                {
+                    ApplyClosestCamera();
+                    camPointRefreshTimer = camPointRefreshInterval;
+                }
                 break;
 
             default:

--- a/Assets/Scripts/MonoBehavioursUsed/DestructionScript.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DestructionScript.cs
@@ -4,11 +4,13 @@ using UnityEngine;
 
 public class DestructionScript : MonoBehaviour
 {
-
+    // Temps avant la destruction automatique de l'objet
     public float timeBeforeDestroy;
-        
-    void Update()
+
+    private void Start()
     {
-       Destroy(gameObject, timeBeforeDestroy);
+        // 📝 Appel unique à Destroy pour éviter une allocation par frame
+        // L'objet sera détruit au bout de `timeBeforeDestroy` secondes
+        Destroy(gameObject, timeBeforeDestroy);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
@@ -18,6 +18,9 @@ public class InteractionManager : MonoBehaviour
     private GameObject localInfoBox;
     public GameObject currentInteractable;
 
+    // Buffer réutilisé pour stocker les collisions détectées
+    private readonly Collider[] _hitsBuffer = new Collider[10];
+
     [Header("References")]
     [Tooltip("Director controlling cutscenes")]
     public PlayableDirector director; // 👈 nouveau champ
@@ -114,9 +117,15 @@ public class InteractionManager : MonoBehaviour
             return;
         }
 
-        Collider[] hits = Physics.OverlapSphere(playerTransform.position, interactionRange, interactableLayer);
+        // Utilisation de Physics.OverlapSphereNonAlloc pour éviter une allocation à chaque frame
+        int hitCount = Physics.OverlapSphereNonAlloc(
+            playerTransform.position,
+            interactionRange,
+            _hitsBuffer,
+            interactableLayer
+        );
 
-        if (hits.Length > 0)
+        if (hitCount > 0)
         {
             // ... ton code inchangé ...
         }

--- a/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PerformanceManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 
 /// <summary>
 /// Gestionnaire simple de performance.
@@ -14,6 +15,10 @@ public class PerformanceManager : MonoBehaviour
     // Moyenne glissante du temps entre deux frames (utilisé pour calculer un FPS stable)
     private float deltaTime = 0f;
 
+    // Référence facultative vers un composant UI Text pour afficher les FPS
+    [Tooltip("Texte UI où afficher les FPS. Laisser vide pour ne rien afficher.")]
+    public Text fpsText;
+
     private void Awake()
     {
         // Force Unity à viser le framerate défini
@@ -24,12 +29,12 @@ public class PerformanceManager : MonoBehaviour
     {
         // Actualise le deltaTime non affecté par le timeScale pour obtenir un calcul d'FPS fiable
         deltaTime += (Time.unscaledDeltaTime - deltaTime) * 0.1f;
-    }
 
-    private void OnGUI()
-    {
-        // Convertit le deltaTime en FPS et l'affiche en haut à gauche de l'écran
-        int fps = Mathf.CeilToInt(1f / deltaTime);
-        GUI.Label(new Rect(10, 10, 100, 20), fps + " FPS");
+        // Affiche les FPS via un élément UI plus léger que OnGUI
+        if (fpsText != null)
+        {
+            int fps = Mathf.CeilToInt(1f / deltaTime);
+            fpsText.text = fps + " FPS";
+        }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -25,14 +24,20 @@ public class PlayerDetection : MonoBehaviour
     public string enemyTag = "Enemy";
 
     // ------------------------------------------------------------------
-    // Liste temporaire des ennemis actuellement engagés dans un combat
-    // Permet d'éviter de redétecter en boucle les mêmes ennemis tant
-    // qu'ils ne sont pas définitivement retirés du monde.
+    // Listes réutilisées pour limiter les allocations pendant Update
+    // enemiesInFight : ennemis déjà engagés en combat
+    // tempEnemies    : buffer pour les calculs de distance
     // ------------------------------------------------------------------
     public List<Enemy> enemiesInFight = new List<Enemy>();
+    private readonly List<Enemy> tempEnemies = new List<Enemy>();
 
     public List<CharacterData> detectedEnemies = new List<CharacterData>();
     public bool detectionOn = true;
+
+    // Buffers pour les raycasts sans allocation
+    private const int MaxColliders = 50;
+    private readonly Collider[] initialResults = new Collider[MaxColliders];
+    private readonly Collider[] expandedResults = new Collider[MaxColliders];
 
     [Header("Effets sonores")]
     [Tooltip("Clips vocaux joués lors de la première détection d'un ennemi")]
@@ -71,22 +76,26 @@ public class PlayerDetection : MonoBehaviour
         if (!detectionOn)
             return;
 
-        // On recherche tous les colliders dans le rayon de base (sans layer mask)
-        // afin de savoir s'il y a réellement un ennemi à proximité avant de jouer une voix.
-        Collider[] initialColliders = Physics.OverlapSphere(
+        // Recherche sans allocation d'un ennemi proche
+        int initialCount = Physics.OverlapSphereNonAlloc(
             transform.position,
-            currentDetectionRadius
+            currentDetectionRadius,
+            initialResults
         );
 
-        // On filtre uniquement ceux qui portent le tag "Enemy"
-        var initialHits = initialColliders
-            .Where(c => c.CompareTag(enemyTag))
-            .ToArray();
+        bool enemyFound = false;
+        for (int i = 0; i < initialCount; i++)
+        {
+            if (initialResults[i].CompareTag(enemyTag))
+            {
+                enemyFound = true;
+                break;
+            }
+        }
 
         // Si aucun ennemi n'est trouvé, on quitte immédiatement la fonction
-        // pour éviter de jouer un clip vocal inutilement.
-        if (initialHits.Length == 0)
-            return; // aucun ennemi trouvé dans le rayon de base
+        if (!enemyFound)
+            return;
 
         // Lecture du clip vocal uniquement lors de la première détection effective d'un ennemi
         if (!firstEnemyDetected && firstDetectionVoices.Count > 0)
@@ -106,39 +115,38 @@ public class PlayerDetection : MonoBehaviour
         detectionOn = false;
         currentDetectionRadius = currentDetectionRadius + detectionExpansion;
 
-        // On récupère tous les colliders dans le rayon élargi
-        Collider[] allColliders = Physics.OverlapSphere(
+        // On récupère tous les colliders dans le rayon élargi sans allocation
+        int allCount = Physics.OverlapSphereNonAlloc(
             transform.position,
-            currentDetectionRadius
+            currentDetectionRadius,
+            expandedResults
         );
 
-        // On filtre encore par tag "Enemy"
-        var allHits = allColliders
-            .Where(c => c.CompareTag(enemyTag))
-            .ToArray();
-
-        // On récupère le composant Enemy (ou le parent contenant Enemy), en évitant les doublons
-        var enemies = allHits
-            .Select(c => c.GetComponentInParent<Enemy>())
-            // On ignore les ennemis déjà engagés dans un combat
-            .Where(e => e != null && !enemiesInFight.Contains(e))
-            .Distinct()
-            .ToList();
-
-        // On ne garde que les 3 plus proches
-        var closestThree = enemies
-            .OrderBy(e => Vector3.Distance(transform.position, e.transform.position))
-            .Take(3)
-            .ToList();
-
-        // On remplit detectedEnemies
-        detectedEnemies.Clear();
-        foreach (var e in closestThree)
+        tempEnemies.Clear();
+        for (int i = 0; i < allCount; i++)
         {
-            detectedEnemies.Add(e.enemyData);
+            Collider col = expandedResults[i];
+            if (!col.CompareTag(enemyTag))
+                continue;
 
+            Enemy enemy = col.GetComponentInParent<Enemy>();
+            if (enemy != null && !enemiesInFight.Contains(enemy) && !tempEnemies.Contains(enemy))
+            {
+                tempEnemies.Add(enemy);
+            }
+        }
+
+        // Trie les ennemis par distance et ne garde que les trois plus proches
+        tempEnemies.Sort((a, b) =>
+            Vector3.Distance(transform.position, a.transform.position)
+                .CompareTo(Vector3.Distance(transform.position, b.transform.position)));
+
+        detectedEnemies.Clear();
+        for (int i = 0; i < tempEnemies.Count && i < 3; i++)
+        {
+            Enemy e = tempEnemies[i];
+            detectedEnemies.Add(e.enemyData);
             // Ajout à la liste temporaire pour empêcher une redétection
-            // et indiquer que cet ennemi est actuellement engagé dans ce combat
             enemiesInFight.Add(e);
         }
 

--- a/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTEBar.cs
@@ -29,6 +29,9 @@ public class QTEBar : MonoBehaviour
         public bool started;
     }
     private readonly List<ScheduledNote> scheduledNotes = new();
+
+    // Liste tampon réutilisée pour retirer les notes terminées sans nouvelle allocation
+    private readonly List<ScheduledNote> removalBuffer = new();
     // Durée par défaut pour qu'une note parcoure toute la barre
     private const float defaultTravelDuration = 2f;
     private float barWidth;
@@ -133,8 +136,8 @@ public class QTEBar : MonoBehaviour
             return;
 
         float now = Time.unscaledTime;
-        // Liste temporaire pour retirer proprement les notes terminées
-        List<ScheduledNote> toRemove = null;
+        // Réutilise une liste tampon pour éviter des allocations à chaque frame
+        removalBuffer.Clear();
 
         foreach (var n in scheduledNotes)
         {
@@ -152,7 +155,7 @@ public class QTEBar : MonoBehaviour
             if (n.image == null)
             {
                 // L'objet a été détruit ailleurs, on supprime la note de la liste
-                (toRemove ??= new List<ScheduledNote>()).Add(n);
+                removalBuffer.Add(n);
                 continue;
             }
 
@@ -160,18 +163,15 @@ public class QTEBar : MonoBehaviour
             UpdateNotePosition(n.image, progress);
 
             if (progress >= 1f)
-                (toRemove ??= new List<ScheduledNote>()).Add(n);
+                removalBuffer.Add(n);
         }
 
-        if (toRemove != null)
+        foreach (var rem in removalBuffer)
         {
-            foreach (var rem in toRemove)
-            {
-                scheduledNotes.Remove(rem);
-                activeNotes.Remove(rem.image);
-                if (rem.image != null)
-                    Destroy(rem.image.gameObject);
-            }
+            scheduledNotes.Remove(rem);
+            activeNotes.Remove(rem.image);
+            if (rem.image != null)
+                Destroy(rem.image.gameObject);
         }
     }
 }


### PR DESCRIPTION
## Résumé
- Détruire les objets temporaires une seule fois via `Start` pour éviter les allocations continues
- Réduire les allocations dans les détections d’ennemis et d’interactions grâce à `OverlapSphereNonAlloc`
- Remplacer l’affichage FPS `OnGUI` par un `Text` léger et limiter les scans de caméras
- Réutiliser des buffers dans la barre de QTE pour supprimer les listes temporaires

## Test
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts inaccessibles 403)*


------
https://chatgpt.com/codex/tasks/task_e_689e49b6a14c83259746688e7454005c