### PR TITLE
Reprise de la timeline WakeUp après le dialogue

### DIFF
--- a/Assets/Scenes/Commencement.unity
+++ b/Assets/Scenes/Commencement.unity
@@ -3816,6 +3816,8 @@ MonoBehaviour:
   onNo:
     m_PersistentCalls:
       m_Calls: []
+  timelineToResume: {fileID: 1565654559}
+  resumeSignal: {fileID: 11400000, guid: beb7ebe11b6701e4da663bcd76869e71, type: 2}
 --- !u!320 &1565654559
 PlayableDirector:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Playables;   // Nécessaire pour contrôler la Timeline
+using UnityEngine.Timeline;    // Permet de manipuler les Signaux (SignalAsset)
 using System.Collections;
 
 /// <summary>
@@ -23,6 +25,12 @@ public class PointOfInterest : MonoBehaviour, IInteractable
     [Tooltip("Événement déclenché si le joueur répond Non.")]
     public UnityEvent onNo;
 
+    [Header("Timeline")]
+    [Tooltip("Timeline à relancer une fois le dialogue terminé.")]
+    public PlayableDirector timelineToResume;
+    [Tooltip("Signal envoyé pour indiquer à la timeline de reprendre.")]
+    public SignalAsset resumeSignal;
+
     // --- Implémentation de l'interface IInteractable ---
     public GameObject GameObject => gameObject;
 
@@ -45,6 +53,31 @@ public class PointOfInterest : MonoBehaviour, IInteractable
 
         if (dialogue != null)
             yield return DialogueManager.Instance.StartDialogue(dialogue);
+
+        // À la fin du dialogue, on envoie un signal de reprise à la Timeline si nécessaire
+        if (timelineToResume != null)
+        {
+            // Vérifie si un SignalReceiver est attaché pour traiter le SIG_Resume
+            if (resumeSignal != null)
+            {
+                var receiver = timelineToResume.GetComponent<SignalReceiver>();
+                if (receiver != null)
+                {
+                    // Invoque la réaction associée au signal pour laisser la Timeline gérer la reprise
+                    receiver.GetReaction(resumeSignal)?.Invoke();
+                }
+                else
+                {
+                    // Pas de SignalReceiver configuré : on reprend la Timeline directement
+                    timelineToResume.Resume();
+                }
+            }
+            else
+            {
+                // Aucun signal défini : reprise immédiate de la Timeline
+                timelineToResume.Resume();
+            }
+        }
 
         if (askConfirmation)
         {


### PR DESCRIPTION
## Résumé
- Ajout d'un mécanisme dans `PointOfInterest` pour émettre un signal SIG_Resume et relancer la Timeline après la fin du dialogue.
- Référence de la Timeline et du signal SIG_Resume dans la scène `Commencement`.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés / accès interdit)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d7be80f08325975685b98224a5cd