### PR TITLE
Ajoute l'harmonique prédominante et l'effet électrique de résonance

### DIFF
--- a/Assets/Scripts/Classes/ZoneSO.cs
+++ b/Assets/Scripts/Classes/ZoneSO.cs
@@ -14,4 +14,8 @@ public class ZoneSO : ScriptableObject
     [Header("Musics")]
     public AudioClip zoneMusic;
     public AudioClip[] battleMusic;
+
+    [Header("Harmonique prédominante")]
+    [Tooltip("Harmonique mise en avant lorsque les musiques de cette zone sont jouées.")]
+    public HarmonicType predominantHarmonic = HarmonicType.Lumiere;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/HarmonicReactionEffect.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/HarmonicReactionEffect.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+
+/// <summary>
+/// Affiche un effet électrique sur le personnage lorsque l'harmonique de la zone
+/// correspond à l'harmonique intrinsèque du personnage. Cet effet visuel permet au
+/// joueur de repérer immédiatement les alliés en résonance avec la musique,
+/// à la manière de l'électricité parcourant Thor dans le MCU.
+/// </summary>
+[RequireComponent(typeof(CharacterUnit))]
+public class HarmonicReactionEffect : MonoBehaviour
+{
+    [Tooltip("Prefab de l'électricité parcourant le corps en cas de résonance.")]
+    public GameObject electricityPrefab;
+
+    private GameObject electricityInstance;
+    private CharacterUnit unit;
+
+    void Awake()
+    {
+        unit = GetComponent<CharacterUnit>();
+    }
+
+    void OnEnable()
+    {
+        // Abonnement à l'évènement de changement d'harmonique prédominante
+        if (ZoneManager.Instance != null)
+            ZoneManager.Instance.OnPredominantHarmonicChanged += OnHarmonicChanged;
+        // Application initiale selon l'harmonique courante
+        if (ZoneManager.Instance != null)
+            OnHarmonicChanged(ZoneManager.Instance.currentPredominantHarmonic);
+    }
+
+    void OnDisable()
+    {
+        if (ZoneManager.Instance != null)
+            ZoneManager.Instance.OnPredominantHarmonicChanged -= OnHarmonicChanged;
+        DisableEffect();
+    }
+
+    /// <summary>
+    /// Active ou désactive l'effet selon la concordance des harmoniques.
+    /// </summary>
+    private void OnHarmonicChanged(HarmonicType newHarmonic)
+    {
+        if (unit != null && unit.Data != null && unit.Data.harmonicType == newHarmonic)
+            EnableEffect();
+        else
+            DisableEffect();
+    }
+
+    /// <summary>
+    /// Instancie l'effet d'électricité s'il n'est pas déjà présent.
+    /// </summary>
+    private void EnableEffect()
+    {
+        if (electricityPrefab == null || electricityInstance != null)
+            return;
+        electricityInstance = Instantiate(electricityPrefab, transform.position, Quaternion.identity, transform);
+    }
+
+    /// <summary>
+    /// Supprime l'effet d'électricité si présent.
+    /// </summary>
+    private void DisableEffect()
+    {
+        if (electricityInstance != null)
+        {
+            Destroy(electricityInstance);
+            electricityInstance = null;
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/ZoneManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ZoneManager.cs
@@ -6,6 +6,16 @@ public class ZoneManager : MonoBehaviour
 
     [Header("Zone courante")]
     public ZoneSO currentZone;
+    [Header("Harmonique prédominante actuelle")]
+    [Tooltip("Harmonique dominante déterminée par le rythme de la musique de la zone courante.")]
+    public HarmonicType currentPredominantHarmonic = HarmonicType.Lumiere;
+
+    /// <summary>
+    /// Évènement déclenché lorsqu'une nouvelle harmonique prédominante est définie.
+    /// Permet aux autres systèmes (effets visuels, gameplay...) de réagir au
+    /// changement de musique ambiante.
+    /// </summary>
+    public event System.Action<HarmonicType> OnPredominantHarmonicChanged;
 
     private void Awake()
     {
@@ -33,11 +43,16 @@ public class ZoneManager : MonoBehaviour
             return; // Pas besoin de changer
 
         currentZone = newZone;
+        // Met à jour l'harmonique prédominante globale selon la zone sélectionnée
+        currentPredominantHarmonic = newZone.predominantHarmonic;
+        // Avertit les abonnés qu'une nouvelle harmonique domine
+        OnPredominantHarmonicChanged?.Invoke(currentPredominantHarmonic);
 
         // Notifie le BattlefieldsManager
         BattlefieldManager.Instance.SetCurrentZone(newZone);
 
         Debug.Log($"[ZoneManager] Nouvelle zone courante : {newZone.zoneName}");
+        Debug.Log($"[ZoneManager] Harmonique prédominante : {currentPredominantHarmonic}");
 
         ZoneNameDisplay.Instance.ShowCurrentZoneInfo();
 

--- a/Docs/HistoireSymphonie.md
+++ b/Docs/HistoireSymphonie.md
@@ -54,6 +54,11 @@ Lorsqu’il accomplit cette Convocation, l’entité qui répond n’est pas Aza
 - Âme d’un enfant réel décédé jeune.
 - Recréé dans le monde d’Azazel à travers le regard aimant et idéalisé de son frère.
 - Incapable de se souvenir de qui il était, il cherche à comprendre sa nature.
+- Pour lui, la musique n'est d'abord qu'un souffle comparable au vent dont il ignore l'origine, inconscient même de son existence jusqu'à ce que Munin la lui révèle.
+- Au début du jeu, il ne connaît que la plate-forme sur laquelle il vit avec quelques autres êtres et n'a jamais questionné la manière dont il communique avec eux ; le langage lui semble inné.
+- Il découvrira plus tard que ses goûts et connaissances proviennent de sa vie passée, notamment son affection pour les rythmes soutenus proches du métal, domaine dans lequel il excelle.
+- Chaque zone visitée résonne d'une harmonique prédominante dictée par le rythme de sa musique : un tempo rapide met en avant l'harmonique de Luciane, une mesure en trois temps favorise celle de Luna, etc.
+- Lorsqu'un personnage est en parfaite résonance avec la musique d'une zone, une électricité parcourt son corps, similaire aux éclairs de Thor, révélant visuellement sa connexion harmonique.
 
 ### 🎥 Munin (nom personnalisable par le joueur)
 - La caméra du jeu, entité diégétique.


### PR DESCRIPTION
## Summary
- Émet un évènement lors du changement d'harmonique prédominante d'une zone
- Ajoute un script d'aura électrique pour signaler les personnages en résonance avec la musique
- Document narratif enrichi pour mentionner l'effet électrique de résonance

## Testing
- `npm test` *(échoue : package.json manquant)*
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b577cf7900832587c50865a9c9b848