### PR TITLE
feat: synchroniser le parent avec le root motion

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+/// <summary>
+/// Synchronise la position et la rotation du GameObject parent avec le Root Motion
+/// calculé par un Animator enfant. À utiliser lorsque l'Animator n'est pas sur le
+/// même GameObject que le Transform racine afin d'éviter que le parent reste en (0,0,0).
+/// </summary>
+public class RootMotionParentSync : MonoBehaviour
+{
+    [Tooltip("Animator possédant les animations en Root Motion.")]
+    public Animator animator; // Référence vers l'Animator enfant.
+
+    void Awake()
+    {
+        // Si aucune référence n'est assignée, on tente de récupérer l'Animator présent dans les enfants.
+        if (animator == null)
+            animator = GetComponentInChildren<Animator>();
+
+        // On force l'utilisation du Root Motion pour que les déplacements proviennent des animations.
+        if (animator != null)
+            animator.applyRootMotion = true;
+    }
+
+    void OnAnimatorMove()
+    {
+        if (animator == null)
+            return; // Aucun Animator : rien à synchroniser.
+
+        // Application du déplacement et de la rotation calculés par l'Animator sur le parent.
+        transform.position += animator.deltaPosition;
+        transform.rotation *= animator.deltaRotation;
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af5072ad198045a1909dbf80033c27c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- Ajout d'un composant `RootMotionParentSync` pour appliquer le root motion de l'Animator au GameObject parent.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68b1476c0048832593962236855ff352