### PR TITLE
Suspend CameraController during timelines

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -135,6 +135,9 @@ public class TimelineManager : MonoBehaviour
         IsTimelinePlaying = true;
         // Bloque immédiatement les déplacements du joueur pendant l'exécution de la timeline.
         TogglePlayerMovement(false);
+        // Désactive le CameraController pour laisser la Timeline contrôler totalement la caméra
+        if (CameraController.Instance != null)
+            CameraController.Instance.enabled = false;
         Debug.Log($"[TimelineManager] Timeline jouée : {pd.name}");
     }
 
@@ -150,6 +153,9 @@ public class TimelineManager : MonoBehaviour
             currentDirector = null;
             // La timeline est terminée : on redonne le contrôle de Lucian au joueur.
             TogglePlayerMovement(true);
+            // Réactive le CameraController pour rendre la main après la cinématique
+            if (CameraController.Instance != null)
+                CameraController.Instance.enabled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Disable CameraController when a timeline starts to prevent conflicting camera updates
- Re-enable CameraController when the timeline stops

## Testing
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88dd008188325852041837f61edf9