### PR TITLE
fix: enable battle intro timeline

### DIFF
--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -128,9 +128,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 36918448}
+  - component: {fileID: 36918449}
+  - component: {fileID: 36918450}
   m_Layer: 6
   m_Name: BattleScene_Camera_BattleIntro
-  m_TagString: Untagged
+  m_TagString: BattleCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -150,6 +152,76 @@ Transform:
   m_Children: []
   m_Father: {fileID: 406581255}
   m_LocalEulerAnglesHint: {x: 20.068, y: 56.175, z: 2.615}
+--- !u!20 &36918449
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36918447}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 1
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 20
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!320 &36918450
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36918447}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 72784fea13a73344ab4475f8f964f9ba, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: -4776175127404202534, guid: 72784fea13a73344ab4475f8f964f9ba, type: 2}
+    value: {fileID: 0}
+  m_ExposedReferences:
+    m_References: []
 --- !u!1 &217199072
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Playables;
+using UnityEngine.Timeline; // Requis pour manipuler les TimelineAsset
 using UnityEngine.InputSystem; // Nécessaire pour utiliser les actions d'input
 
 public class BattleTransitionManager : MonoBehaviour
@@ -340,10 +341,34 @@ public class BattleTransitionManager : MonoBehaviour
             PlayableDirector introDirector = battleCamera.transform.parent.GetComponentInChildren<PlayableDirector>(true);
             if (introDirector != null)
             {
-                // On joue la Timeline d'introduction
-                TimelineManager.Instance.PlayTimeline(introDirector);
-                // On attend la fin de la timeline pour éviter l'affichage de l'UI pendant la cinématique
-                yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
+                // Récupère le TimelineAsset associé pour le transmettre au TimelineLauncher
+                TimelineAsset introAsset = introDirector.playableAsset as TimelineAsset;
+
+                if (introAsset != null && TimelineLauncher.Instance != null)
+                {
+                    // Utilise l'Animator de la première unité comme "caster" pour les éventuels bindings
+                    GameObject casterGO = firstUnit != null ? firstUnit.animator?.gameObject : null;
+
+                    // Lance la timeline d'introduction via le TimelineLauncher afin de bénéficier
+                    // des mêmes mécaniques que pour les MusicalMoves ou les Items
+                    TimelineLauncher.Instance.PlayTimeline(introAsset, casterGO, "BattleCamera");
+
+                    // Attente de la fin réelle de la timeline pour ne pas afficher l'UI trop tôt
+                    float maxTimelineDuration = (float)introAsset.duration + 0f; // marge de sécurité
+                    float timelineTimer = 0f;
+
+                    while (TimelineLauncher.Instance != null &&
+                           TimelineLauncher.Instance.IsTimelineActive &&
+                           timelineTimer < maxTimelineDuration)
+                    {
+                        timelineTimer += Time.deltaTime;
+                        yield return null;
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning("[BattleTransitionManager] TimelineLauncher indisponible ou TimelineAsset manquant.");
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- tag BattleScene intro camera with `BattleCamera`
- add Camera and PlayableDirector components so intro timeline plays
- lancer la timeline d'intro via TimelineLauncher et attendre la fin avant d'afficher l'UI

## Testing
- `dotnet test` *(fail: command not found)*
- `npm test` *(fail: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f91edb6408325b188c1ae383f8eaa