### PR TITLE
Prévisualisation des dialogues via la Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -59,6 +59,12 @@ public class DialogueManager : MonoBehaviour
     private float seq_timePerChar = 0.03f, seq_minHold = 0.5f, seq_maxHold = 2.5f;
     private bool seq_unscaled = true;
 
+    // --- Prévisualisation de l'éditeur ---
+    // Stocke temporairement le container et l'index courant afin
+    // d'avancer manuellement ligne par ligne via un signal.
+    private DialogueContainer previewContainer;
+    private int previewLineIndex = -1;
+
     // Séquence active + verrouillage des contrôles pendant toute la séquence
     private bool inSequence = false;
     private bool lockControlsDuringSequence = true;
@@ -122,9 +128,13 @@ public class DialogueManager : MonoBehaviour
     /// </summary>
     public void PlayDialogue(DialogueContainer container, System.Action onEnd = null)
     {
-        // En mode Éditeur (Timeline preview), on affiche simplement la première ligne sans animations
+        // En mode Éditeur (Timeline preview), on affiche simplement les lignes de façon statique
+        // et on conserve le container pour permettre l'avancement via un signal NextLine.
         if (!Application.isPlaying)
         {
+            previewContainer = container;
+            previewLineIndex = 0;
+
             if (container != null && container.lines != null && container.lines.Length > 0)
             {
                 nameText.text = container.lines[0].speakerName;
@@ -140,6 +150,11 @@ public class DialogueManager : MonoBehaviour
 
                 isOpen = true;
             }
+            else
+            {
+                isOpen = false;
+            }
+
             onEnd?.Invoke();
             return;
         }
@@ -499,6 +514,31 @@ public class DialogueManager : MonoBehaviour
     {
         if (!isOpen) return;
 
+        // Mode Éditeur : avance simplement dans le container prévisualisé
+        if (!Application.isPlaying)
+        {
+            if (previewContainer == null || previewContainer.lines == null)
+                return;
+
+            previewLineIndex++;
+
+            if (previewLineIndex < previewContainer.lines.Length)
+            {
+                var line = previewContainer.lines[previewLineIndex];
+                nameText.text = line.speakerName;
+                dialogueText.text = line.text;
+            }
+            else
+            {
+                // Fin de prévisualisation : on ferme visuellement le dialogue
+                previewContainer = null;
+                isOpen = false;
+            }
+
+            return;
+        }
+
+        // Mode Play : logique habituelle
         if (isTyping)
         {
             skipRequested = true; // affiche la ligne instantanément

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -19,6 +19,12 @@ public struct DialogueLine
 /// - Verrouillage des contrôles joueur
 /// - Positionnement de la bulle
 /// </summary>
+/// <remarks>
+/// L'attribut <see cref="ExecuteAlways"/> permet de prévisualiser les dialogues
+/// directement depuis l'éditeur Unity (notamment lors de l'utilisation des Timelines
+/// et de leurs signaux) sans devoir lancer le Play Mode.
+/// </remarks>
+[ExecuteAlways]
 public class DialogueManager : MonoBehaviour
 {
     [Header("UI")]
@@ -61,11 +67,19 @@ public class DialogueManager : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(gameObject);
+            // En mode éditeur, on détruit immédiatement pour éviter des restes de preview
+            DestroyImmediate(gameObject);
             return;
         }
+
         Instance = this;
-        DontDestroyOnLoad(gameObject);
+
+        // Évite l'avertissement "DontDestroyOnLoad" hors Play Mode
+        if (Application.isPlaying)
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
         rectTransform = GetComponent<RectTransform>();
     }
 
@@ -108,6 +122,28 @@ public class DialogueManager : MonoBehaviour
     /// </summary>
     public void PlayDialogue(DialogueContainer container, System.Action onEnd = null)
     {
+        // En mode Éditeur (Timeline preview), on affiche simplement la première ligne sans animations
+        if (!Application.isPlaying)
+        {
+            if (container != null && container.lines != null && container.lines.Length > 0)
+            {
+                nameText.text = container.lines[0].speakerName;
+                dialogueText.text = container.lines[0].text;
+
+                // Force l'ouverture visuelle de la boîte de dialogue
+                var animator = GetComponentInChildren<Animator>();
+                if (animator != null)
+                {
+                    animator.Play("DialogueBoxOpen", 0, 1f); // sauter directement à la fin de l'anim
+                    animator.Update(0f); // applique immédiatement l'état
+                }
+
+                isOpen = true;
+            }
+            onEnd?.Invoke();
+            return;
+        }
+
         StopAllCoroutines();
         onDialogueEndCallback = onEnd;
         StartCoroutine(StartDialogue(container));

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -1,6 +1,13 @@
 using UnityEngine;
 using UnityEngine.Playables;
 
+/// <summary>
+/// Reçoit les signaux de la Timeline pour déclencher les dialogues.
+/// L'attribut <see cref="ExecuteAlways"/> garantit que ces signaux sont
+/// traités même en mode Éditeur afin de faciliter la mise au point des
+/// cinématiques sans lancer le jeu.
+/// </summary>
+[ExecuteAlways]
 public class DialogueSignalReceiver : MonoBehaviour
 {
     public PlayableDirector timeline;
@@ -9,13 +16,22 @@ public class DialogueSignalReceiver : MonoBehaviour
     public void TriggerDialogueAndPause(DialogueContainer dialogueContainer)
     {
         // Utilise le DialogueContainer pour gérer la position de la bulle
-        DialogueManager.Instance.PlayDialogue(dialogueContainer, OnDialogueEnded);
-        timeline.Pause();
+        DialogueManager.Instance.PlayDialogue(dialogueContainer, Application.isPlaying ? (System.Action)OnDialogueEnded : null);
+
+        // Pause uniquement en Play Mode
+        if (Application.isPlaying && timeline != null)
+        {
+            timeline.Pause();
+        }
     }
 
     private void OnDialogueEnded()
     {
-        timeline.Resume();
+        // Reprise après fermeture du dialogue (Play Mode uniquement)
+        if (timeline != null)
+        {
+            timeline.Resume();
+        }
     }
 
     public void TriggerDialogueNoPause(DialogueContainer dialogueContainer)

--- a/Assets/TimelineResumeOnConfirm.cs
+++ b/Assets/TimelineResumeOnConfirm.cs
@@ -4,9 +4,10 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Playables;
 
-[DisallowMultipleComponent]
-[RequireComponent(typeof(PlayableDirector))]
-public class TimelinePauseResumeOnInteract : MonoBehaviour
+ [DisallowMultipleComponent]
+ [RequireComponent(typeof(PlayableDirector))]
+ [ExecuteAlways]
+ public class TimelinePauseResumeOnInteract : MonoBehaviour
 {
     [Tooltip("Instance de PlayerInputs. Si vide, on prendra celle de InputsManager, sinon on en créera une locale.")]
     [SerializeField] private PlayerInputs playerInputs;
@@ -65,6 +66,10 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void OnEnable()
     {
+        // En mode Éditeur, on n'active pas les entrées pour éviter les erreurs
+        if (!Application.isPlaying)
+            return;
+
         if (playerInputs == null)
         {
             Debug.LogWarning("[TimelinePauseResumeOnInteract] PlayerInputs introuvable.");
@@ -77,6 +82,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void OnDisable()
     {
+        if (!Application.isPlaying)
+            return;
+
         if (playerInputs != null)
         {
             playerInputs.World.Interact.performed -= OnInteract;
@@ -88,6 +96,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void Update()
     {
+        if (!Application.isPlaying)
+            return;
+
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
@@ -120,6 +131,13 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
     /// </summary>
     public void PauseForNextCondition()
     {
+        if (!Application.isPlaying)
+        {
+            // Prévisualisation : pause simple du PlayableDirector sans gestion de conditions
+            director?.Pause();
+            return;
+        }
+
         if (TimelineManager.Instance == null)
             return;
 
@@ -168,6 +186,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
     /// </summary>
     private void OnInteract(InputAction.CallbackContext ctx)
     {
+        if (!Application.isPlaying)
+            return;
+
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
@@ -181,6 +202,13 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void ResumeTimeline()
     {
+        if (!Application.isPlaying)
+        {
+            // En prévisualisation, on relance simplement la Timeline locale
+            director?.Play();
+            return;
+        }
+
         waitingForCondition = false;
         waitingForDialogueToClose = false;
         TimelineManager.Instance.ResumeCurrentTimeline();


### PR DESCRIPTION
## Résumé
- Affiche les lignes de dialogue lors de la prévisualisation de Timeline en mode Éditeur
- Pause/Reprise de la Timeline uniquement en Play Mode pour éviter les erreurs

## Test
- `dotnet test` *(échec : `command not found: dotnet`)*
- `apt-get update` *(échec : 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b165a68a6083258591f280bec99349