### PR TITLE
Corrige le bouclage et la position aléatoire des dialogues

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -48,11 +48,16 @@ public class DialogueManager : MonoBehaviour
 
     public IEnumerator StartDialogue(DialogueContainer container)
     {
-        // Place la bulle selon la configuration du dialogue
-        PositionDialogueBox(container);
-
+        // Joue l'animation d'ouverture de la bulle
         GetComponent<Animator>()?.Play("DialogueBoxOpen");
         isOpen = true;
+
+        // Attendre une frame pour que l'animation initialise correctement l'UI
+        // puis placer la bulle selon la configuration du dialogue.
+        yield return null;
+
+        // Position aléatoire ou personnalisée selon les paramètres du container
+        PositionDialogueBox(container);
 
         foreach (DialogueLine line in container.lines)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
@@ -35,9 +35,10 @@ public class NPC_Leandre : MonoBehaviour, IInteractable
             return;
         }
 
-        if (dialogueStage >= dialoguePhases.Length)
+        // Vérifie qu'au moins un dialogue est configuré
+        if (dialoguePhases == null || dialoguePhases.Length == 0)
         {
-            // Toutes les phases ont été jouées : aucune interaction supplémentaire
+            // Aucun dialogue disponible pour ce PNJ
             return;
         }
 
@@ -80,8 +81,19 @@ public class NPC_Leandre : MonoBehaviour, IInteractable
     /// </summary>
     public void IncrementDialogueStage()
     {
-        // Évite de dépasser la taille du tableau
-        dialogueStage = Mathf.Min(dialogueStage + 1, dialoguePhases.Length);
+        // Sécurise en cas de tableau vide
+        if (dialoguePhases == null || dialoguePhases.Length == 0)
+        {
+            return; // aucune phase de dialogue à parcourir
+        }
+
+        // Incrémente l'indice tant qu'on n'est pas au dernier dialogue
+        // Une fois le dernier atteint, on reste dessus pour le répéter
+        if (dialogueStage < dialoguePhases.Length - 1)
+        {
+            dialogueStage++;
+        }
+        // Sinon, ne rien faire : dialogueStage reste sur le dernier index
     }
 }
 


### PR DESCRIPTION
## Résumé
- Permet à Léandre de boucler sur son dernier dialogue pour rester interactif.
- Repositionne la bulle de dialogue après l'animation d'ouverture afin d'assurer l'affichage aléatoire.

## Tests
- `dotnet test` *(échec : dotnet non installé)*
- `npm test` *(échec : package.json absent)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ed4403c48325b563a42cc10e2948