### PR TITLE
Adaptation des timelines PNJ

### DIFF
--- a/Assets/TimelineLauncher.cs
+++ b/Assets/TimelineLauncher.cs
@@ -37,16 +37,14 @@ public class TimelineLauncher : MonoBehaviour
         director.playableAsset = timelineAsset;
 
         GameObject cameraGO = null;
-        Transform cameraParent = null;
-        GameObject cameraRoot = null;
+        Transform cameraParent = null;   // Parent direct de la caméra pour récupérer son Animator
         if (!string.IsNullOrEmpty(cameraTag))
         {
             cameraGO = GameObject.FindGameObjectWithTag(cameraTag);
             cameraParent = cameraGO != null ? cameraGO.transform.parent : null;
-            cameraRoot = cameraParent != null ? cameraParent.gameObject : cameraGO;
-
             if (caster != null && cameraParent != null)
             {
+                // Replace le parent de la caméra sur le PNJ afin que l'animation suive correctement le mouvement
                 cameraParent.position = caster.transform.position;
                 cameraParent.rotation = caster.transform.rotation;
             }
@@ -57,20 +55,33 @@ public class TimelineLauncher : MonoBehaviour
             string trackName = output.streamName;
             System.Type type = output.outputTargetType;
 
-            if (trackName.ToLower().Contains("caster") && caster != null)
+            // Pour les timelines de PNJ, le track d'animation s'appelle "PNJ" au lieu de "Caster"
+            if ((trackName.ToLower().Contains("caster") || trackName.ToLower().Contains("pnj")) && caster != null)
             {
                 BindObjectToTrack(output, caster);
             }
             else if (trackName.ToLower().Contains("camera"))
             {
-                // Si aucune caméra n'est spécifiée, on relie la track Camera au PNJ (caster).
-                // Cela permet aux timelines déclenchées pendant un dialogue de viser directement le PNJ.
-                if (cameraRoot != null)
+                // L'animation de la caméra doit utiliser l'Animator situé sur le parent de la WorldCamera.
+                // On tente donc de récupérer cet Animator explicitement.
+                if (cameraGO != null)
                 {
-                    BindObjectToTrack(output, cameraRoot);
+                    Animator camAnimator = cameraParent != null
+                        ? cameraParent.GetComponent<Animator>()
+                        : cameraGO.GetComponent<Animator>();
+
+                    if (camAnimator != null)
+                    {
+                        director.SetGenericBinding(output.sourceObject, camAnimator);
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[TimelineLauncher] Animator manquant pour la caméra {cameraTag}");
+                    }
                 }
                 else if (caster != null)
                 {
+                    // Aucun tag de caméra fourni : on se rabat sur le PNJ.
                     BindObjectToTrack(output, caster);
                 }
                 else
@@ -106,7 +117,18 @@ public class TimelineLauncher : MonoBehaviour
             director.SetGenericBinding(timelineAsset.markerTrack, markerReceiver);
         }
 
-        director.Play();
+        // Informe le TimelineManager afin que la caméra sache qu'une Timeline prend la priorité
+        // et qu'aucun autre contrôleur (comme le CameraController) ne vienne interférer.
+        if (TimelineManager.Instance != null)
+        {
+            // Le TimelineManager gère l'état global et stoppe les autres timelines si besoin
+            TimelineManager.Instance.PlayTimeline(director);
+        }
+        else
+        {
+            // En dernier recours on lance directement la Timeline
+            director.Play();
+        }
 
         if (caster != null && cameraParent != null)
         {
@@ -119,7 +141,7 @@ public class TimelineLauncher : MonoBehaviour
     /// <summary>
     /// Joue une timeline en ciblant automatiquement le PNJ actuellement en interaction.
     /// Utilisé depuis les timelines de dialogue pour lancer des timelines d'item ou de MusicalMove
-    /// tout en conservant le PNJ comme cible pour les tracks "Caster" et "Camera".
+    /// tout en conservant le PNJ comme cible pour les tracks "PNJ" et "Camera".
     /// </summary>
     /// <param name="timelineAsset">Timeline à jouer.</param>
     public void PlayTimelineOnCurrentNPC(TimelineAsset timelineAsset)
@@ -134,8 +156,8 @@ public class TimelineLauncher : MonoBehaviour
             return;
         }
 
-        // Appelle PlayTimeline sans tag de caméra : la track "Camera" sera donc reliée au PNJ.
-        PlayTimeline(timelineAsset, npc, null);
+        // Utilise la WorldCamera : la track "Camera" ira chercher l'Animator du parent de la WorldCamera.
+        PlayTimeline(timelineAsset, npc, "WorldCamera");
     }
 
     private void BindObjectToTrack(PlayableBinding output, GameObject go)


### PR DESCRIPTION
## Résumé
- Ajout de la prise en compte du `TimelineManager` lors du lancement des timelines pour désactiver le `CameraController`
- Liaison de l'animation de caméra à l'Animator du parent de la WorldCamera
- Utilisation automatique de la WorldCamera pour les timelines déclenchées sur un PNJ

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c0cb424832596923dba2eb0c48a