### PR TITLE
Ajout d'un fondu noir et d'un indicateur de passage pour les timelines

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.InputSystem; // Nécessaire pour manipuler les InputAction du joueur
+using UnityEngine.UI; // 🖼️ Gestion des éléments d'interface (fillAmount)
 using System.Collections; // Requis pour l'utilisation des coroutines
 
 public class TimelineManager : MonoBehaviour
@@ -35,6 +36,24 @@ public class TimelineManager : MonoBehaviour
     /// Si elle arrive à son terme, la Timeline est interrompue immédiatement.
     /// </summary>
     private Coroutine skipCoroutine;
+
+    /// <summary>
+    /// Image de l'interface affichant la progression du maintien de la touche.
+    /// Doit pointer vers l'enfant "Frame" de "TimelineManagerCanvas".
+    /// </summary>
+    [SerializeField] private Image skipFillImage;
+
+    /// <summary>
+    /// Référence vers le Canvas dédié à l'affichage des informations de Timeline.
+    /// Ce Canvas doit rester inactif lorsque aucune Timeline ne tourne ou qu'elle a été passée.
+    /// </summary>
+    private GameObject timelineCanvas;
+
+    /// <summary>
+    /// Vrai si la timeline a été accélérée via maintien de Cancel.
+    /// Permet d'éviter un double fondu au noir.
+    /// </summary>
+    private bool timelineSkipped = false;
 
     /// <summary>
     /// Active ou désactive l'ensemble des entrées de la map <c>World</c> pendant
@@ -124,6 +143,13 @@ public class TimelineManager : MonoBehaviour
             StopCoroutine(skipCoroutine);
             skipCoroutine = null;
         }
+
+        // Réinitialise la barre de progression si l'utilisateur relâche trop tôt
+        if (skipFillImage != null)
+        {
+            skipFillImage.fillAmount = 0f;
+            skipFillImage.gameObject.SetActive(false);
+        }
     }
 
     /// <summary>
@@ -134,17 +160,44 @@ public class TimelineManager : MonoBehaviour
     /// </summary>
     private IEnumerator SkipTimelineAfterHold()
     {
-        yield return new WaitForSeconds(skipHoldDuration);
+        float elapsed = 0f;
+
+        // Affiche et réinitialise la barre de progression
+        if (skipFillImage != null)
+        {
+            skipFillImage.fillAmount = 0f;
+            skipFillImage.gameObject.SetActive(true);
+        }
+
+        // Incrémente le fillAmount pendant tout le maintien du bouton
+        while (elapsed < skipHoldDuration)
+        {
+            elapsed += Time.deltaTime;
+            if (skipFillImage != null)
+                skipFillImage.fillAmount = Mathf.Clamp01(elapsed / skipHoldDuration);
+            yield return null;
+        }
+
+        // Marque la timeline comme accélérée pour la gestion du fondu de fin
+        timelineSkipped = true;
+
+        if (skipFillImage != null)
+            skipFillImage.gameObject.SetActive(false);
+
+        // Le Canvas n'a plus lieu d'être lorsque la timeline est passée
+        if (timelineCanvas != null)
+            timelineCanvas.SetActive(false);
+
+        // Arrête d'écouter l'entrée Cancel pendant l'accélération
+        skipCoroutine = null;
+        DisableTimelineSkip();
+
+        // Fondu au noir pour masquer la fin accélérée
+        yield return FadeBlackRoutine(true);
 
         // Lance la lecture ultra-rapide de la Timeline plutôt qu'un arrêt brutal.
         // Cela garantit que tous les signaux et animations prévus soient exécutés.
         StartCoroutine(FastForwardTimeline());
-
-        // On n'écoute plus l'input Cancel une fois le passage déclenché.
-        DisableTimelineSkip();
-
-        // La coroutine de maintien est terminée : on libère la référence.
-        skipCoroutine = null;
     }
 
     /// <summary>
@@ -180,6 +233,29 @@ public class TimelineManager : MonoBehaviour
         else
         {
             Instance = this;
+
+            // Recherche et désactivation du Canvas de gestion des timelines
+            timelineCanvas = GameObject.Find("TimelineManagerCanvas");
+            if (timelineCanvas != null)
+            {
+                // Le Canvas ne doit pas être visible tant qu'aucune Timeline n'est jouée
+                timelineCanvas.SetActive(false);
+
+                // Recherche automatique de l'image de remplissage si elle n'est pas assignée dans l'inspecteur
+                if (skipFillImage == null)
+                {
+                    var frame = timelineCanvas.transform.Find("Passer/Frame");
+                    if (frame != null)
+                        skipFillImage = frame.GetComponent<Image>();
+                }
+            }
+
+            // Initialise l'image pour éviter une barre visible au démarrage
+            if (skipFillImage != null)
+            {
+                skipFillImage.fillAmount = 0f;
+                skipFillImage.gameObject.SetActive(false);
+            }
         }
     }
 
@@ -262,6 +338,9 @@ public class TimelineManager : MonoBehaviour
         ToggleWorldInputs(false);
         // Réactive uniquement l'action Cancel pour permettre un éventuel passage de la Timeline.
         EnableTimelineSkip();
+        // Affiche le Canvas de gestion des timelines pendant la lecture
+        if (timelineCanvas != null)
+            timelineCanvas.SetActive(true);
         // Désactive le CameraController pour laisser la Timeline contrôler totalement la caméra
         if (CameraController.Instance != null)
             CameraController.Instance.enabled = false;
@@ -293,11 +372,20 @@ public class TimelineManager : MonoBehaviour
         // On n'a plus besoin d'écouter l'input Cancel une fois la cinématique terminée.
         DisableTimelineSkip();
 
+        // Masque le Canvas car la timeline est terminée
+        if (timelineCanvas != null)
+            timelineCanvas.SetActive(false);
 
-        // 1) Fondu vers le noir pour cacher le "snap" de fin de Timeline et rester en noir.
-        //    Pendant cette étape, l'écran devient totalement noir puis y reste tant que
-        //    l'on n'a pas relancé la séquence de retour.
-        yield return FadeBlackRoutine(true);
+        // 1) Fondu vers le noir pour cacher le "snap" de fin de Timeline.
+        //    Si la timeline a déjà été accélérée, l'écran est noir : on évite un second fondu.
+        if (!timelineSkipped)
+        {
+            yield return FadeBlackRoutine(true);
+        }
+        else
+        {
+            timelineSkipped = false; // Réinitialisation pour la prochaine timeline
+        }
 
         // 2) La cinématique est terminée : on redonne le contrôle de Lucian en réactivant les inputs "World".
         IsTimelinePlaying = false;


### PR DESCRIPTION
## Résumé
- Affichage d'une jauge de progression lors du maintien de la touche pour passer une timeline
- Fondu au noir avant l'accélération d'une timeline afin de masquer la transition
- Prévention d'un double fondu en fin de timeline après un passage accéléré
- Activation du `TimelineManagerCanvas` uniquement pendant la lecture d'une timeline

## Test
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f25d3e148325b450f76d43b12598