### PR TITLE
Ajout du PNJ Léandre désabusé

### DIFF
--- a/Assets/Dialogue/Leandre_Phase1.asset
+++ b/Assets/Dialogue/Leandre_Phase1.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c8aacd0e4b30b5d46a727666d017bf22, type: 3}
+  m_Name: Leandre_Phase1
+  m_EditorClassIdentifier:
+  lines:
+  - speakerName: Léandre
+    text: "Pff... encore une journée à ne rien faire sur cette plateforme."
+  - speakerName: Lucian
+    text: "Tu gardes espoir, Léandre?"
+  - speakerName: Léandre
+    text: "J'en sais rien. Je ne me souviens même pas d'où je viens."
+  - speakerName: Léandre
+    text: "Si quelqu'un peut nous sortir d'ici, c'est toi."
+  - speakerName: Léandre
+    text: "Alors... tu vas trouver un moyen, hein?"
+  - speakerName: Lucian
+    text: "Je ferai tout pour nous libérer."
+  - speakerName: Léandre
+    text: "Je compte sur toi. Moi, je suis trop fatigué pour y croire."
+  randomPosition: 1
+  customPosition: {x: 0, y: 0, z: 0}

--- a/Assets/Dialogue/Leandre_Phase1.asset.meta
+++ b/Assets/Dialogue/Leandre_Phase1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d1c01c0-a233-4784-a63b-930608846756
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// PNJ "Léandre" : personnage désabusé et apathique,
+/// bloqué sur la plateforme et espérant que Lucian trouvera un moyen de tous les libérer.
+/// À chaque interaction, il partage son découragement mais rappelle qu'il compte sur Lucian.
+/// </summary>
+public class NPC_Leandre : MonoBehaviour, IInteractable
+{
+    [Header("Dialogues du PNJ")]
+    [Tooltip("Liste des phases de dialogue (0 = première interaction, etc.).")]
+    public DialogueContainer[] dialoguePhases; // Références vers les dialogues successifs
+
+    // Indice de la prochaine phase à jouer
+    private int dialogueStage = 0;
+
+    // --- Implémentation de IInteractable ---
+
+    /// <summary>
+    /// Retourne le GameObject porteur de ce script.
+    /// Permet à l'InteractionManager de récupérer la référence du PNJ.
+    /// </summary>
+    public GameObject GameObject => gameObject;
+
+    /// <summary>
+    /// Déclenche le dialogue correspondant à la phase en cours
+    /// si aucune autre interaction ou cinématique n'est active.
+    /// </summary>
+    public void Interact()
+    {
+        if (DialogueManager.Instance.isOpen || EventsManager.Instance.eventInProgress)
+        {
+            // Empêche les dialogues simultanés ou les cinématiques concurrentes
+            return;
+        }
+
+        if (dialogueStage >= dialoguePhases.Length)
+        {
+            // Toutes les phases ont été jouées : aucune interaction supplémentaire
+            return;
+        }
+
+        // Lance le dialogue approprié
+        StartCoroutine(PlayDialogue());
+    }
+
+    /// <summary>
+    /// Lance le dialogue de la phase courante, puis incrémente la phase.
+    /// </summary>
+    private IEnumerator PlayDialogue()
+    {
+        // Signale qu'un événement est en cours pour bloquer d'autres interactions
+        EventsManager.Instance.eventInProgress = true;
+
+        DialogueContainer container = dialoguePhases[dialogueStage];
+        if (container != null)
+        {
+            // Démarre le dialogue et attend sa fin en prenant en compte la position de la bulle
+            yield return DialogueManager.Instance.StartDialogue(container);
+        }
+
+        // Prépare la phase suivante
+        IncrementDialogueStage();
+
+        // Libère le verrou d'événement
+        EventsManager.Instance.eventInProgress = false;
+    }
+
+    /// <summary>
+    /// Avance à la prochaine phase de dialogue.
+    /// </summary>
+    public void IncrementDialogueStage()
+    {
+        // Évite de dépasser la taille du tableau
+        dialogueStage = Mathf.Min(dialogueStage + 1, dialoguePhases.Length);
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f05d9d97-28ae-4ece-8a25-10779616e9b0


### PR DESCRIPTION
## Résumé
- Ajout du script `NPC_Leandre` pour gérer les interactions du PNJ Léandre.
- Création du dialogue `Leandre_Phase1` où Léandre exprime son espoir timide envers Lucian.

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e5f3754c83259a3cf844d8a08f60