### PR TITLE
Ajout de la Glow-Up Scene

### DIFF
--- a/Assets/Scenes/GlowUpScene.unity
+++ b/Assets/Scenes/GlowUpScene.unity
@@ -1,0 +1,155 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 1
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_Name: GlowUpInitializer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27602f5b-c024-4e10-8fca-28477b1488e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  distanceLucian: 10

--- a/Assets/Scenes/GlowUpScene.unity.meta
+++ b/Assets/Scenes/GlowUpScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ef710165-cca4-4425-9822-9114cdcc722c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs
@@ -1,0 +1,145 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+/// <summary>
+/// Configure automatiquement la "Glow-Up Scene" pour obtenir le rendu stylisé décrit dans la documentation.
+/// Tout est généré en C# afin d'éviter une scène trop lourde à maintenir.
+/// </summary>
+public class GlowUpSceneSetup : MonoBehaviour
+{
+    [Header("Paramètres de profondeur de champ")]
+    [Tooltip("Distance actuelle entre la caméra et Lucian en mètres.")]
+    public float distanceLucian = 10f; // valeur par défaut pour calculer le DOF
+
+    private void Start()
+    {
+        // 1) Caméra principale ------------------------------------------------------
+        // On récupère ou crée la caméra principale puis on applique les réglages
+        Camera cam = Camera.main;
+        if (cam == null)
+        {
+            cam = new GameObject("Main Camera").AddComponent<Camera>();
+            cam.tag = "MainCamera";
+        }
+
+        // Ajout des données HDRP pour accéder aux paramètres physiques
+        HDAdditionalCameraData hdCam = cam.gameObject.GetComponent<HDAdditionalCameraData>();
+        if (hdCam == null)
+            hdCam = cam.gameObject.AddComponent<HDAdditionalCameraData>();
+
+        // Paramètres d'exposition manuelle (ISO, Shutter, Aperture, Compensation)
+        hdCam.physicalParameters.exposureMode = HDPhysicalCameraExposureMode.Manual;
+        hdCam.physicalParameters.iso = 100f;
+        hdCam.physicalParameters.shutterSpeed = 1f / 60f;
+        hdCam.physicalParameters.aperture = 5.6f;
+        hdCam.physicalParameters.compensation = 0f;
+
+        // 2) Volume de post-traitement ---------------------------------------------
+        // On crée un Volume global qui contiendra tous les effets graphiques.
+        Volume volume = cam.gameObject.GetComponent<Volume>();
+        if (volume == null)
+        {
+            volume = cam.gameObject.AddComponent<Volume>();
+            volume.isGlobal = true; // Effets appliqués sur toute la scène
+        }
+
+        // Si aucun profil n'est présent, on en crée un nouveau
+        if (volume.profile == null)
+            volume.profile = ScriptableObject.CreateInstance<VolumeProfile>();
+        VolumeProfile profile = volume.profile;
+
+        // Tonemapping ACES ---------------------------------------------------------
+        Tonemapping tonemapping = profile.Add<Tonemapping>(false);
+        tonemapping.mode.value = TonemappingMode.ACES;
+
+        // Bloom doux ---------------------------------------------------------------
+        Bloom bloom = profile.Add<Bloom>(false);
+        bloom.intensity.value = 0.3f; // entre 0.2 et 0.35
+        bloom.threshold.value = 1.2f; // entre 1.1 et 1.3
+        bloom.scatter.value = 0.7f;   // diffusion
+
+        // Vignette légère ----------------------------------------------------------
+        Vignette vignette = profile.Add<Vignette>(false);
+        vignette.intensity.value = 0.18f;
+        vignette.smoothness.value = 0.4f;
+
+        // Aberration chromatique ---------------------------------------------------
+        ChromaticAberration ca = profile.Add<ChromaticAberration>(false);
+        ca.intensity.value = 0.03f;
+
+        // Profondeur de champ ------------------------------------------------------
+        DepthOfField dof = profile.Add<DepthOfField>(false);
+        dof.focusMode.value = DepthOfFieldMode.UsePhysicalCamera;
+        dof.focusDistance.value = distanceLucian + 2f; // focus légèrement derrière Lucian
+        dof.aperture.value = 4f;
+        dof.bladeCount.value = 7;
+
+        // Occlusion ambiante -------------------------------------------------------
+        ScreenSpaceAmbientOcclusion ssao = profile.Add<ScreenSpaceAmbientOcclusion>(false);
+        ssao.intensity.value = 0.7f;
+        ssao.radius.value = 0.35f;
+        ssao.quality.value = ScalableSettingLevelParameter.Level.High;
+
+        // Global Illumination optionnelle (désactivée par défaut pour rester stylisée)
+        ScreenSpaceGlobalIllumination ssgi = profile.Add<ScreenSpaceGlobalIllumination>(false);
+        ssgi.intensity.value = 0.4f;
+        ssgi.active = false; // l'utilisateur peut l'activer dans l'inspecteur si besoin
+
+        // Color grading ------------------------------------------------------------
+        WhiteBalance wb = profile.Add<WhiteBalance>(false);
+        wb.temperature.value = -10f; // légère correction vers le froid
+
+        ColorAdjustments colorAdj = profile.Add<ColorAdjustments>(false);
+        colorAdj.lift.value = new Vector4(0.97f, 0.98f, 1f, 0f);
+        colorAdj.gamma.value = new Vector4(1.02f, 1.02f, 1.02f, 0f);
+        colorAdj.gain.value = new Vector4(1.05f, 1.05f, 1.05f, 0f);
+        colorAdj.saturation.value = 1.1f;
+
+        // 3) Ciel et ambiance ------------------------------------------------------
+        VisualEnvironment visualEnv = profile.Add<VisualEnvironment>(false);
+        visualEnv.skyType.value = (int)SkyType.PhysicallyBased;
+
+        PhysicallyBasedSky sky = profile.Add<PhysicallyBasedSky>(false);
+        sky.sunSize.value = 0.5f;
+
+        IndirectLightingController indirect = profile.Add<IndirectLightingController>(false);
+        indirect.indirectDiffuseLightingMultiplier.value = 1.1f;
+        indirect.indirectSpecularLightingMultiplier.value = 0.9f;
+
+        // 4) Brume & Volumétriques -------------------------------------------------
+        Fog fog = profile.Add<Fog>(false);
+        fog.enabled.value = true;
+        fog.fogType.value = FogType.Volumetric;
+        fog.baseFogDistance.value = 100f; // moyenne entre 80 et 120 m
+        fog.anisotropy.value = 0.6f;
+        fog.baseHeight.value = 0f;
+        fog.heightAttenuation.value = 0.15f;
+
+        // 5) Lumière directionnelle principale ------------------------------------
+        GameObject lightObj = new GameObject("Main Directional Light");
+        Light light = lightObj.AddComponent<Light>();
+        light.type = LightType.Directional;
+        HDAdditionalLightData hdLight = lightObj.AddComponent<HDAdditionalLightData>();
+        hdLight.lightUnit = LightUnit.Lux;
+        hdLight.intensity = 80000f; // moyenne entre 70k et 90k
+        hdLight.shadowResolution = 4096; // Shadowmap 4k
+        hdLight.enableContactShadows = true;
+        hdLight.SetShadowCascades(4); // 4 cascades
+        hdLight.shadowDistance = 100f;
+        hdLight.SetColor(Color.white, 5800f); // temp 6500K -> 5800K
+
+        // 6) Reflection Probe ------------------------------------------------------
+        GameObject probeObj = new GameObject("Global Reflection Probe");
+        ReflectionProbe probe = probeObj.AddComponent<ReflectionProbe>();
+        probe.mode = UnityEngine.Rendering.ReflectionProbeMode.Baked;
+        probe.boxProjection = true;
+        probe.refreshMode = UnityEngine.Rendering.ReflectionProbeRefreshMode.OnAwake;
+        probe.intensity = 0.8f;
+
+        // 7) Motion Blur minimal (ajouté pour les dash/teleport) --------------------
+        MotionBlur motionBlur = profile.Add<MotionBlur>(false);
+        motionBlur.intensity.value = 0f; // pas d'effet par défaut
+        motionBlur.shutterAngle.value = 0.2f;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27602f5b-c024-4e10-8fca-28477b1488e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- Création de la scène `GlowUpScene` avec un objet initialiseur.
- Ajout du script `GlowUpSceneSetup` configurant caméra HDRP, volume de post-traitement, lumière directionnelle et probes.

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4fff1d8832594e441388ac117d1