### PR TITLE
Corriger les GUID invalides des fichiers Leandre

### DIFF
--- a/Assets/Dialogue/Leandre_Phase1.asset.meta
+++ b/Assets/Dialogue/Leandre_Phase1.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1d1c01c0-a233-4784-a63b-930608846756
+guid: 1d1c01c0a2334784a63b930608846756
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: f05d9d97-28ae-4ece-8a25-10779616e9b0
+guid: f05d9d9728ae4ece8a2510779616e9b0


### PR DESCRIPTION
## Résumé
- Remplacement des GUIDs erronés contenant des tirets dans `Leandre_Phase1.asset.meta` et `NPC_Leandre.cs.meta` pour assurer leur prise en compte par Unity.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8d38f88832589afc34ac2a2a63f