### PR TITLE
Prévisualisation des signaux Timeline dans l'Éditeur

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AnimationSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AnimationSignalReceiver.cs
@@ -1,6 +1,10 @@
 using UnityEngine;
 using System.Collections.Generic;
 
+/// <summary>
+/// Entrée référencée par l'<see cref="AnimationSignalReceiver"/> pour
+/// associer un identifiant à un <see cref="Animator"/> spécifique.
+/// </summary>
 [System.Serializable]
 public class AnimatorEntry
 {
@@ -11,6 +15,13 @@ public class AnimatorEntry
     public Animator animator;
 }
 
+/// <summary>
+/// Récepteur d'animation déclenché par les Signaux de la Timeline.
+/// L'attribut <see cref="ExecuteAlways"/> garantit son exécution même
+/// hors Play Mode, permettant de tester visuellement les animations
+/// depuis l'Éditeur.
+/// </summary>
+[ExecuteAlways]
 public class AnimationSignalReceiver : MonoBehaviour
 {
     [Header("List of Animators available in this scene")]
@@ -18,6 +29,9 @@ public class AnimationSignalReceiver : MonoBehaviour
 
     public void TriggerAnimation(AnimationTriggerSO trigger)
     {
+        // Méthode invoquée par la Timeline, y compris lors de la prévisualisation
+        // en mode Éditeur. On vérifie systématiquement les entrées pour éviter
+        // toute erreur pendant l'édition.
         if (trigger == null)
         {
             Debug.LogWarning("[AnimationSignalReceiver] Received null AnimationTriggerSO.");

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -19,6 +19,12 @@ public struct DialogueLine
 /// - Verrouillage des contrôles joueur
 /// - Positionnement de la bulle
 /// </summary>
+/// <remarks>
+/// L'attribut <see cref="ExecuteAlways"/> permet de prévisualiser les dialogues
+/// directement depuis l'éditeur Unity (notamment lors de l'utilisation des Timelines
+/// et de leurs signaux) sans devoir lancer le Play Mode.
+/// </remarks>
+[ExecuteAlways]
 public class DialogueManager : MonoBehaviour
 {
     [Header("UI")]
@@ -53,6 +59,12 @@ public class DialogueManager : MonoBehaviour
     private float seq_timePerChar = 0.03f, seq_minHold = 0.5f, seq_maxHold = 2.5f;
     private bool seq_unscaled = true;
 
+    // --- Prévisualisation de l'éditeur ---
+    // Stocke temporairement le container et l'index courant afin
+    // d'avancer manuellement ligne par ligne via un signal.
+    private DialogueContainer previewContainer;
+    private int previewLineIndex = -1;
+
     // Séquence active + verrouillage des contrôles pendant toute la séquence
     private bool inSequence = false;
     private bool lockControlsDuringSequence = true;
@@ -61,11 +73,19 @@ public class DialogueManager : MonoBehaviour
     {
         if (Instance != null && Instance != this)
         {
-            Destroy(gameObject);
+            // En mode éditeur, on détruit immédiatement pour éviter des restes de preview
+            DestroyImmediate(gameObject);
             return;
         }
+
         Instance = this;
-        DontDestroyOnLoad(gameObject);
+
+        // Évite l'avertissement "DontDestroyOnLoad" hors Play Mode
+        if (Application.isPlaying)
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+
         rectTransform = GetComponent<RectTransform>();
     }
 
@@ -108,6 +128,37 @@ public class DialogueManager : MonoBehaviour
     /// </summary>
     public void PlayDialogue(DialogueContainer container, System.Action onEnd = null)
     {
+        // En mode Éditeur (Timeline preview), on affiche simplement les lignes de façon statique
+        // et on conserve le container pour permettre l'avancement via un signal NextLine.
+        if (!Application.isPlaying)
+        {
+            previewContainer = container;
+            previewLineIndex = 0;
+
+            if (container != null && container.lines != null && container.lines.Length > 0)
+            {
+                nameText.text = container.lines[0].speakerName;
+                dialogueText.text = container.lines[0].text;
+
+                // Force l'ouverture visuelle de la boîte de dialogue
+                var animator = GetComponentInChildren<Animator>();
+                if (animator != null)
+                {
+                    animator.Play("DialogueBoxOpen", 0, 1f); // sauter directement à la fin de l'anim
+                    animator.Update(0f); // applique immédiatement l'état
+                }
+
+                isOpen = true;
+            }
+            else
+            {
+                isOpen = false;
+            }
+
+            onEnd?.Invoke();
+            return;
+        }
+
         StopAllCoroutines();
         onDialogueEndCallback = onEnd;
         StartCoroutine(StartDialogue(container));
@@ -463,6 +514,31 @@ public class DialogueManager : MonoBehaviour
     {
         if (!isOpen) return;
 
+        // Mode Éditeur : avance simplement dans le container prévisualisé
+        if (!Application.isPlaying)
+        {
+            if (previewContainer == null || previewContainer.lines == null)
+                return;
+
+            previewLineIndex++;
+
+            if (previewLineIndex < previewContainer.lines.Length)
+            {
+                var line = previewContainer.lines[previewLineIndex];
+                nameText.text = line.speakerName;
+                dialogueText.text = line.text;
+            }
+            else
+            {
+                // Fin de prévisualisation : on ferme visuellement le dialogue
+                previewContainer = null;
+                isOpen = false;
+            }
+
+            return;
+        }
+
+        // Mode Play : logique habituelle
         if (isTyping)
         {
             skipRequested = true; // affiche la ligne instantanément

--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -1,6 +1,13 @@
 using UnityEngine;
 using UnityEngine.Playables;
 
+/// <summary>
+/// Reçoit les signaux de la Timeline pour déclencher les dialogues.
+/// L'attribut <see cref="ExecuteAlways"/> garantit que ces signaux sont
+/// traités même en mode Éditeur afin de faciliter la mise au point des
+/// cinématiques sans lancer le jeu.
+/// </summary>
+[ExecuteAlways]
 public class DialogueSignalReceiver : MonoBehaviour
 {
     public PlayableDirector timeline;
@@ -9,13 +16,22 @@ public class DialogueSignalReceiver : MonoBehaviour
     public void TriggerDialogueAndPause(DialogueContainer dialogueContainer)
     {
         // Utilise le DialogueContainer pour gérer la position de la bulle
-        DialogueManager.Instance.PlayDialogue(dialogueContainer, OnDialogueEnded);
-        timeline.Pause();
+        DialogueManager.Instance.PlayDialogue(dialogueContainer, Application.isPlaying ? (System.Action)OnDialogueEnded : null);
+
+        // Pause uniquement en Play Mode
+        if (Application.isPlaying && timeline != null)
+        {
+            timeline.Pause();
+        }
     }
 
     private void OnDialogueEnded()
     {
-        timeline.Resume();
+        // Reprise après fermeture du dialogue (Play Mode uniquement)
+        if (timeline != null)
+        {
+            timeline.Resume();
+        }
     }
 
     public void TriggerDialogueNoPause(DialogueContainer dialogueContainer)

--- a/Assets/Scripts/MonoBehavioursUsed/EventSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/EventSignalReceiver.cs
@@ -1,5 +1,13 @@
 using UnityEngine;
 
+/// <summary>
+/// Récepteur générique pour déclencher des évènements depuis une Timeline.
+/// L'attribut <see cref="ExecuteAlways"/> permet de prévisualiser ces
+/// évènements directement dans l'Éditeur sans lancer le Play Mode,
+/// garantissant que tous les signaux sont pris en compte lors de la
+/// construction des cinématiques.
+/// </summary>
+[ExecuteAlways]
 public class EventSignalReceiver : MonoBehaviour
 {
     [Header("Player Move Settings")]
@@ -11,7 +19,9 @@ public class EventSignalReceiver : MonoBehaviour
 
     private void Start()
     {
-        // Cache le joueur pour éviter le Find() en boucle
+        // Méthode exécutée également dans l'Éditeur grâce à ExecuteAlways.
+        // On met en cache la référence au joueur pour que les signaux
+        // puissent le manipuler pendant la prévisualisation.
         GameObject player = GameObject.FindGameObjectWithTag("Player");
         if (player != null)
         {
@@ -21,6 +31,8 @@ public class EventSignalReceiver : MonoBehaviour
 
     private void Update()
     {
+        // En prévisualisation, les signaux Timeline peuvent définir un
+        // vecteur de déplacement pour tester les trajectoires sans lancer le jeu.
         if (playerTransform != null && moveDirection != Vector3.zero)
         {
             // Déplace dans l'espace local du joueur (avant, arrière, côté)

--- a/Assets/Scripts/MonoBehavioursUsed/MoveToExecutor.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MoveToExecutor.cs
@@ -1,6 +1,13 @@
 using System.Collections;
 using UnityEngine;
 
+/// <summary>
+/// Exécute les déplacements <c>MoveTo</c> déclenchés depuis les Signaux
+/// de la Timeline. Grâce à l'attribut <see cref="ExecuteAlways"/> la classe
+/// fonctionne également en mode Éditeur, ce qui permet de prévisualiser les
+/// trajectoires sans avoir à lancer le jeu.
+/// </summary>
+[ExecuteAlways]
 [DisallowMultipleComponent]
 public class MoveToExecutor : MonoBehaviour
 {
@@ -22,7 +29,49 @@ public class MoveToExecutor : MonoBehaviour
             return;
         }
 
-        // ----- D�placement -----
+        // Lorsque l'on prévisualise la Timeline hors Play Mode, on applique
+        // immédiatement la transformation sans lancer de coroutine afin de
+        // voir instantanément le résultat.
+        if (!Application.isPlaying)
+        {
+            // ----- Déplacement direct -----
+            if (TryResolveDestination(config, out Vector3 previewDst))
+            {
+                if (config.useLocalSpace && subject.parent != null)
+                    subject.localPosition = subject.parent.InverseTransformPoint(previewDst);
+                else
+                    subject.position = previewDst;
+            }
+            else
+            {
+                Debug.LogWarning("[MoveToExecutor] Impossible de résoudre la destination.");
+            }
+
+            // ----- Rotation directe (optionnelle) -----
+            if (config.rotationTargetMode != RotationTargetMode.None &&
+                TryResolveLookTarget(config, out Vector3 previewLook))
+            {
+                Vector3 up = (config.customUp == Vector3.zero ? Vector3.up : config.customUp.normalized);
+
+                Vector3 dir = (previewLook - subject.position);
+                if (dir.sqrMagnitude < 1e-8f) dir = subject.forward;
+
+                Quaternion targetRot = Quaternion.LookRotation(dir, up) * Quaternion.Euler(config.rotationEulerOffset);
+
+                Vector3 targetEuler = targetRot.eulerAngles;
+                Vector3 currentEuler = subject.rotation.eulerAngles;
+
+                if (!config.rotateAxes.X) targetEuler.x = currentEuler.x;
+                if (!config.rotateAxes.Y) targetEuler.y = currentEuler.y;
+                if (!config.rotateAxes.Z) targetEuler.z = currentEuler.z;
+
+                subject.rotation = Quaternion.Euler(targetEuler);
+            }
+
+            return; // rien de plus à faire en mode Éditeur
+        }
+
+        // ----- Déplacement -----
         if (TryResolveDestination(config, out Vector3 dstWorld))
         {
             StartMove(
@@ -37,7 +86,7 @@ public class MoveToExecutor : MonoBehaviour
         }
         else
         {
-            Debug.LogWarning("[MoveToExecutor] Impossible de r�soudre la destination.");
+            Debug.LogWarning("[MoveToExecutor] Impossible de résoudre la destination.");
         }
 
         // ----- Rotation (optionnelle) -----
@@ -215,13 +264,13 @@ public class MoveToExecutor : MonoBehaviour
         Vector3 up
     )
     {
-        // Si la cible est tr�s proche, garde la direction actuelle
+        // Si la cible est très proche, garde la direction actuelle
         Vector3 dir = (lookWorld - subject.position);
         if (dir.sqrMagnitude < 1e-8f) dir = subject.forward;
 
         Quaternion targetRot = Quaternion.LookRotation(dir, up) * Quaternion.Euler(eulerOffset);
 
-        // Eulers de d�part/arriv�e + masquage par axe
+        // Eulers de départ/arrivée + masquage par axe
         Vector3 startEuler = subject.rotation.eulerAngles;
         Vector3 targetEuler = targetRot.eulerAngles;
 

--- a/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/QTESignalReceiver.cs
@@ -2,7 +2,11 @@ using UnityEngine;
 
 /// <summary>
 /// Récepteur appelé depuis une Timeline pour lancer un QTE.
+/// L'attribut <see cref="ExecuteAlways"/> autorise la prévisualisation
+/// des QTE dans l'Éditeur afin de régler précisément leur placement
+/// sans lancer le jeu.
 /// </summary>
+[ExecuteAlways]
 public class QTESignalReceiver : MonoBehaviour
 {
     /// <summary>
@@ -11,6 +15,9 @@ public class QTESignalReceiver : MonoBehaviour
     /// <param name="trigger">Données du QTE à jouer</param>
     public void TriggerQTE(QTETriggerSO trigger)
     {
+        // Méthode utilisée aussi bien en mode Éditeur qu'en jeu. Les
+        // vérifications permettent d'éviter les erreurs de référence
+        // durant la prévisualisation.
         if (trigger == null)
         {
             Debug.LogWarning("[QTESignalReceiver] TriggerQTE appelé avec null.");

--- a/Assets/Scripts/UnusedScripts/CameraSignalReceiver.cs
+++ b/Assets/Scripts/UnusedScripts/CameraSignalReceiver.cs
@@ -1,15 +1,23 @@
 using UnityEngine;
 
+/// <summary>
+/// Récepteur de signaux Timeline destiné à contrôler des mouvements de
+/// caméra expérimentaux. Le tag <see cref="ExecuteAlways"/> permet de
+/// tester ces mouvements directement dans l'Éditeur.
+/// </summary>
+[ExecuteAlways]
 public class CameraSignalReceiver : MonoBehaviour
 {
     public void StartOrbit(OrbitAroundTriggerSO orbitTrigger)
     {
+        // Exécuté également lors de la prévisualisation pour voir le mouvement de caméra.
         if (orbitTrigger != null)
             orbitTrigger.StartOrbit();
     }
 
     public void StopOrbit(OrbitAroundTriggerSO orbitTrigger)
     {
+        // Stoppe l'orbite en jeu ou dans l'Éditeur si l'orbite a été lancée.
         if (orbitTrigger != null)
             orbitTrigger.StopOrbit();
     }

--- a/Assets/TimelineResumeOnConfirm.cs
+++ b/Assets/TimelineResumeOnConfirm.cs
@@ -4,9 +4,10 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.Playables;
 
-[DisallowMultipleComponent]
-[RequireComponent(typeof(PlayableDirector))]
-public class TimelinePauseResumeOnInteract : MonoBehaviour
+ [DisallowMultipleComponent]
+ [RequireComponent(typeof(PlayableDirector))]
+ [ExecuteAlways]
+ public class TimelinePauseResumeOnInteract : MonoBehaviour
 {
     [Tooltip("Instance de PlayerInputs. Si vide, on prendra celle de InputsManager, sinon on en créera une locale.")]
     [SerializeField] private PlayerInputs playerInputs;
@@ -65,6 +66,10 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void OnEnable()
     {
+        // En mode Éditeur, on n'active pas les entrées pour éviter les erreurs
+        if (!Application.isPlaying)
+            return;
+
         if (playerInputs == null)
         {
             Debug.LogWarning("[TimelinePauseResumeOnInteract] PlayerInputs introuvable.");
@@ -77,6 +82,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void OnDisable()
     {
+        if (!Application.isPlaying)
+            return;
+
         if (playerInputs != null)
         {
             playerInputs.World.Interact.performed -= OnInteract;
@@ -88,6 +96,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void Update()
     {
+        if (!Application.isPlaying)
+            return;
+
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
@@ -120,6 +131,13 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
     /// </summary>
     public void PauseForNextCondition()
     {
+        if (!Application.isPlaying)
+        {
+            // Prévisualisation : pause simple du PlayableDirector sans gestion de conditions
+            director?.Pause();
+            return;
+        }
+
         if (TimelineManager.Instance == null)
             return;
 
@@ -168,6 +186,9 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
     /// </summary>
     private void OnInteract(InputAction.CallbackContext ctx)
     {
+        if (!Application.isPlaying)
+            return;
+
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
@@ -181,6 +202,13 @@ public class TimelinePauseResumeOnInteract : MonoBehaviour
 
     private void ResumeTimeline()
     {
+        if (!Application.isPlaying)
+        {
+            // En prévisualisation, on relance simplement la Timeline locale
+            director?.Play();
+            return;
+        }
+
         waitingForCondition = false;
         waitingForDialogueToClose = false;
         TimelineManager.Instance.ResumeCurrentTimeline();


### PR DESCRIPTION
## Résumé
- Marque tous les *SignalReceivers* avec `ExecuteAlways` pour qu'ils réagissent aux signaux même hors Play Mode
- Ajoute des commentaires détaillés afin de clarifier le comportement en prévisualisation
- Autorise les déplacements `MoveTo` à s'exécuter dans l'Éditeur via `ExecuteAlways` et une application immédiate des paramètres

## Test
- `dotnet test` *(échec : command not found)*
- `apt-get update` *(403 Forbidden : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68b165a68a6083258591f280bec99349