### PR TITLE
Animation de début de dialogue par défaut sans Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
@@ -62,10 +62,14 @@ public class NPC_LeVieux : MonoBehaviour, IInteractable
         {
             NPCDialoguePhase phase = dialoguePhases[dialogueStage];
 
-            // Joue l'animation d'entrée en dialogue.
+            // Joue l'animation d'entrée uniquement si aucune Timeline n'est définie.
+            // Lorsque l'on dispose d'une Timeline, celle-ci est censée gérer ses propres animations.
             Animator anim = GetComponent<Animator>();
-            if (anim != null)
+            if (anim != null && phase.timeline == null)
+            {
+                // Animation par défaut pour signaler le début de la discussion.
                 anim.Play("Dialogue_Start");
+            }
 
             // Lance la Timeline éventuelle via le TimelineLauncher et attend sa fin.
             if (phase.timeline != null && TimelineLauncher.Instance != null)

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
@@ -68,10 +68,14 @@ public class NPC_Leandre : MonoBehaviour, IInteractable
         {
             NPCDialoguePhase phase = dialoguePhases[dialogueStage];
 
-            // Animation de début de dialogue
+            // Animation de début : uniquement si aucune Timeline n'est associée à la phase.
+            // Si une Timeline est fournie, elle gère elle-même les animations nécessaires.
             Animator anim = GetComponent<Animator>();
-            if (anim != null)
+            if (anim != null && phase.timeline == null)
+            {
+                // Animation par défaut de début de dialogue.
                 anim.Play("Dialogue_Start");
+            }
 
             // Lecture de la Timeline associée via le TimelineLauncher centralisé
             if (phase.timeline != null && TimelineLauncher.Instance != null)


### PR DESCRIPTION
## Résumé
- Joue l'animation `Dialogue_Start` uniquement pour les phases sans Timeline afin d'éviter les conflits.
- Laisse les Timelines gérer leurs propres animations quand elles sont présentes.

## Tests
- `dotnet build` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68a31690279083258889da42c8cdb64e