### PR TITLE
Ajout du PNJ "Le Vieux" avec dialogues évolutifs

### DIFF
--- a/Assets/Dialogue/LeVieux_Phase1.asset
+++ b/Assets/Dialogue/LeVieux_Phase1.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8aacd0e4b30b5d46a727666d017bf22, type: 3}
+  m_Name: LeVieux_Phase1
+  m_EditorClassIdentifier:
+  lines:
+  - speakerName: Le Vieux
+    text: Oh... Voilà longtemps que je n'ai croisé une âme aussi vive.
+  - speakerName: Lucian
+    text: Qui êtes-vous ?
+  - speakerName: Le Vieux
+    text: Juste un reste de songe, petit. Le monde change, même ici.

--- a/Assets/Dialogue/LeVieux_Phase1.asset.meta
+++ b/Assets/Dialogue/LeVieux_Phase1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6cd05ba12bd40e3a3617235606c1f09
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Dialogue/LeVieux_Phase2.asset
+++ b/Assets/Dialogue/LeVieux_Phase2.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8aacd0e4b30b5d46a727666d017bf22, type: 3}
+  m_Name: LeVieux_Phase2
+  m_EditorClassIdentifier:
+  lines:
+  - speakerName: Le Vieux
+    text: Te voilà de retour. Le Rêve t'attire, mais prends garde aux entités qui veillent.
+  - speakerName: Lucian
+    text: Je cherche la Source. Savez-vous où elle se trouve ?
+  - speakerName: Le Vieux
+    text: Chaque pas t'en rapproche. Écoute les harmonies de ton cœur.

--- a/Assets/Dialogue/LeVieux_Phase2.asset.meta
+++ b/Assets/Dialogue/LeVieux_Phase2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cb00f1fc7124c73b282a5f3ac21a591
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Dialogue/LeVieux_Phase3.asset
+++ b/Assets/Dialogue/LeVieux_Phase3.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8aacd0e4b30b5d46a727666d017bf22, type: 3}
+  m_Name: LeVieux_Phase3
+  m_EditorClassIdentifier:
+  lines:
+  - speakerName: Le Vieux
+    text: L'avenir du Rêve dépend de ton choix, Lucian.
+  - speakerName: Lucian
+    text: Je ne suis pas certain d'être prêt...
+  - speakerName: Le Vieux
+    text: Nul ne l'est jamais. Mais avancer est la seule symphonie qui compte.

--- a/Assets/Dialogue/LeVieux_Phase3.asset.meta
+++ b/Assets/Dialogue/LeVieux_Phase3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: defc213ea56d4a33a281a065a54967b4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// PNJ "Le Vieux" : gère plusieurs phases de dialogue en fonction
+/// du nombre d'interactions du joueur.
+/// </summary>
+public class NPC_LeVieux : MonoBehaviour, IInteractable
+{
+    [Header("Dialogues du PNJ")]
+    [Tooltip("Liste des phases de dialogue (0 = première interaction, etc.).")]
+    public DialogueContainer[] dialoguePhases; // Références vers les dialogues successifs
+
+    // Indice de la prochaine phase à jouer
+    private int dialogueStage = 0;
+
+    // --- Implémentation de IInteractable ---
+    public GameObject GameObject => gameObject;
+
+    /// <summary>
+    /// Déclenche le dialogue correspondant à la phase en cours
+    /// si aucune autre interaction n'est active.
+    /// </summary>
+    public void Interact()
+    {
+        if (DialogueManager.Instance.isOpen || EventsManager.Instance.eventInProgress)
+        {
+            // Empêche les dialogues simultanés ou les cinématiques concurrentes
+            return;
+        }
+
+        if (dialogueStage >= dialoguePhases.Length)
+        {
+            // Toutes les phases ont été jouées : aucune interaction supplémentaire
+            return;
+        }
+
+        // Lance le dialogue approprié
+        StartCoroutine(PlayDialogue());
+    }
+
+    /// <summary>
+    /// Lance le dialogue de la phase courante, puis incrémente la phase.
+    /// </summary>
+    private IEnumerator PlayDialogue()
+    {
+        // Signale qu'un événement est en cours pour bloquer d'autres interactions
+        EventsManager.Instance.eventInProgress = true;
+
+        DialogueContainer container = dialoguePhases[dialogueStage];
+        if (container != null)
+        {
+            // Démarre le dialogue et attend sa fin
+            yield return DialogueManager.Instance.StartDialogue(container.lines);
+        }
+
+        // Prépare la phase suivante
+        IncrementDialogueStage();
+
+        // Libère le verrou d'événement
+        EventsManager.Instance.eventInProgress = false;
+    }
+
+    /// <summary>
+    /// Avance à la prochaine phase de dialogue.
+    /// </summary>
+    public void IncrementDialogueStage()
+    {
+        // Évite de dépasser la taille du tableau
+        dialogueStage = Mathf.Min(dialogueStage + 1, dialoguePhases.Length);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e5041ef3aca4c29b42f48977bce9748


### PR DESCRIPTION
## Résumé
- Ajout du script `NPC_LeVieux` gérant plusieurs phases de dialogue.
- Création de trois assets de dialogue pour chaque phase du PNJ.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés, installation impossible)*
- `npm test` *(échec : aucun fichier package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1be76b7b883259af8508383db25ea