### PR TITLE
Prévisualisation des dialogues via la Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -19,6 +19,12 @@ public struct DialogueLine
 /// - Verrouillage des contrôles joueur
 /// - Positionnement de la bulle
 /// </summary>
+/// <remarks>
+/// L'attribut <see cref="ExecuteAlways"/> permet de prévisualiser les dialogues
+/// directement depuis l'éditeur Unity (notamment lors de l'utilisation des Timelines
+/// et de leurs signaux) sans devoir lancer le Play Mode.
+/// </remarks>
+[ExecuteAlways]
 public class DialogueManager : MonoBehaviour
 {
     [Header("UI")]
@@ -61,11 +67,19 @@ public class DialogueManager : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(gameObject);
+            // En mode éditeur, on détruit immédiatement pour éviter des restes de preview
+            DestroyImmediate(gameObject);
             return;
         }
+
         Instance = this;
-        DontDestroyOnLoad(gameObject);
+
+        // Évite l'avertissement "DontDestroyOnLoad" hors Play Mode
+        if (Application.isPlaying)
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
         rectTransform = GetComponent<RectTransform>();
     }
 
@@ -108,6 +122,28 @@ public class DialogueManager : MonoBehaviour
     /// </summary>
     public void PlayDialogue(DialogueContainer container, System.Action onEnd = null)
     {
+        // En mode Éditeur (Timeline preview), on affiche simplement la première ligne sans animations
+        if (!Application.isPlaying)
+        {
+            if (container != null && container.lines != null && container.lines.Length > 0)
+            {
+                nameText.text = container.lines[0].speakerName;
+                dialogueText.text = container.lines[0].text;
+
+                // Force l'ouverture visuelle de la boîte de dialogue
+                var animator = GetComponentInChildren<Animator>();
+                if (animator != null)
+                {
+                    animator.Play("DialogueBoxOpen", 0, 1f); // sauter directement à la fin de l'anim
+                    animator.Update(0f); // applique immédiatement l'état
+                }
+
+                isOpen = true;
+            }
+            onEnd?.Invoke();
+            return;
+        }
+
         StopAllCoroutines();
         onDialogueEndCallback = onEnd;
         StartCoroutine(StartDialogue(container));

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -1,6 +1,13 @@
 using UnityEngine;
 using UnityEngine.Playables;
 
+/// <summary>
+/// Reçoit les signaux de la Timeline pour déclencher les dialogues.
+/// L'attribut <see cref="ExecuteAlways"/> garantit que ces signaux sont
+/// traités même en mode Éditeur afin de faciliter la mise au point des
+/// cinématiques sans lancer le jeu.
+/// </summary>
+[ExecuteAlways]
 public class DialogueSignalReceiver : MonoBehaviour
 {
     public PlayableDirector timeline;
@@ -9,13 +16,22 @@ public class DialogueSignalReceiver : MonoBehaviour
     public void TriggerDialogueAndPause(DialogueContainer dialogueContainer)
     {
         // Utilise le DialogueContainer pour gérer la position de la bulle
-        DialogueManager.Instance.PlayDialogue(dialogueContainer, OnDialogueEnded);
-        timeline.Pause();
+        DialogueManager.Instance.PlayDialogue(dialogueContainer, Application.isPlaying ? (System.Action)OnDialogueEnded : null);
+
+        // Pause uniquement en Play Mode
+        if (Application.isPlaying && timeline != null)
+        {
+            timeline.Pause();
+        }
     }
 
     private void OnDialogueEnded()
     {
-        timeline.Resume();
+        // Reprise après fermeture du dialogue (Play Mode uniquement)
+        if (timeline != null)
+        {
+            timeline.Resume();
+        }
     }
 
     public void TriggerDialogueNoPause(DialogueContainer dialogueContainer)


### PR DESCRIPTION
## Résumé
- Affiche les lignes de dialogue lors de la prévisualisation de Timeline en mode Éditeur
- Pause/Reprise de la Timeline uniquement en Play Mode pour éviter les erreurs

## Test
- `dotnet test` *(échec : `command not found: dotnet`)*
- `apt-get update` *(échec : 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b165a68a6083258591f280bec99349