### PR TITLE
Ajout de fondu noir au début et maintien du noir en fin de timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.InputSystem; // Nécessaire pour manipuler les InputAction du joueur
+using System.Collections; // Requis pour l'utilisation des coroutines
 
 public class TimelineManager : MonoBehaviour
 {
@@ -135,6 +136,9 @@ public class TimelineManager : MonoBehaviour
         if (CameraController.Instance != null)
             CameraController.Instance.enabled = false;
         Debug.Log($"[TimelineManager] Timeline jouée : {pd.name}");
+
+        // Lance un fondu noir pour encadrer le début de la timeline
+        StartCoroutine(FadeBlackRoutine());
     }
 
     /// <summary>
@@ -144,14 +148,77 @@ public class TimelineManager : MonoBehaviour
     {
         if (currentDirector == pd)
         {
-            Debug.Log($"[TimelineManager] Timeline stoppée : {pd.name}");
-            IsTimelinePlaying = false;
-            currentDirector = null;
-            // La timeline est terminée : on redonne le contrôle de Lucian en réactivant les inputs "World".
-            ToggleWorldInputs(true);
-            // Réactive le CameraController pour rendre la main après la cinématique
-            if (CameraController.Instance != null)
-                CameraController.Instance.enabled = true;
+            // On délègue la fin de timeline à une coroutine afin de chaîner le fondu
+            StartCoroutine(HandleTimelineEnd(pd));
         }
+    }
+
+    /// <summary>
+    /// Gère la séquence de fin de timeline avec fondu noir, masquage des repositionnements
+    /// puis restitution progressive des commandes au joueur.
+    /// </summary>
+    private IEnumerator HandleTimelineEnd(PlayableDirector pd)
+    {
+        Debug.Log($"[TimelineManager] Timeline stoppée : {pd.name}");
+
+        // 1) Fondu vers le noir pour cacher le "snap" de fin de Timeline et rester en noir.
+        //    Pendant cette étape, l'écran devient totalement noir puis y reste tant que
+        //    l'on n'a pas relancé la séquence de retour.
+        yield return FadeBlackRoutine(true);
+
+        // 2) La cinématique est terminée : on redonne le contrôle de Lucian en réactivant les inputs "World".
+        IsTimelinePlaying = false;
+        currentDirector = null;
+        ToggleWorldInputs(true);
+
+        // 3) Réactivation du CameraController pour rendre la main après la cinématique
+        if (CameraController.Instance != null)
+            CameraController.Instance.enabled = true;
+
+        // 4) Une fois tout rétabli en arrière-plan, on peut revenir progressivement à l'image.
+        yield return FadeFromBlackRoutine();
+    }
+
+    /// <summary>
+    /// Sequence de fondu : transparent -> noir (1s), maintien (1s) puis optionnellement noir -> transparent (1s).
+    /// Utilise le <see cref="FadeChildrenOpacity"/> dont l'enfant 0 doit être un panneau noir couvrant l'écran.
+    /// </summary>
+    /// <param name="stayBlack">
+    ///     True pour rester sur un écran noir à la fin du fondu (utile en fin de timeline),
+    ///     False pour revenir à l'image en fin de séquence.
+    /// </param>
+    private IEnumerator FadeBlackRoutine(bool stayBlack = false)
+    {
+        var fader = FadeChildrenOpacity.Instance;
+        if (fader == null)
+            yield break; // Aucun fader disponible, on quitte silencieusement
+
+        // 1) transparent vers noir
+        fader.ChangeOpacity(0, 1f, 1f);
+        yield return new WaitForSeconds(1f);
+
+        // 2) pause d'une seconde à opacité maximale
+        yield return new WaitForSeconds(1f);
+
+        // 3) noir vers transparent (sauf si on veut rester en noir)
+        if (!stayBlack)
+        {
+            fader.ChangeOpacity(0, 0f, 1f);
+            yield return new WaitForSeconds(1f);
+        }
+    }
+
+    /// <summary>
+    /// Fait revenir l'écran du noir vers la transparence en 1 seconde.
+    /// Utilisé après <see cref="FadeBlackRoutine(bool)"/> lorsque <c>stayBlack</c> est vrai.
+    /// </summary>
+    private IEnumerator FadeFromBlackRoutine()
+    {
+        var fader = FadeChildrenOpacity.Instance;
+        if (fader == null)
+            yield break;
+
+        fader.ChangeOpacity(0, 0f, 1f);
+        yield return new WaitForSeconds(1f);
     }
 }


### PR DESCRIPTION
## Résumé
- Maintien de l'écran noir à la fin d'une timeline avant de rendre la main au joueur
- Paramétrage du fondu pour rester noir ou revenir à l'image selon le contexte

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b19a51ff0c8325a51a02ec861a60a4