### PR TITLE
Ajout d'un masque circulaire pour l'occlusion caméra

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
@@ -15,12 +15,18 @@ public class CameraOcclusionMask : MonoBehaviour
     [Tooltip("Marge supplémentaire autour de la silhouette de la cible")]
     [SerializeField] private float sizePadding = 20f;
 
+    [Header("Shader de masque circulaire")]
+    [Tooltip("Shader appliqué aux obstacles afin d'y découper un cercle transparent")] 
+    [SerializeField] private Shader occlusionShader;
+
     // Renderer principal de la cible utilisé pour calculer sa taille à l'écran
     private Renderer targetRenderer;
 
     private RectTransform maskRect;
-    // Liste des Renderers rendus invisibles afin de pouvoir les réafficher ensuite
-    private readonly List<Renderer> hiddenRenderers = new List<Renderer>();
+    // Sauvegarde des matériaux originaux pour pouvoir rétablir l'affichage des obstacles
+    private readonly Dictionary<Renderer, Material[]> originalMaterials = new Dictionary<Renderer, Material[]>();
+    // Liste des renderers utilisant actuellement le shader de découpe
+    private readonly List<Renderer> maskedRenderers = new List<Renderer>();
 
     private void Awake()
     {
@@ -33,6 +39,10 @@ public class CameraOcclusionMask : MonoBehaviour
         // Récupération du renderer de la cible pour estimer son empreinte à l'écran
         if (target != null)
             targetRenderer = target.GetComponentInChildren<Renderer>();
+
+        // Si aucun shader n'est renseigné dans l'inspecteur, on tente de le charger par défaut
+        if (occlusionShader == null)
+            occlusionShader = Shader.Find("Custom/OcclusionCircleCutout");
     }
 
     private void LateUpdate()
@@ -91,14 +101,40 @@ public class CameraOcclusionMask : MonoBehaviour
 
             maskRect.sizeDelta = Vector2.one * (computedSize + sizePadding);
 
-            // Désactivation des renderers des obstacles détectés
+            // Calcul des paramètres normalisés du masque pour le shader
+            Vector2 maskCenter01 = new Vector2(screenCenter.x / Screen.width, screenCenter.y / Screen.height);
+            float maskRadius01 = (maskRect.sizeDelta.x * 0.5f) / Screen.width;
+
+            // Application du shader de découpe à chaque obstacle touché
             foreach (RaycastHit hit in hits)
             {
                 Renderer rend = hit.collider.GetComponent<Renderer>();
-                if (rend != null && !hiddenRenderers.Contains(rend))
+                if (rend == null) continue;
+
+                // Si l'obstacle n'a pas encore été traité, on sauvegarde son matériau et on applique le shader
+                if (!originalMaterials.ContainsKey(rend))
                 {
-                    rend.enabled = false; // On masque l'obstacle
-                    hiddenRenderers.Add(rend); // On garde une trace pour le réactiver plus tard
+                    originalMaterials[rend] = rend.materials;
+
+                    Material[] newMats = new Material[rend.materials.Length];
+                    for (int m = 0; m < newMats.Length; m++)
+                    {
+                        Material baseMat = rend.materials[m];
+                        Material mat = new Material(occlusionShader);
+                        // Conservation de la texture principale si elle existe
+                        if (baseMat.HasProperty("_MainTex"))
+                            mat.SetTexture("_MainTex", baseMat.GetTexture("_MainTex"));
+                        newMats[m] = mat;
+                    }
+                    rend.materials = newMats;
+                    maskedRenderers.Add(rend);
+                }
+
+                // Mise à jour des propriétés du masque pour ce renderer
+                foreach (Material mat in rend.materials)
+                {
+                    mat.SetVector("_MaskCenter", maskCenter01);
+                    mat.SetFloat("_MaskRadius", maskRadius01);
                 }
             }
         }
@@ -106,29 +142,15 @@ public class CameraOcclusionMask : MonoBehaviour
         {
             if (maskObject.activeSelf)
                 maskObject.SetActive(false);
-        }
 
-        // Réactivation des obstacles qui ne sont plus occultants
-        for (int i = hiddenRenderers.Count - 1; i >= 0; i--)
-        {
-            Renderer rend = hiddenRenderers[i];
-            bool stillHidden = false;
-
-            foreach (RaycastHit hit in hits)
+            // Restauration des matériaux d'origine lorsque l'occlusion n'est plus présente
+            foreach (Renderer rend in maskedRenderers)
             {
-                if (hit.collider.GetComponent<Renderer>() == rend)
-                {
-                    stillHidden = true;
-                    break;
-                }
+                if (rend != null && originalMaterials.ContainsKey(rend))
+                    rend.materials = originalMaterials[rend];
             }
-
-            if (!stillHidden)
-            {
-                if (rend != null)
-                    rend.enabled = true; // On réaffiche l'obstacle
-                hiddenRenderers.RemoveAt(i);
-            }
+            maskedRenderers.Clear();
+            originalMaterials.Clear();
         }
     }
 }

--- a/Assets/Shaders/OcclusionCircleCutout.shader
+++ b/Assets/Shaders/OcclusionCircleCutout.shader
@@ -1,0 +1,57 @@
+Shader "Custom/OcclusionCircleCutout"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _MaskCenter ("Mask Center", Vector) = (0,0,0,0)
+        _MaskRadius ("Mask Radius", Float) = 0.25
+    }
+    SubShader
+    {
+        Tags {"RenderType"="Opaque"}
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float2 _MaskCenter;
+            float _MaskRadius;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+                float4 screenPos : TEXCOORD1;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                o.screenPos = ComputeScreenPos(o.vertex);
+                return o;
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                float2 screenUV = i.screenPos.xy / i.screenPos.w;
+                float dist = distance(screenUV, _MaskCenter);
+                if (dist < _MaskRadius)
+                    discard; // On rend transparent l'intérieur du cercle
+                return tex2D(_MainTex, i.uv);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Shaders/OcclusionCircleCutout.shader.meta
+++ b/Assets/Shaders/OcclusionCircleCutout.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ba404fbf33284c4c80e35480dbd40a10
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- Ajoute un shader `OcclusionCircleCutout` pour découper un cercle transparent dans les obstacles
- Met à jour `CameraOcclusionMask` pour appliquer ce shader au lieu de désactiver les renderers

## Tests
- `dotnet build` *(échec: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a079df148325afbccd3d9d04831f