### PR TITLE
Masquer la LocalInfoBox pendant les interactions

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
@@ -78,6 +78,12 @@ public class InteractionManager : MonoBehaviour
     {
         if (currentInteractable != null)
         {
+            // Masquer immédiatement l'invite locale pour éviter qu'elle reste affichée
+            if (localInfoBox != null)
+            {
+                localInfoBox.SetActive(false);
+                InputsManager.Instance.ActivateOnly(InputsManager.Instance.playerInputs.World.Get());
+            }
             currentInteractable.GetComponent<IInteractable>().Interact();
         }
     }
@@ -91,6 +97,18 @@ public class InteractionManager : MonoBehaviour
     {
         if (DialogueManager.Instance.isOpen || EventsManager.Instance.eventInProgress)
         {
+            // Si une interaction est en cours, on s'assure que la LocalInfoBox reste cachée
+            if (currentInteractable != null)
+            {
+                currentInteractable = null;
+            }
+
+            if (localInfoBox != null && localInfoBox.activeSelf)
+            {
+                localInfoBox.SetActive(false);
+                InputsManager.Instance.ActivateOnly(InputsManager.Instance.playerInputs.World.Get());
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Résumé
- Masque immédiatement la LocalInfoBox lorsqu'une interaction débute.
- Garantit que la LocalInfoBox reste cachée tant qu'un dialogue ou un évènement est en cours.

## Tests
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f20389a4832594b92af6417b0762