### PR TITLE
Gestion des caméras pour éviter les chutes de FPS

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -238,6 +238,9 @@ public class BattleTransitionManager : MonoBehaviour
         if (worldScene != null)
             worldScene.SetActive(false);
 
+        // Active uniquement les caméras nécessaires au lancement du combat
+        CameraActivationManager.Instance?.ActivateBattleAndVersusCameras();
+
         AudioClip randomClip = null;
         ZoneSO currentZone = ZoneManager.Instance != null ? ZoneManager.Instance.currentZone : null;
         if (currentZone != null && currentZone.battleMusic != null && currentZone.battleMusic.Length > 0)
@@ -277,6 +280,9 @@ public class BattleTransitionManager : MonoBehaviour
         versusTransition.SetActive(true);
         versusCameraCanvas.SetActive(true);
 
+        // S'assure que la VersusCam est bien active conjointement à la BattleCam
+        CameraActivationManager.Instance?.ActivateBattleAndVersusCameras();
+
         // Cache le bouton "Continuer" tant que le chargement du champ de bataille n'est pas terminé
         foreach (var go in continuePrompts)
             if (go != null)
@@ -310,6 +316,10 @@ public class BattleTransitionManager : MonoBehaviour
         brokenGlass.SetActive(true);
         Animator glass = brokenGlass.GetComponent<Animator>();
         glass.Play("Glass_Explode");
+
+        // À la fin de l'animation, la VersusCam doit se désactiver
+        if (CameraActivationManager.Instance != null)
+            StartCoroutine(CameraActivationManager.Instance.DisableVersusAfterAnimation(glass));
 
         AudioManager.Instance.PlaySound(brokenGlassSound);
 
@@ -404,6 +414,9 @@ public class BattleTransitionManager : MonoBehaviour
         // Réactive également le GameObject principal du monde pour reprendre l'exploration
         if (worldScene != null)
             worldScene.SetActive(true);
+
+        // Retour à l'exploration : seule la WorldCam doit être active
+        CameraActivationManager.Instance?.ActivateWorldCamera();
 
         if (maskRingParticles != null)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Gère l'activation des différentes caméras du jeu afin d'éviter qu'elles soient
+/// toutes actives simultanément, ce qui provoquerait une chute de FPS.
+/// </summary>
+public class CameraActivationManager : MonoBehaviour
+{
+    public static CameraActivationManager Instance { get; private set; }
+
+    private Camera worldCamera;   // Référence à la WorldCam_Cam
+    private Camera battleCamera;  // Référence à la BattleCam_Cam
+    private Camera versusCamera;  // Référence à la VersusCam_Cam
+
+    /// <summary>
+    /// Création automatique du gestionnaire après le chargement de la scène.
+    /// </summary>
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void CreateInstance()
+    {
+        if (Instance == null)
+        {
+            GameObject manager = new GameObject("CameraActivationManager");
+            manager.AddComponent<CameraActivationManager>();
+        }
+    }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void Start()
+    {
+        // Recherche des caméras par leurs tags respectifs
+        worldCamera = GameObject.FindGameObjectWithTag("WorldCamera")?.GetComponent<Camera>();
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
+        versusCamera = GameObject.FindGameObjectWithTag("VersusCamera")?.GetComponent<Camera>();
+
+        ActivateWorldCamera(); // État par défaut : exploration
+    }
+
+    /// <summary>
+    /// Active uniquement la WorldCamera pour l'exploration.
+    /// </summary>
+    public void ActivateWorldCamera()
+    {
+        SetCameraState(worldCamera, true);
+        SetCameraState(battleCamera, false);
+        SetCameraState(versusCamera, false);
+    }
+
+    /// <summary>
+    /// Active la BattleCamera et la VersusCamera simultanément (début d'un combat).
+    /// </summary>
+    public void ActivateBattleAndVersusCameras()
+    {
+        SetCameraState(worldCamera, false);
+        SetCameraState(battleCamera, true);
+        SetCameraState(versusCamera, true);
+    }
+
+    /// <summary>
+    /// Active uniquement la BattleCamera (Versus terminé).
+    /// </summary>
+    public void ActivateBattleCamera()
+    {
+        SetCameraState(worldCamera, false);
+        SetCameraState(battleCamera, true);
+        SetCameraState(versusCamera, false);
+    }
+
+    /// <summary>
+    /// Désactive la VersusCamera après la fin d'une animation donnée.
+    /// </summary>
+    public IEnumerator DisableVersusAfterAnimation(Animator animator)
+    {
+        if (animator == null)
+            yield break;
+
+        // Attente d'une frame pour être sûr que l'animation a bien démarré
+        yield return null;
+        float duration = animator.GetCurrentAnimatorStateInfo(0).length;
+        yield return new WaitForSeconds(duration);
+        ActivateBattleCamera();
+    }
+
+    /// <summary>
+    /// Active ou désactive proprement une caméra si elle existe.
+    /// </summary>
+    private void SetCameraState(Camera cam, bool state)
+    {
+        if (cam != null)
+            cam.gameObject.SetActive(state);
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f603fe7a12d4defbb4f2a7c57415962


### PR DESCRIPTION
## Résumé
- Ajout d'un `CameraActivationManager` pour activer/désactiver WorldCam, BattleCam et VersusCam.
- Intégration du gestionnaire dans `BattleTransitionManager` afin de limiter les caméras actives et désactiver VersusCam après `Glass_Explode`.

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689f8550ae008325800cf91673fc65cd