### PR TITLE
Ajout du système de succès déclenchable par Timeline

### DIFF
--- a/Assets/Scripts/Classes/AchievementSO.cs
+++ b/Assets/Scripts/Classes/AchievementSO.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+/// <summary>
+/// Objet scriptable représentant un succès à débloquer.
+/// Permet de définir un identifiant, un nom visible et une
+/// description. L'état de déblocage est également stocké
+/// pour pouvoir persister cette information.
+/// </summary>
+[CreateAssetMenu(fileName = "NewAchievement", menuName = "Achievements/Achievement")]
+public class AchievementSO : ScriptableObject
+{
+    [Header("Identification")]
+    [Tooltip("Identifiant unique du succès, utilisé pour le débloquer via le code.")]
+    public string id;
+
+    [Tooltip("Nom affiché au joueur lorsque le succès est obtenu.")]
+    public string nom;
+
+    [TextArea]
+    [Tooltip("Description détaillant comment obtenir ce succès.")]
+    public string description;
+
+    [Header("État")] 
+    [Tooltip("Indique si le succès a déjà été débloqué.")]
+    public bool unlocked;
+}

--- a/Assets/Scripts/Classes/AchievementSO.cs.meta
+++ b/Assets/Scripts/Classes/AchievementSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5a3013f257a44feabcaffd94ae78dac1

--- a/Assets/Scripts/Editor/AchievementManagerEditor.cs
+++ b/Assets/Scripts/Editor/AchievementManagerEditor.cs
@@ -1,0 +1,51 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Inspecteur personnalisé pour <see cref="AchievementManager"/>.
+/// Affiche en permanence les listes de succès disponibles et débloqués
+/// et quelques informations utiles pendant le Play Mode.
+/// </summary>
+[CustomEditor(typeof(AchievementManager))]
+public class AchievementManagerEditor : Editor
+{
+    private void OnEnable()
+    {
+        // Actualise l'inspecteur en temps réel pendant le Play Mode.
+        EditorApplication.update += RepaintInspector;
+    }
+
+    private void OnDisable()
+    {
+        EditorApplication.update -= RepaintInspector;
+    }
+
+    private void RepaintInspector()
+    {
+        Repaint();
+    }
+
+    public override void OnInspectorGUI()
+    {
+        // Sécurité : on vérifie que l'objet sérialisé existe toujours.
+        if (serializedObject == null)
+            return;
+
+        serializedObject.Update();
+
+        // Affiche l'inspecteur par défaut (listes des succès).
+        DrawDefaultInspector();
+
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("--- Informations ---", EditorStyles.boldLabel);
+
+        // Affiche le nombre de succès restants et débloqués pour un aperçu rapide.
+        AchievementManager manager = (AchievementManager)target;
+        EditorGUILayout.LabelField("Succès disponibles", manager.achievements.Count.ToString());
+        EditorGUILayout.LabelField("Succès débloqués", manager.unlockedAchievements.Count.ToString());
+
+        serializedObject.ApplyModifiedProperties();
+    }
+}
+#endif

--- a/Assets/Scripts/Editor/AchievementManagerEditor.cs.meta
+++ b/Assets/Scripts/Editor/AchievementManagerEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ade40887b3984171abf652f76c8c2573

--- a/Assets/Scripts/MonoBehavioursUsed/AchievementManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AchievementManager.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Gestionnaire centralisé des succès du jeu.
+/// Un singleton simple pour enregistrer et débloquer les succès
+/// depuis n'importe quel endroit du projet.
+/// </summary>
+public class AchievementManager : MonoBehaviour
+{
+    /// <summary>
+    /// Instance unique accessible globalement.
+    /// </summary>
+    public static AchievementManager Instance { get; private set; }
+
+    [Tooltip("Liste de tous les succès disponibles et non encore débloqués.")]
+    public List<AchievementSO> achievements = new List<AchievementSO>();
+
+    [Tooltip("Succès déjà débloqués par le joueur.")]
+    public List<AchievementSO> unlockedAchievements = new List<AchievementSO>();
+
+    private void Awake()
+    {
+        // Mise en place du singleton. Si une autre instance existe, on la détruit
+        // pour conserver un gestionnaire unique persistant entre les scènes.
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    /// <summary>
+    /// Débloque le succès passé en paramètre s'il ne l'est pas déjà.
+    /// </summary>
+    /// <param name="achievement">Succès à débloquer.</param>
+    public void Unlock(AchievementSO achievement)
+    {
+        if (achievement == null)
+        {
+            Debug.LogWarning("[AchievementManager] Succès référencé nul.");
+            return;
+        }
+
+        if (achievement.unlocked)
+        {
+            // Déjà obtenu : on ignore sans erreur.
+            return;
+        }
+
+        achievement.unlocked = true;
+
+        // Lorsque le succès est débloqué, on le retire de la liste
+        // des succès disponibles et on l'ajoute à la liste des succès
+        // débloqués afin de garder l'inspecteur organisé.
+        if (achievements.Contains(achievement))
+        {
+            achievements.Remove(achievement);
+            unlockedAchievements.Add(achievement);
+        }
+        else if (!unlockedAchievements.Contains(achievement))
+        {
+            // Si le succès n'est dans aucune liste, on l'ajoute tout de même
+            // aux débloqués pour ne pas perdre la référence.
+            unlockedAchievements.Add(achievement);
+            Debug.LogWarning($"[AchievementManager] Le succès {achievement.name} n'était référencé dans aucune liste.");
+        }
+
+        // Ici on pourrait déclencher des effets : affichage d'une UI, sauvegarde, son, etc.
+        Debug.Log($"Succès débloqué : {achievement.nom}");
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/AchievementManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/AchievementManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de01594e5ab548bb8801e78c163ad919

--- a/Assets/Scripts/MonoBehavioursUsed/AchievementSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AchievementSignalReceiver.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+/// <summary>
+/// Récepteur de signaux Timeline dédié au déblocage des succès.
+/// Il suffit de l'ajouter à un objet de la scène et de relier
+/// la méthode <see cref="TriggerAchievement"/> à un Signal Emitter
+/// dans une Timeline pour débloquer facilement un succès.
+/// </summary>
+public class AchievementSignalReceiver : MonoBehaviour
+{
+    /// <summary>
+    /// Appelé depuis la Timeline avec une référence vers le succès à débloquer.
+    /// </summary>
+    /// <param name="achievement">Succès ciblé.</param>
+    public void TriggerAchievement(AchievementSO achievement)
+    {
+        if (AchievementManager.Instance == null)
+        {
+            Debug.LogWarning("[AchievementSignalReceiver] Aucun AchievementManager présent dans la scène.");
+            return;
+        }
+
+        AchievementManager.Instance.Unlock(achievement);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/AchievementSignalReceiver.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/AchievementSignalReceiver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 906c3239e4fe418bbce2704a621a9bf4

--- a/Docs/SystemeSuccesTimeline.md
+++ b/Docs/SystemeSuccesTimeline.md
@@ -1,0 +1,18 @@
+# Système de succès via Timeline
+
+Ce document explique comment déclencher des succès dans **Symphonie** à l'aide des signaux d'une Timeline.
+
+1. **Préparer les succès**
+   - Créez un `AchievementSO` pour chaque succès dans `Assets/Scripts/Classes`.
+   - Renseignez l'identifiant, le nom et la description du succès en tenant compte de l'histoire (voir `Docs/HistoireSymphonie.md`).
+
+2. **Placer le gestionnaire**
+   - Ajoutez l'objet `AchievementManager` dans votre scène principale et renseignez la liste `achievements` avec tous les succès disponibles.
+   - Lorsqu'un succès est débloqué, il quitte automatiquement cette liste pour être ajouté à `unlockedAchievements`, permettant de suivre facilement les progrès depuis l'inspecteur.
+   - L'objet est persistant entre les scènes pour conserver l'état des succès.
+
+3. **Déclencher depuis une Timeline**
+   - Ajoutez un composant `AchievementSignalReceiver` sur un objet présent sur la Timeline.
+   - Dans la Timeline, insérez un `Signal Emitter` et associez le succès à débloquer à l'événement `TriggerAchievement`.
+
+Grâce à cette approche, il est facile de lier l'obtention d'un succès à un moment narratif précis, qu'il s'agisse d'une cinématique ou d'une action de gameplay scénarisée.


### PR DESCRIPTION
## Résumé
- Sépare la liste des succès en succès disponibles et succès débloqués avec mise à jour automatique lors du déblocage.
- Ajoute un inspecteur personnalisé pour `AchievementManager` affichant les deux listes et leurs compteurs.
- Précise dans la documentation l’organisation des listes de succès et leur suivi dans l’inspecteur.

## Tests
- `dotnet --version` *(échec: command not found)*
- `apt-get update` *(échec: dépôt non signé - 403 Forbidden)*
- `dotnet test` *(échec: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d9b79504832583e966291bb1656b