### PR TITLE
Corrige une NullReferenceException lors de l'accélération de Timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -240,22 +240,27 @@ public class TimelineManager : MonoBehaviour
     /// </summary>
     private IEnumerator FastForwardTimeline()
     {
-        if (currentDirector == null)
+        // On garde une référence locale car currentDirector peut être modifié ailleurs
+        var director = currentDirector;
+        if (director == null)
             yield break; // Aucun directeur, rien à accélérer
 
         // Récupère le Playable racine pour manipuler sa vitesse.
-        var rootPlayable = currentDirector.playableGraph.GetRootPlayable(0);
+        var rootPlayable = director.playableGraph.GetRootPlayable(0);
         double originalSpeed = rootPlayable.GetSpeed();
 
         // Vitesse très élevée : la Timeline se termine généralement en une frame.
         rootPlayable.SetSpeed(1000f);
 
-        // Attend que la Timeline signale sa fin.
-        while (currentDirector.state == PlayState.Playing)
+        // Attend que la Timeline signale sa fin sans provoquer d'exception
+        // si le directeur est détruit entre-temps.
+        while (director != null && director.state == PlayState.Playing)
             yield return null;
 
-        // Restaure la vitesse par sécurité pour les prochaines timelines.
-        rootPlayable.SetSpeed(originalSpeed);
+        // Restaure la vitesse par sécurité pour les prochaines timelines
+        // uniquement si le Playable existe toujours.
+        if (rootPlayable.IsValid())
+            rootPlayable.SetSpeed(originalSpeed);
     }
 
     void Awake()


### PR DESCRIPTION
## Résumé
- Empêche `FastForwardTimeline` de s'appuyer sur `currentDirector` susceptible d'être remis à `null`
- Restaure la vitesse du Playable uniquement lorsqu'il est toujours valide

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fab62b64832597464fece4dde493