### PR TITLE
feat: conditions flexibles pour reprise de timeline

### DIFF
--- a/Assets/TimelineResumeOnConfirm.cs
+++ b/Assets/TimelineResumeOnConfirm.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Playables;
@@ -6,34 +8,60 @@ using UnityEngine.Playables;
 [RequireComponent(typeof(PlayableDirector))]
 public class TimelinePauseResumeOnInteract : MonoBehaviour
 {
-    [Tooltip("Instance de PlayerInputs. Si vide, on prendra celle de InputsManager, sinon on en cr�era une locale.")]
+    [Tooltip("Instance de PlayerInputs. Si vide, on prendra celle de InputsManager, sinon on en créera une locale.")]
     [SerializeField] private PlayerInputs playerInputs;
 
-    private PlayableDirector director;
-    private bool ownsLocalInputs = false; // vrai si on a cr�� notre propre instance locale
+    [Header("Conditions à valider pour reprendre la Timeline")] 
+    [Tooltip("Liste ordonnée des conditions qui devront être remplies pour que la timeline reprenne après chaque pause déclenchée par un Signal.")]
+    [SerializeField] private List<ResumeCondition> resumeConditions = new();
+
+    private PlayableDirector director; // Référence à la Timeline contrôlée
+    private bool ownsLocalInputs = false; // vrai si on a créé notre propre instance locale
+    private int currentConditionIndex = -1; // index de la condition en cours dans la liste
+    private bool waitingForCondition = false; // indique si l'on attend une condition avant de reprendre
+
+    /// <summary>
+    /// Représente une condition pouvant être utilisée pour reprendre la timeline.
+    /// On peut facilement étendre ce système en ajoutant de nouveaux types.
+    /// </summary>
+    [Serializable]
+    private class ResumeCondition
+    {
+        public enum ConditionType
+        {
+            InteractInput,      // Attend un input "Interact" du joueur
+            GameObjectInactive  // Attend qu'un GameObject donné soit désactivé
+        }
+
+        [Tooltip("Type de la condition à vérifier avant de reprendre la timeline.")]
+        public ConditionType type = ConditionType.InteractInput;
+
+        [Tooltip("GameObject à surveiller si le type est GameObjectInactive.")]
+        public GameObject targetObject; // utilisé uniquement pour GameObjectInactive
+    }
 
     private void Awake()
     {
         director = GetComponent<PlayableDirector>();
 
-        // Si rien n'est r�f�renc� dans l'inspecteur, on tente d'utiliser l'instance globale
+        // Si rien n'est référencé dans l'inspecteur, on tente d'utiliser l'instance globale
         if (playerInputs == null)
         {
             if (InputsManager.Instance != null && InputsManager.Instance.playerInputs != null)
             {
-                playerInputs = InputsManager.Instance.playerInputs; // on r�utilise celle du jeu
+                playerInputs = InputsManager.Instance.playerInputs; // on réutilise celle du jeu
                 ownsLocalInputs = false;
             }
             else
             {
-                playerInputs = new PlayerInputs(); // on cr�e une instance locale
+                playerInputs = new PlayerInputs(); // on crée une instance locale
                 ownsLocalInputs = true;
             }
         }
         else
         {
-            // Une instance a �t� assign�e manuellement dans l'inspecteur
-            // On consid�re qu'elle est "locale" � ce composant.
+            // Une instance a été assignée manuellement dans l'inspecteur
+            // On considère qu'elle est "locale" à ce composant.
             ownsLocalInputs = true;
         }
     }
@@ -49,7 +77,7 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
         // On s'assure que la map World est active pour recevoir l'input Interact
         playerInputs.World.Enable();
 
-        // Abonnement � l'input Interact
+        // Abonnement à l'input Interact
         playerInputs.World.Interact.performed += OnInteract;
     }
 
@@ -57,31 +85,89 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
     {
         if (playerInputs != null)
         {
-            // D�sabonnement propre
+            // Désabonnement propre
             playerInputs.World.Interact.performed -= OnInteract;
 
-            // Si on poss�de une instance locale, on peut la d�sactiver proprement
+            // Si on possède une instance locale, on peut la désactiver proprement
             if (ownsLocalInputs)
             {
                 playerInputs.World.Disable();
             }
-            // Si l'instance vient d'InputsManager, on ne touche pas � son lifecycle
+            // Si l'instance vient d'InputsManager, on ne touche pas à son lifecycle
         }
     }
 
-    private void OnInteract(InputAction.CallbackContext ctx)
+    private void Update()
     {
-        if (director == null || TimelineManager.Instance == null)
+        if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
-        // Bascule : si Paused -> Resume, si Playing -> Pause (sinon, ne rien faire)
-        if (director.state == PlayState.Paused)
+        // Récupère la condition en cours
+        if (currentConditionIndex < 0 || currentConditionIndex >= resumeConditions.Count)
+            return;
+
+        var cond = resumeConditions[currentConditionIndex];
+
+        // On vérifie les conditions qui doivent être testées en continu
+        switch (cond.type)
         {
-            TimelineManager.Instance.SetCurentTimelineSpeed(0);
+            case ResumeCondition.ConditionType.GameObjectInactive:
+                if (cond.targetObject != null && !cond.targetObject.activeInHierarchy)
+                {
+                    ResumeTimeline();
+                }
+                break;
+            // Les autres types sont gérés par évènement, donc rien à faire ici
         }
-        else if (director.state == PlayState.Playing)
+    }
+
+    /// <summary>
+    /// Méthode appelée par un Signal de la Timeline pour marquer une pause et définir la prochaine condition à attendre.
+    /// </summary>
+    public void PauseForNextCondition()
+    {
+        if (TimelineManager.Instance == null)
+            return;
+
+        // On prépare la prochaine condition
+        currentConditionIndex++;
+
+        if (currentConditionIndex >= resumeConditions.Count)
         {
+            Debug.LogWarning("[TimelinePauseResumeOnInteract] Aucune condition restante, reprise immédiate.");
             TimelineManager.Instance.SetCurentTimelineSpeed(1);
+            return;
         }
+
+        waitingForCondition = true; // indique qu'on attend quelque chose
+        TimelineManager.Instance.SetCurentTimelineSpeed(0); // met la timeline en pause (speed 0)
+    }
+
+    /// <summary>
+    /// Callback exécuté lors de l'appui sur l'action "Interact".
+    /// Ne reprend la timeline que si la condition attendue est de type InteractInput.
+    /// </summary>
+    private void OnInteract(InputAction.CallbackContext ctx)
+    {
+        if (!waitingForCondition || TimelineManager.Instance == null)
+            return;
+
+        if (currentConditionIndex < 0 || currentConditionIndex >= resumeConditions.Count)
+            return;
+
+        var cond = resumeConditions[currentConditionIndex];
+        if (cond.type == ResumeCondition.ConditionType.InteractInput)
+        {
+            ResumeTimeline();
+        }
+    }
+
+    /// <summary>
+    /// Relance la Timeline en remettant sa vitesse à 1.
+    /// </summary>
+    private void ResumeTimeline()
+    {
+        waitingForCondition = false;
+        TimelineManager.Instance.SetCurentTimelineSpeed(1);
     }
 }


### PR DESCRIPTION
## Résumé
- ajouter un système de conditions séquentielles pour la reprise des timelines
- gérer l’attente sur input "Interact" ou sur l’inactivation d’un GameObject

## Test
- `dotnet build` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a88854c52883258816c21046f60da9