### PR TITLE
Simplifie les dialogues alternatifs

### DIFF
--- a/Assets/Scripts/Classes/ConditionalDialogue.cs
+++ b/Assets/Scripts/Classes/ConditionalDialogue.cs
@@ -1,56 +1,32 @@
 using UnityEngine;
 
 /// <summary>
-/// Association d'un dialogue à une condition simple sur les <see cref="GameData"/>.
-/// Cela permet de déclencher des conversations différentes selon les succès du joueur.
+/// Association d'un dialogue à un succès requis.
+/// Si le succès est débloqué et que le dialogue principal a déjà été joué,
+/// ce dialogue alternatif peut être sélectionné.
 /// </summary>
 [System.Serializable]
 public class ConditionalDialogue
 {
-    [Tooltip("Nom du champ booléen dans GameData à vérifier. Laisser vide pour toujours vrai.")]
-    public string gameDataBool;
-
-    [Tooltip("Succès requis pour activer ce dialogue (optionnel).")]
+    [Tooltip("Succès requis pour activer ce dialogue alternatif.")]
     public AchievementSO requiredAchievement;
-
-    [Tooltip("Valeur attendue pour que le dialogue soit sélectionné. S'applique au booléen ou à l'état du succès.")]
-    public bool requiredValue = true;
 
     [Tooltip("Dialogue joué si la condition est remplie.")]
     public DialogueContainer dialogue;
 
     /// <summary>
     /// Vérifie si la condition associée est satisfaite.
-    /// Priorité :
-    /// 1) Succès requis via <see cref="AchievementSO"/> ;
-    /// 2) Champ booléen dans les <see cref="GameData"/>.
+    /// Le dialogue alternatif est sélectionné uniquement si le dialogue principal
+    /// a déjà été joué et si le succès requis est débloqué.
     /// </summary>
-    public bool IsConditionMet(GameData data)
+    /// <param name="mainDialoguePlayed">Indique si le dialogue principal a été joué au moins une fois.</param>
+    public bool IsConditionMet(bool mainDialoguePlayed)
     {
-        // --- Vérification du succès ---
-        // Si un AchievementSO est assigné, on compare son état "unlocked" à la valeur attendue.
-        if (requiredAchievement != null)
-        {
-            return requiredAchievement.unlocked == requiredValue;
-        }
+        // Sans succès requis, aucune condition n'est remplie
+        if (requiredAchievement == null)
+            return false;
 
-        // --- Vérification des GameData ---
-        if (data == null)
-            return false; // Pas de données de jeu : condition non remplie
-
-        // Aucune condition spécifiée : toujours vrai
-        if (string.IsNullOrEmpty(gameDataBool))
-            return true;
-
-        // Utilise la réflexion pour lire le champ booléen demandé
-        var field = typeof(GameData).GetField(gameDataBool);
-        if (field != null && field.FieldType == typeof(bool))
-        {
-            bool value = (bool)field.GetValue(data);
-            return value == requiredValue;
-        }
-
-        // Champ introuvable ou type incorrect
-        return false;
+        // Le succès doit être débloqué ET le dialogue principal déjà joué
+        return mainDialoguePlayed && requiredAchievement.unlocked;
     }
 }

--- a/Assets/Scripts/Classes/NPCDialoguePhase.cs
+++ b/Assets/Scripts/Classes/NPCDialoguePhase.cs
@@ -12,10 +12,13 @@ public class NPCDialoguePhase
     [Tooltip("Dialogue principal associé à cette phase.")]
     public DialogueContainer dialogue;
 
-    // Permet de définir plusieurs variantes de dialogue en fonction
-    // de l'état des GameData ou des succès débloqués.
-    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData ou des succès.")]
+    // Variantes déclenchées après le premier passage et en fonction des succès.
+    [Tooltip("Dialogues alternatifs joués après le dialogue principal si un succès est débloqué.")]
     public ConditionalDialogue[] alternateDialogues;
+
+    // Indique si le dialogue principal a déjà été joué au moins une fois.
+    // Non sérialisé pour éviter d'encombrer l'inspecteur.
+    [System.NonSerialized] public bool mainDialoguePlayed;
 
     [Tooltip("Timeline à lancer avant le dialogue (optionnel).")]
     public TimelineAsset timeline; // ⚙️ Remplacé PlayableDirector par TimelineAsset pour lecture via TimelineLauncher
@@ -38,25 +41,30 @@ public class NPCDialoguePhase
     public UnityEvent onNo;
 
     /// <summary>
-    /// Retourne le dialogue adapté en fonction des conditions renseignées.
-    /// Les variantes sont évaluées l'une après l'autre : dès qu'une condition
-    /// est remplie (succès débloqué, booléen dans GameData, etc.), son dialogue
-    /// est utilisé à la place du principal.
+    /// Retourne le dialogue approprié.
+    /// Le dialogue principal est joué une première fois, puis les variantes
+    /// sont évaluées en fonction des succès débloqués.
     /// </summary>
-    public DialogueContainer GetDialogue(GameData data)
+    public DialogueContainer GetDialogue()
     {
-        if (data != null && alternateDialogues != null)
+        // Si le dialogue principal n'a jamais été joué, on le renvoie
+        if (!mainDialoguePlayed)
+        {
+            mainDialoguePlayed = true; // Marque le passage
+            return dialogue;
+        }
+
+        // Ensuite, on vérifie les dialogues alternatifs
+        if (alternateDialogues != null)
         {
             foreach (var alt in alternateDialogues)
             {
-                // Chaque ConditionalDialogue teste lui-même si sa condition est remplie
-                // en vérifiant les succès ou les champs de GameData.
-                if (alt != null && alt.IsConditionMet(data))
+                if (alt != null && alt.IsConditionMet(mainDialoguePlayed))
                     return alt.dialogue;
             }
         }
 
-        // Aucun dialogue alternatif valide, on retourne le dialogue par défaut
+        // Par défaut, on rejoue le dialogue principal
         return dialogue;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NPCBase.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NPCBase.cs
@@ -94,7 +94,8 @@ public class NPCBase : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
             }
 
             // Démarrage du dialogue adapté au contexte
-            DialogueContainer container = phase.GetDialogue(GameManager.Instance != null ? GameManager.Instance.gameData : null);
+            // Récupération du dialogue adapté à la progression et aux succès
+            DialogueContainer container = phase.GetDialogue();
             if (container != null)
             {
                 yield return DialogueManager.Instance.StartDialogue(container);

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -37,8 +37,11 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
     [Tooltip("Dialogue par défaut lorsque le joueur interagit avec ce point d'intérêt.")]
     public DialogueContainer dialogue;
 
-    [Tooltip("Dialogues alternatifs déclenchés selon l'état des GameData (succès, quêtes...).")]
+    [Tooltip("Dialogues alternatifs joués après le premier passage si un succès est débloqué.")]
     public ConditionalDialogue[] alternateDialogues;
+
+    // Indique si le dialogue principal a déjà été joué au moins une fois
+    private bool mainDialoguePlayed = false;
 
     [Header("Timeline (direct)")]
     [Tooltip("Cochez pour lancer un PlayableDirector à la fin du dialogue.")]
@@ -123,7 +126,13 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
         // 1) Dialogue
         DialogueContainer container = GetDialogue();
         if (container != null)
+        {
             yield return DialogueManager.Instance.StartDialogue(container);
+
+            // Marque le dialogue principal comme joué après sa première exécution
+            if (container == dialogue)
+                mainDialoguePlayed = true;
+        }
 
         // 2) Timeline
         if (launchTimeline && directorToPlay != null)
@@ -178,20 +187,21 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
     /// </summary>
     private DialogueContainer GetDialogue()
     {
-        // Récupère les données de jeu pour l'évaluation des succès
-        GameData data = GameManager.Instance != null ? GameManager.Instance.gameData : null;
+        // Si le dialogue principal n'a jamais été joué, on le retourne directement
+        if (!mainDialoguePlayed)
+            return dialogue;
 
-        if (data != null && alternateDialogues != null)
+        // Ensuite, on vérifie les dialogues alternatifs liés à des succès
+        if (alternateDialogues != null)
         {
-            // Parcourt les dialogues alternatifs et retourne le premier dont la condition est satisfaite
             foreach (var alt in alternateDialogues)
             {
-                if (alt != null && alt.IsConditionMet(data))
+                if (alt != null && alt.IsConditionMet(mainDialoguePlayed))
                     return alt.dialogue;
             }
         }
 
-        // Aucun dialogue alternatif valide : on retourne le dialogue par défaut
+        // Aucun dialogue alternatif valide : on rejoue le dialogue principal
         return dialogue;
     }
 

--- a/Docs/SystemeSuccesTimeline.md
+++ b/Docs/SystemeSuccesTimeline.md
@@ -20,4 +20,11 @@ Grâce à cette approche, il est facile de lier l'obtention d'un succès à un m
 
 ## Conditionner les dialogues avec les succès
 
-Les PNJ peuvent désormais adapter leurs répliques en fonction des succès débloqués. Dans l'inspecteur, utilisez la classe `ConditionalDialogue` pour associer un `AchievementSO` à un `DialogueContainer` alternatif. Lorsque le succès indiqué est (ou n'est pas) obtenu, le dialogue correspondant remplace automatiquement celui par défaut.
+Les PNJ peuvent adapter leurs répliques en fonction des succès débloqués.  
+Dans l'inspecteur, utilisez la classe `ConditionalDialogue` pour lier un `AchievementSO` à un `DialogueContainer` alternatif.  
+Le dialogue alternatif est joué **uniquement** lorsque :
+
+1. le dialogue principal a déjà été présenté au joueur ;
+2. le succès requis est débloqué.
+
+Si l'une de ces conditions n'est pas remplie, le dialogue par défaut est rejoué.


### PR DESCRIPTION
## Résumé
- Réduit `ConditionalDialogue` à un succès requis et son dialogue associé
- Ajoute le suivi du dialogue principal pour activer les variantes en fonction des succès
- Documente la nouvelle logique de déclenchement dans `SystemeSuccesTimeline`

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `apt-get update` *(échoue : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fd4044548325a78d2016a7e411ce