### PR TITLE
Fix: navigation au joystick dans le clavier virtuel

### DIFF
--- a/Assets/Prefabs/VirtualKeyboard.prefab
+++ b/Assets/Prefabs/VirtualKeyboard.prefab
@@ -1263,7 +1263,7 @@ MonoBehaviour:
   keyboardRoot: {fileID: 1177172479610300591}
   buttonsContainer: {fileID: 6594947862159591136}
   cursor: {fileID: 9045819102240577774}
-  outputText: {fileID: 2666381627580633979}
+  currentVKWord: {fileID: 2666381627580633979}
   columns: 13
 --- !u!1 &1200298959478812816
 GameObject:

--- a/Assets/VirtualKeyboard.cs
+++ b/Assets/VirtualKeyboard.cs
@@ -20,19 +20,24 @@ public class VirtualKeyboard : MonoBehaviour
     [Tooltip("Objet représentant le curseur de sélection.")]
     [SerializeField] private RectTransform cursor;
 
-    [Tooltip("Zone de texte où sera affichée la saisie.")]
-    [SerializeField] private TextMeshProUGUI outputText;
+    [Tooltip("Zone de texte où sera affichée la saisie (champ 'Output Text' dans la scène).")]
+    [SerializeField] private TextMeshProUGUI currentVKWord;
 
     [Header("Paramètres")]
     [Tooltip("Nombre de colonnes dans la grille du clavier.")]
     [SerializeField] private int columns = 13;
 
+    [Tooltip("Temps minimal entre deux déplacements du curseur (en secondes).")]
+    [SerializeField] private float moveDelay = 0.1f;
+
     // Liste interne des touches disponibles sur le clavier.
     private readonly List<RectTransform> _keys = new();
     // Index courant dans la liste des touches.
     private int _currentIndex;
-    // Chaîne saisie par le joueur.
-    private string _currentText = string.Empty;
+    // Mémorise le dernier moment où un déplacement a été effectué pour limiter la vitesse.
+    private float _lastMoveTime;
+    // Texte actuellement saisi via le clavier virtuel, accessible aux autres systèmes.
+    public string currentVKWordText { get; private set; } = string.Empty;
 
     // Référence vers le système d'inputs généré par l'Input System.
     private PlayerInputs playerInputs;
@@ -90,6 +95,10 @@ public class VirtualKeyboard : MonoBehaviour
         _currentIndex = 0;
         UpdateCursor();
 
+        // Activation du mapping World afin de recevoir les entrées
+        // du joystick ou du clavier pendant l'utilisation du clavier virtuel.
+        playerInputs.World.Enable();
+
         // Abonnements aux différentes entrées du joueur.
         playerInputs.World.Move.performed += OnMove;
         playerInputs.World.Interact.performed += OnInteract;
@@ -108,6 +117,10 @@ public class VirtualKeyboard : MonoBehaviour
             playerInputs.World.Move.performed -= OnMove;
             playerInputs.World.Interact.performed -= OnInteract;
             playerInputs.World.Cancel.performed -= OnCancel;
+
+            // Désactivation du mapping World pour éviter
+            // toute réception d'entrées lorsque le clavier est fermé.
+            playerInputs.World.Disable();
         }
 
         if (cursor != null)
@@ -118,10 +131,27 @@ public class VirtualKeyboard : MonoBehaviour
     }
 
     /// <summary>
+    /// S'assure que les entrées sont correctement libérées si l'objet est détruit.
+    /// </summary>
+    private void OnDestroy()
+    {
+        // On ferme proprement le clavier pour retirer les abonnements et désactiver la map.
+        CloseVK();
+
+        // Libère les ressources de l'Input System.
+        if (playerInputs != null)
+            playerInputs.Dispose();
+    }
+
+    /// <summary>
     /// Gestion du déplacement du curseur à l'intérieur de la grille du clavier.
     /// </summary>
     private void OnMove(InputAction.CallbackContext ctx)
     {
+        // Empêche les déplacements trop rapides en vérifiant le délai minimal.
+        if (Time.unscaledTime - _lastMoveTime < moveDelay)
+            return;
+
         Vector2 input = ctx.ReadValue<Vector2>();
         int row = _currentIndex / columns;
         int col = _currentIndex % columns;
@@ -142,6 +172,9 @@ public class VirtualKeyboard : MonoBehaviour
         {
             _currentIndex = newIndex;
             UpdateCursor();
+
+            // Enregistre l'heure du déplacement pour appliquer la temporisation.
+            _lastMoveTime = Time.unscaledTime;
         }
     }
 
@@ -167,9 +200,10 @@ public class VirtualKeyboard : MonoBehaviour
         }
         else
         {
-            _currentText += keyName;
-            if (outputText != null)
-                outputText.text = _currentText;
+            // Ajoute la lettre sélectionnée au mot en cours et met à jour l'affichage.
+            currentVKWordText += keyName;
+            if (currentVKWord != null)
+                currentVKWord.text = currentVKWordText;
         }
     }
 
@@ -186,12 +220,13 @@ public class VirtualKeyboard : MonoBehaviour
     /// </summary>
     private void RemoveLastChar()
     {
-        if (_currentText.Length == 0)
+        if (currentVKWordText.Length == 0)
             return;
 
-        _currentText = _currentText.Substring(0, _currentText.Length - 1);
-        if (outputText != null)
-            outputText.text = _currentText;
+        // Retire le dernier caractère et met à jour le texte affiché.
+        currentVKWordText = currentVKWordText.Substring(0, currentVKWordText.Length - 1);
+        if (currentVKWord != null)
+            currentVKWord.text = currentVKWordText;
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- temporise le déplacement du curseur (0,1 s) pour une navigation plus fluide
- ajoute chaque lettre sélectionnée via l'input `Interact` au texte affiché
- active/désactive le mapping d'entrées `World` lors de l'ouverture/fermeture du clavier
- renomme la zone d'affichage en `currentVKWord` pour refléter le champ `Output Text`

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c837828483258fe78c556c2dfe41