### PR TITLE
Utilise TimelineAsset pour les phases de dialogue des PNJ

### DIFF
--- a/Assets/Scripts/Classes/NPCDialoguePhase.cs
+++ b/Assets/Scripts/Classes/NPCDialoguePhase.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using UnityEngine.Playables;
+using UnityEngine.Timeline;
 
 /// <summary>
 /// Représente une phase complète de dialogue pour un PNJ.
@@ -12,7 +12,7 @@ public class NPCDialoguePhase
     public DialogueContainer dialogue;
 
     [Tooltip("Timeline à lancer avant le dialogue (optionnel).")]
-    public PlayableDirector timeline;
+    public TimelineAsset timeline; // ⚙️ Remplacé PlayableDirector par TimelineAsset pour lecture via TimelineLauncher
 
     [Tooltip("Si activé, enchaîne automatiquement avec la phase suivante.")]
     public bool autoProceed;

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using UnityEngine.Playables;
+using UnityEngine.Timeline; // 📽️ Permet d'utiliser des TimelineAsset dans les phases de dialogue
 using System.Collections;
 
 /// <summary>
@@ -67,12 +67,14 @@ public class NPC_LeVieux : MonoBehaviour, IInteractable
             if (anim != null)
                 anim.Play("Dialogue_Start");
 
-            // Lance la Timeline éventuelle et attend sa fin.
-            if (phase.timeline != null)
+            // Lance la Timeline éventuelle via le TimelineLauncher et attend sa fin.
+            if (phase.timeline != null && TimelineLauncher.Instance != null)
             {
-                phase.timeline.Play();
-                // Attend la fin de la lecture de la timeline.
-                while (phase.timeline.state == PlayState.Playing)
+                // Joue la timeline en ciblant automatiquement ce PNJ
+                TimelineLauncher.Instance.PlayTimelineOnCurrentNPC(phase.timeline);
+
+                // Attente de la fin de la Timeline pour assurer la cohérence de la séquence
+                while (TimelineLauncher.Instance.IsTimelineActive)
                     yield return null;
             }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using UnityEngine.Playables;
+using UnityEngine.Timeline; // 📽️ Requis pour utiliser TimelineAsset dans les phases de dialogue
 using System.Collections;
 
 /// <summary>
@@ -73,12 +73,15 @@ public class NPC_Leandre : MonoBehaviour, IInteractable
             if (anim != null)
                 anim.Play("Dialogue_Start");
 
-            // Lecture de la Timeline associée
-            if (phase.timeline != null)
+            // Lecture de la Timeline associée via le TimelineLauncher centralisé
+            if (phase.timeline != null && TimelineLauncher.Instance != null)
             {
-                phase.timeline.Play();
-                while (phase.timeline.state == PlayState.Playing)
-                    yield return null; // Attente de la fin
+                // Joue la timeline en ciblant automatiquement le PNJ courant
+                TimelineLauncher.Instance.PlayTimelineOnCurrentNPC(phase.timeline);
+
+                // Attend la fin de la timeline pour enchaîner proprement
+                while (TimelineLauncher.Instance.IsTimelineActive)
+                    yield return null;
             }
 
             // Démarrage du dialogue


### PR DESCRIPTION
## Résumé
- Remplace PlayableDirector par TimelineAsset dans `NPCDialoguePhase` pour compatibilité avec `TimelineLauncher`
- Lecture des timelines de dialogue via `TimelineLauncher` dans `NPC_Leandre` et `NPC_LeVieux`

## Tests
- `dotnet test` *(échoué : dotnet introuvable)*
- `apt-get update` *(échoué : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68a30700537883258dd6c4e8fe237479