### PR TITLE
Prévisualisation des dialogues via la Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -19,6 +19,12 @@ public struct DialogueLine
 /// - Verrouillage des contrôles joueur
 /// - Positionnement de la bulle
 /// </summary>
+/// <remarks>
+/// L'attribut <see cref="ExecuteAlways"/> permet de prévisualiser les dialogues
+/// directement depuis l'éditeur Unity (notamment lors de l'utilisation des Timelines
+/// et de leurs signaux) sans devoir lancer le Play Mode.
+/// </remarks>
+[ExecuteAlways]
 public class DialogueManager : MonoBehaviour
 {
     [Header("UI")]

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -1,6 +1,13 @@
 using UnityEngine;
 using UnityEngine.Playables;
 
+/// <summary>
+/// Reçoit les signaux de la Timeline pour déclencher les dialogues.
+/// L'attribut <see cref="ExecuteAlways"/> garantit que ces signaux sont
+/// traités même en mode Éditeur afin de faciliter la mise au point des
+/// cinématiques sans lancer le jeu.
+/// </summary>
+[ExecuteAlways]
 public class DialogueSignalReceiver : MonoBehaviour
 {
     public PlayableDirector timeline;


### PR DESCRIPTION
## Résumé
- Permet l'exécution des scripts de dialogue en mode Éditeur grâce à `ExecuteAlways`
- Assure la réception des signaux de Timeline pour visualiser les dialogues hors Play Mode

## Test
- `dotnet test` *(échec : `dotnet` manquant)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68b165a68a6083258591f280bec99349