### PR TITLE
Position aléatoire des bulles de dialogue

### DIFF
--- a/Assets/Scripts/Classes/DialogueContainer.cs
+++ b/Assets/Scripts/Classes/DialogueContainer.cs
@@ -3,5 +3,14 @@ using UnityEngine;
 [CreateAssetMenu(menuName = "Symphonie/Dialogue Container")]
 public class DialogueContainer : ScriptableObject
 {
+    // Lignes de dialogue à afficher
     public DialogueLine[] lines;
+
+    // Si vrai, la bulle de dialogue sera placée à une position aléatoire
+    // sécurisée afin d'éviter les bords de l'écran
+    public bool randomPosition = true;
+
+    // Position personnalisée (en coordonnées d'ancrage UI) utilisée
+    // lorsque randomPosition est désactivé
+    public Vector3 customPosition;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/CinematicPlayer.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CinematicPlayer.cs
@@ -38,7 +38,9 @@ public class CinematicPlayer : MonoBehaviour
                     if (step.dialogue != null)
                     {
                         bool done = false;
-                        DialogueManager.Instance.PlayDialogue(step.dialogue.lines, () => done = true);
+                        // Passe le DialogueContainer complet pour bénéficier de la
+                        // configuration de position (aléatoire ou fixe)
+                        DialogueManager.Instance.PlayDialogue(step.dialogue, () => done = true);
                         while (!done)
                             yield return null;
                     }

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -23,6 +23,8 @@ public class DialogueManager : MonoBehaviour
     public static DialogueManager Instance { get; private set; }
 
     private System.Action onDialogueEndCallback;
+    // Référence rapide au RectTransform pour repositionner la bulle
+    private RectTransform rectTransform;
 
     void Awake()
     {
@@ -33,21 +35,26 @@ public class DialogueManager : MonoBehaviour
         }
         Instance = this;
         DontDestroyOnLoad(gameObject);
+        rectTransform = GetComponent<RectTransform>();
     }
 
-    public void PlayDialogue(DialogueLine[] lines, System.Action onEnd = null)
+    // --- Nouvelle API utilisant DialogueContainer ---
+    public void PlayDialogue(DialogueContainer container, System.Action onEnd = null)
     {
         StopAllCoroutines();
         onDialogueEndCallback = onEnd;
-        StartCoroutine(StartDialogue(lines));
+        StartCoroutine(StartDialogue(container));
     }
 
-    public IEnumerator StartDialogue(DialogueLine[] lines)
+    public IEnumerator StartDialogue(DialogueContainer container)
     {
+        // Place la bulle selon la configuration du dialogue
+        PositionDialogueBox(container);
+
         GetComponent<Animator>()?.Play("DialogueBoxOpen");
         isOpen = true;
 
-        foreach (DialogueLine line in lines)
+        foreach (DialogueLine line in container.lines)
         {
             nameText.text = line.speakerName;
             yield return StartCoroutine(TypeLine(line.text));
@@ -87,9 +94,63 @@ public class DialogueManager : MonoBehaviour
         isTyping = false;
     }
 
+    // --- Compatibilité rétroactive pour les anciens appels ---
+    public void PlayDialogue(DialogueLine[] lines, System.Action onEnd = null)
+    {
+        var temp = ScriptableObject.CreateInstance<DialogueContainer>();
+        temp.lines = lines;
+        temp.randomPosition = true; // Par défaut, position aléatoire
+        PlayDialogue(temp, onEnd);
+    }
+
+    public IEnumerator StartDialogue(DialogueLine[] lines)
+    {
+        var temp = ScriptableObject.CreateInstance<DialogueContainer>();
+        temp.lines = lines;
+        temp.randomPosition = true;
+        yield return StartDialogue(temp);
+    }
+
     // Optionnel : dialogue sans pause timeline
     public void PlayDialogue(DialogueLine[] lines)
     {
         PlayDialogue(lines, null);
+    }
+
+    public void PlayDialogue(DialogueContainer container)
+    {
+        PlayDialogue(container, null);
+    }
+
+    /// <summary>
+    /// Positionne la bulle de dialogue soit aléatoirement, soit à une position
+    /// spécifique définie dans le DialogueContainer.
+    /// </summary>
+    private void PositionDialogueBox(DialogueContainer container)
+    {
+        if (rectTransform == null)
+            rectTransform = GetComponent<RectTransform>();
+
+        RectTransform canvasRect = rectTransform.parent as RectTransform;
+        Vector2 newPos = Vector2.zero;
+        float margin = 50f; // Marge pour éviter les bords
+
+        if (container.randomPosition)
+        {
+            // Calcule des limites sûres à l'intérieur du canvas
+            float xMin = -canvasRect.rect.width / 2 + rectTransform.rect.width / 2 + margin;
+            float xMax = canvasRect.rect.width / 2 - rectTransform.rect.width / 2 - margin;
+            float yMin = -canvasRect.rect.height / 2 + rectTransform.rect.height / 2 + margin;
+            float yMax = canvasRect.rect.height / 2 - rectTransform.rect.height / 2 - margin;
+
+            newPos = new Vector2(Random.Range(xMin, xMax), Random.Range(yMin, yMax));
+        }
+        else
+        {
+            // Utilise la position fournie (x, y) sans toucher au z
+            newPos = new Vector2(container.customPosition.x, container.customPosition.y);
+        }
+
+        rectTransform.anchoredPosition = newPos;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -5,10 +5,11 @@ public class DialogueSignalReceiver : MonoBehaviour
 {
     public PlayableDirector timeline;
 
-    // AppelÈ depuis la Timeline avec des dialogueLines spÈcifiques
+    // Appel√© depuis la Timeline avec des dialogueLines sp√©cifiques
     public void TriggerDialogueAndPause(DialogueContainer dialogueContainer)
     {
-        DialogueManager.Instance.PlayDialogue(dialogueContainer.lines, OnDialogueEnded);
+        // Utilise le DialogueContainer pour g√©rer la position de la bulle
+        DialogueManager.Instance.PlayDialogue(dialogueContainer, OnDialogueEnded);
         timeline.Pause();
     }
 
@@ -19,6 +20,6 @@ public class DialogueSignalReceiver : MonoBehaviour
 
     public void TriggerDialogueNoPause(DialogueContainer dialogueContainer)
     {
-        DialogueManager.Instance.PlayDialogue(dialogueContainer.lines);
+        DialogueManager.Instance.PlayDialogue(dialogueContainer);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
@@ -50,8 +50,8 @@ public class NPC_LeVieux : MonoBehaviour, IInteractable
         DialogueContainer container = dialoguePhases[dialogueStage];
         if (container != null)
         {
-            // Démarre le dialogue et attend sa fin
-            yield return DialogueManager.Instance.StartDialogue(container.lines);
+            // Démarre le dialogue et attend sa fin en prenant en compte la position de la bulle
+            yield return DialogueManager.Instance.StartDialogue(container);
         }
 
         // Prépare la phase suivante


### PR DESCRIPTION
## Résumé
- Ajout d'un booléen `randomPosition` et d'une `customPosition` dans les `DialogueContainer`.
- Positionnement aléatoire ou personnalisé des bulles via `DialogueManager`.
- Mise à jour des appels de dialogue pour exploiter la nouvelle configuration.

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dfa97b18832591b84e8fcd9bf0ef