### PR TITLE
Support des dialogues conditionnels pour POI et PNJ

### DIFF
--- a/Assets/GameDatas/GameData.asset
+++ b/Assets/GameDatas/GameData.asset
@@ -17,3 +17,4 @@ MonoBehaviour:
   squadXP: 0
   enemiesDefeatedCount: 0
   muninName: Munin
+  muninMet: 0

--- a/Assets/Scripts/Classes/ConditionalDialogue.cs
+++ b/Assets/Scripts/Classes/ConditionalDialogue.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Association d'un dialogue à une condition simple sur les <see cref="GameData"/>.
+/// Cela permet de déclencher des conversations différentes selon les succès du joueur.
+/// </summary>
+[System.Serializable]
+public class ConditionalDialogue
+{
+    [Tooltip("Nom du champ booléen dans GameData à vérifier. Laisser vide pour toujours vrai.")]
+    public string gameDataBool;
+
+    [Tooltip("Valeur attendue pour que le dialogue soit sélectionné.")]
+    public bool requiredValue = true;
+
+    [Tooltip("Dialogue joué si la condition est remplie.")]
+    public DialogueContainer dialogue;
+
+    /// <summary>
+    /// Vérifie si la condition associée est satisfaite en se basant sur les GameData fournies.
+    /// </summary>
+    public bool IsConditionMet(GameData data)
+    {
+        if (data == null)
+            return false;
+
+        // Aucune condition spécifiée : toujours vrai
+        if (string.IsNullOrEmpty(gameDataBool))
+            return true;
+
+        // Utilise la réflexion pour lire le champ booléen demandé
+        var field = typeof(GameData).GetField(gameDataBool);
+        if (field != null && field.FieldType == typeof(bool))
+        {
+            bool value = (bool)field.GetValue(data);
+            return value == requiredValue;
+        }
+
+        return false; // Champ introuvable ou type incorrect
+    }
+}

--- a/Assets/Scripts/Classes/NPCDialoguePhase.cs
+++ b/Assets/Scripts/Classes/NPCDialoguePhase.cs
@@ -9,8 +9,11 @@ using UnityEngine.Events; // Permet d'ajouter des callbacks via l'inspecteur
 [System.Serializable]
 public class NPCDialoguePhase
 {
-    [Tooltip("Dialogue associé à cette phase.")]
+    [Tooltip("Dialogue principal associé à cette phase.")]
     public DialogueContainer dialogue;
+
+    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData.")]
+    public ConditionalDialogue[] alternateDialogues;
 
     [Tooltip("Timeline à lancer avant le dialogue (optionnel).")]
     public TimelineAsset timeline; // ⚙️ Remplacé PlayableDirector par TimelineAsset pour lecture via TimelineLauncher
@@ -31,4 +34,21 @@ public class NPCDialoguePhase
 
     [Tooltip("Événement déclenché si le joueur répond Non.")]
     public UnityEvent onNo;
+
+    /// <summary>
+    /// Retourne le dialogue adapté en fonction des succès enregistrés.
+    /// </summary>
+    public DialogueContainer GetDialogue(GameData data)
+    {
+        if (data != null && alternateDialogues != null)
+        {
+            foreach (var alt in alternateDialogues)
+            {
+                if (alt != null && alt.IsConditionMet(data))
+                    return alt.dialogue;
+            }
+        }
+
+        return dialogue; // Dialogue par défaut si aucune condition n'est remplie
+    }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
@@ -15,6 +15,8 @@ public class GameData : ScriptableObject
     public int squadXP;
     public int enemiesDefeatedCount;
     public string muninName = "Munin"; // Nom de la caméra contrôlée par le joueur
+    // Succès : indique si le joueur a déjà rencontré Munin
+    public bool muninMet;
 
     public void SaveToFile(string fileName = "save.json")
     {
@@ -24,7 +26,8 @@ public class GameData : ScriptableObject
             squadLevel = squadLevel,
             squadXP = squadXP,
             enemiesDefeatedCount = enemiesDefeatedCount,
-            muninName = muninName
+            muninName = muninName,
+            muninMet = muninMet // Persistance du succès "Munin rencontré"
         };
 
         string json = JsonUtility.ToJson(save, true);
@@ -53,6 +56,7 @@ public class GameData : ScriptableObject
         squadXP = loaded.squadXP;
         enemiesDefeatedCount = loaded.enemiesDefeatedCount;
         muninName = loaded.muninName; // Recharge le nom personnalisé de Munin
+        muninMet = loaded.muninMet;   // Recharge le succès "Munin rencontré"
 
         Debug.Log($"[GameData] Données chargées depuis : {path}");
     }
@@ -64,6 +68,7 @@ public class GameData : ScriptableObject
         squadXP = 0;
         enemiesDefeatedCount = 0;
         muninName = "Munin"; // Réinitialise le nom de Munin par défaut
+        muninMet = false;     // Réinitialise le succès
         Debug.Log("GameData has been reset.");
 }
 }
@@ -76,6 +81,7 @@ public class GameDataSave
     public int squadXP;
     public int enemiesDefeatedCount;
     public string muninName; // Nom sauvegardé de Munin
+    public bool muninMet;    // Sauvegarde du succès "Munin rencontré"
 }
 
 public enum GameState

--- a/Assets/Scripts/MonoBehavioursUsed/NPCBase.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPCBase.cs
@@ -93,10 +93,11 @@ public class NPCBase : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
                     yield return null;
             }
 
-            // Démarrage du dialogue
-            if (phase.dialogue != null)
+            // Démarrage du dialogue adapté au contexte
+            DialogueContainer container = phase.GetDialogue(GameManager.Instance != null ? GameManager.Instance.gameData : null);
+            if (container != null)
             {
-                yield return DialogueManager.Instance.StartDialogue(phase.dialogue);
+                yield return DialogueManager.Instance.StartDialogue(container);
             }
 
             // Animation de fin de dialogue

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -34,8 +34,11 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
     public bool orbitAround = false;
 
     [Header("Dialogue")]
-    [Tooltip("Dialogue joué lorsque le joueur interagit avec ce point d'intérêt.")]
+    [Tooltip("Dialogue par défaut lorsque le joueur interagit avec ce point d'intérêt.")]
     public DialogueContainer dialogue;
+
+    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData (succès, quêtes...).")]
+    public ConditionalDialogue[] alternateDialogues;
 
     [Header("Timeline (direct)")]
     [Tooltip("Cochez pour lancer un PlayableDirector à la fin du dialogue.")]
@@ -118,8 +121,9 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
         }
 
         // 1) Dialogue
-        if (dialogue != null)
-            yield return DialogueManager.Instance.StartDialogue(dialogue);
+        DialogueContainer container = GetDialogue();
+        if (container != null)
+            yield return DialogueManager.Instance.StartDialogue(container);
 
         // 2) Timeline
         if (launchTimeline && directorToPlay != null)
@@ -167,6 +171,28 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
         // Clé stable : jeu + scène + GUID sérialisé
         string scene = gameObject.scene.IsValid() ? gameObject.scene.path : "unsaved_scene";
         return $"POI_{scene}_{uniqueId}";
+    }
+
+    /// <summary>
+    /// Sélectionne le dialogue approprié en fonction des conditions définies.
+    /// </summary>
+    private DialogueContainer GetDialogue()
+    {
+        // Récupère les données de jeu pour l'évaluation des succès
+        GameData data = GameManager.Instance != null ? GameManager.Instance.gameData : null;
+
+        if (data != null && alternateDialogues != null)
+        {
+            // Parcourt les dialogues alternatifs et retourne le premier dont la condition est satisfaite
+            foreach (var alt in alternateDialogues)
+            {
+                if (alt != null && alt.IsConditionMet(data))
+                    return alt.dialogue;
+            }
+        }
+
+        // Aucun dialogue alternatif valide : on retourne le dialogue par défaut
+        return dialogue;
     }
 
     // Réinitialisation manuelle depuis l’éditeur (utile pour tests)


### PR DESCRIPTION
## Résumé
- Ajout d'un système générique de dialogues conditionnels basé sur GameData
- Possibilité pour les PNJ et points d'intérêt d'afficher des dialogues alternatifs
- Introduction du succès `muninMet` persistant dans les sauvegardes

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d606887c8325ba7fd7f2d8c28af1