### PR TITLE
Fix: navigation au joystick dans le clavier virtuel

### DIFF
--- a/Assets/VirtualKeyboard.cs
+++ b/Assets/VirtualKeyboard.cs
@@ -90,6 +90,10 @@ public class VirtualKeyboard : MonoBehaviour
         _currentIndex = 0;
         UpdateCursor();
 
+        // Activation du mapping World afin de recevoir les entrées
+        // du joystick ou du clavier pendant l'utilisation du clavier virtuel.
+        playerInputs.World.Enable();
+
         // Abonnements aux différentes entrées du joueur.
         playerInputs.World.Move.performed += OnMove;
         playerInputs.World.Interact.performed += OnInteract;
@@ -108,6 +112,10 @@ public class VirtualKeyboard : MonoBehaviour
             playerInputs.World.Move.performed -= OnMove;
             playerInputs.World.Interact.performed -= OnInteract;
             playerInputs.World.Cancel.performed -= OnCancel;
+
+            // Désactivation du mapping World pour éviter
+            // toute réception d'entrées lorsque le clavier est fermé.
+            playerInputs.World.Disable();
         }
 
         if (cursor != null)
@@ -115,6 +123,19 @@ public class VirtualKeyboard : MonoBehaviour
 
         if (keyboardRoot != null)
             keyboardRoot.SetActive(false);
+    }
+
+    /// <summary>
+    /// S'assure que les entrées sont correctement libérées si l'objet est détruit.
+    /// </summary>
+    private void OnDestroy()
+    {
+        // On ferme proprement le clavier pour retirer les abonnements et désactiver la map.
+        CloseVK();
+
+        // Libère les ressources de l'Input System.
+        if (playerInputs != null)
+            playerInputs.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- Active la map d'inputs `World` à l'ouverture du clavier virtuel pour capter le joystick
- Désactive et nettoie les actions à la fermeture du clavier
- Libère les ressources InputSystem lors de la destruction du clavier

## Tests
- `dotnet test` *(échec : commande introuvable dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c837828483258fe78c556c2dfe41