### PR TITLE
Corrige NullReference lors du placement de la bulle de dialogue

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -132,6 +132,24 @@ public class DialogueManager : MonoBehaviour
             rectTransform = GetComponent<RectTransform>();
 
         RectTransform canvasRect = rectTransform.parent as RectTransform;
+
+        // Évite les NullReference si le RectTransform parent n'est pas trouvé.
+        // On tente de récupérer le Canvas parent pour calculer une position valide.
+        if (canvasRect == null)
+        {
+            Canvas parentCanvas = GetComponentInParent<Canvas>();
+            if (parentCanvas != null)
+            {
+                canvasRect = parentCanvas.GetComponent<RectTransform>();
+            }
+            else
+            {
+                // Si aucun Canvas n'est présent, on abandonne proprement en avertissant.
+                Debug.LogWarning("DialogueManager : aucun Canvas parent trouvé pour positionner la bulle de dialogue.");
+                return;
+            }
+        }
+
         Vector2 newPos = Vector2.zero;
         float margin = 50f; // Marge pour éviter les bords
 


### PR DESCRIPTION
## Résumé
- Évite les NullReference lorsque le DialogueManager n'a pas de Canvas parent en sécurisant la recherche du RectTransform du canvas.

## Tests
- `npm test` *(échoue : package.json introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e26d924c8325ad4bf9336cea3045