### PR TITLE
feat: permettre de nommer Munin au démarrage

### DIFF
--- a/Assets/GameDatas/GameData.asset
+++ b/Assets/GameDatas/GameData.asset
@@ -12,6 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 0}
   m_Name: GameData
   m_EditorClassIdentifier: Assembly-CSharp::GameData
-  defeatedEnemies:
+  defeatedEnemies: []
   squadLevel: 0
   squadXP: 0
+  enemiesDefeatedCount: 0
+  muninName: Munin

--- a/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
@@ -13,6 +13,7 @@ public class GameData : ScriptableObject
     public int squadLevel;
     public int squadXP;
     public int enemiesDefeatedCount;
+    public string muninName = "Munin"; // Nom de la caméra contrôlée par le joueur
 
     public void SaveToFile(string fileName = "save.json")
     {
@@ -21,7 +22,8 @@ public class GameData : ScriptableObject
             defeatedEnemyIDs = new List<int>(defeatedEnemies),
             squadLevel = squadLevel,
             squadXP = squadXP,
-            enemiesDefeatedCount = enemiesDefeatedCount
+            enemiesDefeatedCount = enemiesDefeatedCount,
+            muninName = muninName
         };
 
         string json = JsonUtility.ToJson(save, true);
@@ -49,6 +51,7 @@ public class GameData : ScriptableObject
         squadLevel = loaded.squadLevel;
         squadXP = loaded.squadXP;
         enemiesDefeatedCount = loaded.enemiesDefeatedCount;
+        muninName = loaded.muninName; // Recharge le nom personnalisé de Munin
 
         Debug.Log($"[GameData] Données chargées depuis : {path}");
     }
@@ -59,8 +62,9 @@ public class GameData : ScriptableObject
         squadLevel = 0;
         squadXP = 0;
         enemiesDefeatedCount = 0;
+        muninName = "Munin"; // Réinitialise le nom de Munin par défaut
         Debug.Log("GameData has been reset.");
-    }
+}
 }
 
 [System.Serializable]
@@ -70,6 +74,7 @@ public class GameDataSave
     public int squadLevel;
     public int squadXP;
     public int enemiesDefeatedCount;
+    public string muninName; // Nom sauvegardé de Munin
 }
 
 public enum GameState

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
@@ -30,6 +30,11 @@ public class MainMenuManager : MonoBehaviour
     private PlayerInputs playerInputs;
     private Canvas parentCanvas;
 
+    [Header("Nom de Munin")]
+    public GameObject namePanel; // Panneau UI demandant le nom du joueur
+    public TMP_InputField nameInputField; // Champ de saisie du nom
+    public string defaultMuninName = "Munin"; // Nom par défaut si aucun n'est fourni
+
     void Awake()
     {
         playerInputs = new PlayerInputs();
@@ -38,7 +43,7 @@ public class MainMenuManager : MonoBehaviour
     private void Start()
     {
         if (pressA != null)
-            pressA.alpha = 0.5f;
+            pressA.alpha = 0.5f; // Pré-affiche le message "Press A"
         if (menuContainer != null)
             menuContainer.SetActive(false);
         if (loadMenu != null)
@@ -59,6 +64,20 @@ public class MainMenuManager : MonoBehaviour
             menuItems = new Transform[menuContainer.transform.childCount];
             for (int i = 0; i < menuItems.Length; i++)
                 menuItems[i] = menuContainer.transform.GetChild(i);
+        }
+
+        // Chargement ou demande du nom de Munin
+        if (PlayerPrefs.HasKey("MuninName"))
+        {
+            // Si un nom existe déjà, on le charge dans les données de jeu
+            string savedName = PlayerPrefs.GetString("MuninName");
+            if (GameManager.Instance != null && GameManager.Instance.gameData != null)
+                GameManager.Instance.gameData.muninName = savedName;
+        }
+        else
+        {
+            // Aucun nom enregistré : on affiche le panneau de saisie
+            ShowNamePanel();
         }
     }
 
@@ -100,6 +119,13 @@ public class MainMenuManager : MonoBehaviour
 
     private void OnConfirm(InputAction.CallbackContext ctx)
     {
+        // Si le panneau de saisie du nom est actif, le bouton de confirmation validera le nom
+        if (namePanel != null && namePanel.activeSelf)
+        {
+            ConfirmName();
+            return;
+        }
+
         if (waitingForInput)
         {
             Debug.Log("Bouton A pressé");
@@ -136,6 +162,46 @@ public class MainMenuManager : MonoBehaviour
 
         currentIndex = 0;
         UpdateCursor();
+    }
+
+    /// <summary>
+    /// Affiche le panneau permettant au joueur de choisir le nom de Munin.
+    /// </summary>
+    private void ShowNamePanel()
+    {
+        waitingForInput = false; // Empêche l'ouverture du menu tant que le nom n'est pas choisi
+        if (pressA != null)
+            pressA.gameObject.SetActive(false); // Masque "Press A" durant la saisie
+        if (namePanel != null)
+            namePanel.SetActive(true);
+        if (nameInputField != null)
+            nameInputField.text = defaultMuninName; // Pré-remplit avec le nom par défaut
+    }
+
+    /// <summary>
+    /// Valide le nom saisi, le sauvegarde et affiche de nouveau l'écran de démarrage.
+    /// </summary>
+    public void ConfirmName()
+    {
+        string chosenName = nameInputField != null ? nameInputField.text : string.Empty;
+        if (string.IsNullOrWhiteSpace(chosenName))
+            chosenName = defaultMuninName; // Utilise le nom par défaut si aucune saisie
+
+        // Met à jour les données de jeu
+        if (GameManager.Instance != null && GameManager.Instance.gameData != null)
+            GameManager.Instance.gameData.muninName = chosenName;
+
+        // Sauvegarde dans les préférences locales
+        PlayerPrefs.SetString("MuninName", chosenName);
+        PlayerPrefs.Save();
+
+        // Cache le panneau et réaffiche "Press A"
+        if (namePanel != null)
+            namePanel.SetActive(false);
+        if (pressA != null)
+            pressA.gameObject.SetActive(true);
+
+        waitingForInput = true; // Le joueur peut maintenant accéder au menu principal
     }
 
     public void ContinueGame()


### PR DESCRIPTION
## Summary
- ajoute le champ `muninName` dans les données de jeu et le sauvegarde
- permet au joueur de choisir le nom de Munin depuis le menu principal
- initialise un nom par défaut et persiste le choix dans les préférences

## Testing
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8517b14308325854e53085539604e