### PR TITLE
Synchronisation du Root Motion avec le parent

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RootMotionParentSync.cs
@@ -2,19 +2,28 @@ using UnityEngine;
 
 /// <summary>
 /// Synchronise la position et la rotation du GameObject parent avec le Root Motion
-/// calculé par un Animator enfant. À utiliser lorsque l'Animator n'est pas sur le
-/// même GameObject que le Transform racine afin d'éviter que le parent reste en (0,0,0).
+/// calculé par l'Animator présent sur le même GameObject. Ce composant est pensé
+/// pour être placé sur l'Animator lui‑même (ex. : <c>Lucian_Battle</c>) afin de
+/// déplacer son parent dans la scène.
 /// </summary>
 public class RootMotionParentSync : MonoBehaviour
 {
     [Tooltip("Animator possédant les animations en Root Motion.")]
-    public Animator animator; // Référence vers l'Animator enfant.
+    public Animator animator; // Référence vers l'Animator local.
+
+    // Transform du parent à déplacer via le Root Motion.
+    private Transform parentTransform;
 
     void Awake()
     {
-        // Si aucune référence n'est assignée, on tente de récupérer l'Animator présent dans les enfants.
+        // Récupération de l'Animator sur le même GameObject si non assigné.
         if (animator == null)
-            animator = GetComponentInChildren<Animator>();
+            animator = GetComponent<Animator>();
+
+        // Sauvegarde du Transform parent pour y appliquer les déplacements.
+        parentTransform = transform.parent;
+        if (parentTransform == null)
+            Debug.LogWarning("RootMotionParentSync : aucun parent trouvé, le Root Motion ne sera pas appliqué.", this);
 
         // On force l'utilisation du Root Motion pour que les déplacements proviennent des animations.
         if (animator != null)
@@ -23,12 +32,21 @@ public class RootMotionParentSync : MonoBehaviour
 
     void OnAnimatorMove()
     {
-        if (animator == null)
-            return; // Aucun Animator : rien à synchroniser.
+        // Sans Animator ou sans parent, aucune synchronisation possible.
+        if (animator == null || parentTransform == null)
+            return;
 
-        // Application du déplacement et de la rotation calculés par l'Animator sur le parent.
-        transform.position += animator.deltaPosition;
-        transform.rotation *= animator.deltaRotation;
+        // Application du déplacement calculé par l'Animator sur le Transform parent.
+        parentTransform.position += animator.deltaPosition;
+
+        // Application de la rotation calculée par l'Animator sur le Transform parent.
+        parentTransform.rotation *= animator.deltaRotation;
+
+        // Réinitialisation de la position locale pour éviter que l'Animator retourne à l'origine.
+        transform.localPosition = Vector3.zero;
+
+        // Réinitialisation de la rotation locale pour empêcher tout décalage visuel.
+        transform.localRotation = Quaternion.identity;
     }
 }
 


### PR DESCRIPTION
## Résumé
- Ajout d'un `Transform` parent pour appliquer le Root Motion au parent et non à l'Animator lui-même.
- Réinitialisation de la position et de la rotation locales pour éviter les retours à l'origine.

## Tests
- `dotnet test` *(échoué: dotnet manquant)*
- `apt-get update` *(échoué: dépôts non signés / accès interdit)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a54fb6c832598eacd7fc782ecd6