### PR TITLE
Ajout d'une boîte de confirmation et des points d'intérêt interactifs

### DIFF
--- a/Assets/Scripts/Classes/NPCDialoguePhase.cs
+++ b/Assets/Scripts/Classes/NPCDialoguePhase.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Timeline;
+using UnityEngine.Events; // Permet d'ajouter des callbacks via l'inspecteur
 
 /// <summary>
 /// Représente une phase complète de dialogue pour un PNJ.
@@ -16,4 +17,18 @@ public class NPCDialoguePhase
 
     [Tooltip("Si activé, enchaîne automatiquement avec la phase suivante.")]
     public bool autoProceed;
+
+    [Header("Confirmation")]
+    [Tooltip("Ouvre une boîte de confirmation à la fin de cette phase.")]
+    public bool askConfirmation;
+
+    [Tooltip("Texte affiché dans la boîte de confirmation.")]
+    [TextArea]
+    public string confirmationText;
+
+    [Tooltip("Événement déclenché si le joueur répond Oui.")]
+    public UnityEvent onYes;
+
+    [Tooltip("Événement déclenché si le joueur répond Non.")]
+    public UnityEvent onNo;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/ConfirmationBox.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ConfirmationBox.cs
@@ -1,0 +1,96 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using TMPro;
+
+/// <summary>
+/// Boîte de confirmation générique affichant une question au joueur
+/// et récupérant sa réponse Oui/Non via l'Input System.
+/// </summary>
+public class ConfirmationBox : MonoBehaviour
+{
+    public static ConfirmationBox Instance { get; private set; }
+
+    [Header("Références UI")]
+    [Tooltip("Zone de texte où s'affiche la question posée au joueur.")]
+    public TextMeshProUGUI messageText;
+
+    private System.Action yesCallback;   // Action exécutée en cas de réponse positive
+    private System.Action noCallback;    // Action exécutée en cas de réponse négative
+
+    void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        gameObject.SetActive(false); // Masqué par défaut
+    }
+
+    void OnEnable()
+    {
+        // Abonne les entrées Oui/Non uniquement lorsque la boîte est visible
+        var info = InputsManager.Instance.playerInputs.InfoBox;
+        info.Confirm.performed += OnConfirm;
+        info.Cancel.performed += OnCancel;
+    }
+
+    void OnDisable()
+    {
+        if (InputsManager.Instance == null) return;
+        var info = InputsManager.Instance.playerInputs.InfoBox;
+        info.Confirm.performed -= OnConfirm;
+        info.Cancel.performed -= OnCancel;
+    }
+
+    /// <summary>
+    /// Affiche la boîte avec le message donné et les callbacks associés.
+    /// </summary>
+    public void Show(string message, System.Action onYes, System.Action onNo)
+    {
+        messageText.text = message;
+        yesCallback = onYes;
+        noCallback = onNo;
+        gameObject.SetActive(true);
+
+        // Active uniquement la map InfoBox pour empêcher les déplacements
+        InputsManager.Instance.ActivateOnly(InputsManager.Instance.playerInputs.InfoBox.Get());
+    }
+
+    /// <summary>
+    /// Fonction appelée lorsque le joueur choisit "Oui".
+    /// </summary>
+    public void OnConfirm(InputAction.CallbackContext ctx) => Confirm();
+
+    /// <summary>
+    /// Fonction appelée lorsque le joueur choisit "Non".
+    /// </summary>
+    public void OnCancel(InputAction.CallbackContext ctx) => Cancel();
+
+    private void Confirm()
+    {
+        Close();
+        yesCallback?.Invoke();
+    }
+
+    private void Cancel()
+    {
+        Close();
+        noCallback?.Invoke();
+    }
+
+    /// <summary>
+    /// Ferme la boîte et réactive les déplacements du joueur.
+    /// </summary>
+    private void Close()
+    {
+        gameObject.SetActive(false);
+        yesCallback = null;
+        noCallback = null;
+
+        // Réactive le gameplay classique
+        InputsManager.Instance.ActivateOnly(InputsManager.Instance.playerInputs.World.Get());
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/ConfirmationBox.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/ConfirmationBox.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92ee08ad3b1941da91d513a07a42ef5e

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_LeVieux.cs
@@ -92,6 +92,19 @@ public class NPC_LeVieux : MonoBehaviour, IInteractable
             if (anim != null)
                 anim.Play("Dialogue_End");
 
+            // Affiche une éventuelle boîte de confirmation à la fin du dialogue
+            if (phase.askConfirmation)
+            {
+                bool done = false; // Attendra que le joueur fasse un choix
+                ConfirmationBox.Instance.Show(
+                    phase.confirmationText,
+                    () => { phase.onYes?.Invoke(); done = true; },
+                    () => { phase.onNo?.Invoke(); done = true; }
+                );
+                while (!done)
+                    yield return null;
+            }
+
             // Détermine si l'on doit passer automatiquement à la phase suivante.
             bool wasLast = dialogueStage >= dialoguePhases.Length - 1;
             bool auto = phase.autoProceed;

--- a/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPC_Leandre.cs
@@ -98,6 +98,19 @@ public class NPC_Leandre : MonoBehaviour, IInteractable
             if (anim != null)
                 anim.Play("Dialogue_End");
 
+            // Boîte de confirmation éventuelle à la fin du dialogue
+            if (phase.askConfirmation)
+            {
+                bool done = false;
+                ConfirmationBox.Instance.Show(
+                    phase.confirmationText,
+                    () => { phase.onYes?.Invoke(); done = true; },
+                    () => { phase.onNo?.Invoke(); done = true; }
+                );
+                while (!done)
+                    yield return null; // Attend la réponse du joueur
+            }
+
             // Gestion de la progression
             bool wasLast = dialogueStage >= dialoguePhases.Length - 1;
             bool auto = phase.autoProceed;

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using UnityEngine.Events;
+using System.Collections;
+
+/// <summary>
+/// Point d'intérêt interactif : lance un dialogue puis éventuellement
+/// une confirmation Oui/Non pour que le joueur prenne une décision.
+/// </summary>
+public class PointOfInterest : MonoBehaviour, IInteractable
+{
+    [Header("Dialogue")]
+    [Tooltip("Dialogue joué lorsque le joueur interagit avec ce point d'intérêt.")]
+    public DialogueContainer dialogue;
+
+    [Header("Confirmation")]
+    [Tooltip("Ouvre une boîte de confirmation à la fin du dialogue.")]
+    public bool askConfirmation;
+    [Tooltip("Texte affiché dans la boîte de confirmation.")]
+    [TextArea]
+    public string confirmationText;
+    [Tooltip("Événement déclenché si le joueur répond Oui.")]
+    public UnityEvent onYes;
+    [Tooltip("Événement déclenché si le joueur répond Non.")]
+    public UnityEvent onNo;
+
+    // --- Implémentation de l'interface IInteractable ---
+    public GameObject GameObject => gameObject;
+
+    public void Interact()
+    {
+        if (DialogueManager.Instance.isOpen || EventsManager.Instance.eventInProgress)
+            return; // Empêche les interactions multiples
+
+        StartCoroutine(RunInteraction());
+    }
+
+    public void IncrementDialogueStage() { /* Aucun dialogue progressif pour l'instant */ }
+
+    /// <summary>
+    /// Coroutine gérant l'enchaînement dialogue puis confirmation.
+    /// </summary>
+    private IEnumerator RunInteraction()
+    {
+        EventsManager.Instance.eventInProgress = true; // Bloque les autres interactions
+
+        if (dialogue != null)
+            yield return DialogueManager.Instance.StartDialogue(dialogue);
+
+        if (askConfirmation)
+        {
+            bool done = false;
+            ConfirmationBox.Instance.Show(
+                confirmationText,
+                () => { onYes?.Invoke(); done = true; },
+                () => { onNo?.Invoke(); done = true; }
+            );
+            while (!done)
+                yield return null; // Attend la décision du joueur
+        }
+
+        EventsManager.Instance.eventInProgress = false; // Libère les interactions
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9105ae06ff94860880db1dc68bb43d2


### PR DESCRIPTION
## Résumé
- Ajout d'un composant `ConfirmationBox` pour afficher des choix Oui/Non et geler les déplacements.
- Extension des phases de dialogue `NPCDialoguePhase` avec un système de confirmation optionnel.
- Intégration de la confirmation dans les scripts `NPC_LeVieux` et `NPC_Leandre`.
- Nouveau `PointOfInterest` permettant de lancer un dialogue et une confirmation.

## Test
- `dotnet test` *(échoue : commande introuvable)*
- `apt-get update` *(échoue : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68a5caa247f883259ab37dd4d26f2987