### PR TITLE
Adaptation des dialogues aux succès

### DIFF
--- a/Assets/Scripts/Classes/ConditionalDialogue.cs
+++ b/Assets/Scripts/Classes/ConditionalDialogue.cs
@@ -10,19 +10,33 @@ public class ConditionalDialogue
     [Tooltip("Nom du champ booléen dans GameData à vérifier. Laisser vide pour toujours vrai.")]
     public string gameDataBool;
 
-    [Tooltip("Valeur attendue pour que le dialogue soit sélectionné.")]
+    [Tooltip("Succès requis pour activer ce dialogue (optionnel).")]
+    public AchievementSO requiredAchievement;
+
+    [Tooltip("Valeur attendue pour que le dialogue soit sélectionné. S'applique au booléen ou à l'état du succès.")]
     public bool requiredValue = true;
 
     [Tooltip("Dialogue joué si la condition est remplie.")]
     public DialogueContainer dialogue;
 
     /// <summary>
-    /// Vérifie si la condition associée est satisfaite en se basant sur les GameData fournies.
+    /// Vérifie si la condition associée est satisfaite.
+    /// Priorité :
+    /// 1) Succès requis via <see cref="AchievementSO"/> ;
+    /// 2) Champ booléen dans les <see cref="GameData"/>.
     /// </summary>
     public bool IsConditionMet(GameData data)
     {
+        // --- Vérification du succès ---
+        // Si un AchievementSO est assigné, on compare son état "unlocked" à la valeur attendue.
+        if (requiredAchievement != null)
+        {
+            return requiredAchievement.unlocked == requiredValue;
+        }
+
+        // --- Vérification des GameData ---
         if (data == null)
-            return false;
+            return false; // Pas de données de jeu : condition non remplie
 
         // Aucune condition spécifiée : toujours vrai
         if (string.IsNullOrEmpty(gameDataBool))
@@ -36,6 +50,7 @@ public class ConditionalDialogue
             return value == requiredValue;
         }
 
-        return false; // Champ introuvable ou type incorrect
+        // Champ introuvable ou type incorrect
+        return false;
     }
 }

--- a/Assets/Scripts/Classes/NPCDialoguePhase.cs
+++ b/Assets/Scripts/Classes/NPCDialoguePhase.cs
@@ -12,7 +12,9 @@ public class NPCDialoguePhase
     [Tooltip("Dialogue principal associé à cette phase.")]
     public DialogueContainer dialogue;
 
-    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData.")]
+    // Permet de définir plusieurs variantes de dialogue en fonction
+    // de l'état des GameData ou des succès débloqués.
+    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData ou des succès.")]
     public ConditionalDialogue[] alternateDialogues;
 
     [Tooltip("Timeline à lancer avant le dialogue (optionnel).")]
@@ -36,7 +38,10 @@ public class NPCDialoguePhase
     public UnityEvent onNo;
 
     /// <summary>
-    /// Retourne le dialogue adapté en fonction des succès enregistrés.
+    /// Retourne le dialogue adapté en fonction des conditions renseignées.
+    /// Les variantes sont évaluées l'une après l'autre : dès qu'une condition
+    /// est remplie (succès débloqué, booléen dans GameData, etc.), son dialogue
+    /// est utilisé à la place du principal.
     /// </summary>
     public DialogueContainer GetDialogue(GameData data)
     {
@@ -44,11 +49,14 @@ public class NPCDialoguePhase
         {
             foreach (var alt in alternateDialogues)
             {
+                // Chaque ConditionalDialogue teste lui-même si sa condition est remplie
+                // en vérifiant les succès ou les champs de GameData.
                 if (alt != null && alt.IsConditionMet(data))
                     return alt.dialogue;
             }
         }
 
-        return dialogue; // Dialogue par défaut si aucune condition n'est remplie
+        // Aucun dialogue alternatif valide, on retourne le dialogue par défaut
+        return dialogue;
     }
 }

--- a/Docs/SystemeSuccesTimeline.md
+++ b/Docs/SystemeSuccesTimeline.md
@@ -17,3 +17,7 @@ Ce document explique comment déclencher des succès dans **Symphonie** à l'aid
    - Dans la Timeline, insérez un `Signal Emitter` et associez le succès à débloquer à l'événement `TriggerAchievement`.
 
 Grâce à cette approche, il est facile de lier l'obtention d'un succès à un moment narratif précis, qu'il s'agisse d'une cinématique ou d'une action de gameplay scénarisée.
+
+## Conditionner les dialogues avec les succès
+
+Les PNJ peuvent désormais adapter leurs répliques en fonction des succès débloqués. Dans l'inspecteur, utilisez la classe `ConditionalDialogue` pour associer un `AchievementSO` à un `DialogueContainer` alternatif. Lorsque le succès indiqué est (ou n'est pas) obtenu, le dialogue correspondant remplace automatiquement celui par défaut.


### PR DESCRIPTION
## Résumé
- Permet d'utiliser un AchievementSO pour conditionner les dialogues alternatifs
- Documente l'usage des succès pour varier les dialogues

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e04eb0848325b6f3656fbca7b6d7