### PR TITLE
Évite les déclenchements tardifs de TimelinePauseResumeOnInteract

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -15,6 +15,12 @@ public class TimelineManager : MonoBehaviour
     private PlayableDirector currentDirector;
 
     /// <summary>
+    /// Accès en lecture seule à la Timeline actuellement suivie par le manager.
+    /// Utile pour s'assurer qu'une condition de reprise concerne bien la timeline active.
+    /// </summary>
+    public PlayableDirector CurrentDirector => currentDirector;
+
+    /// <summary>
     /// PlayableDirector générique utilisé pour jouer les <see cref="TimelineAsset"/>.
     /// Autrefois géré par <c>TimelineLauncher</c>, il est maintenant centralisé ici pour
     /// simplifier la maintenance.

--- a/Assets/TimelineResumeOnConfirm.cs
+++ b/Assets/TimelineResumeOnConfirm.cs
@@ -21,6 +21,10 @@ using UnityEngine.Playables;
     private int currentConditionIndex = -1;
     private bool waitingForCondition = false;
 
+    // Référence vers la Timeline pour laquelle on attend la condition.
+    // Permet de s'assurer qu'elle n'a pas été passée ou remplacée.
+    private PlayableDirector waitingDirector;
+
     // Utilisé uniquement pour la condition DialogueClosed afin d'éviter une reprise immédiate si aucun dialogue n'était ouvert au moment de la pause.
     private bool waitingForDialogueToClose = false;
 
@@ -102,6 +106,14 @@ using UnityEngine.Playables;
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
+        // Si la timeline qui avait déclenché l'attente n'est plus celle en cours,
+        // on annule l'attente pour éviter un déclenchement tardif.
+        if (TimelineManager.Instance.CurrentDirector != waitingDirector)
+        {
+            waitingForCondition = false;
+            return;
+        }
+
         if (currentConditionIndex < 0 || currentConditionIndex >= resumeConditions.Count)
             return;
 
@@ -171,6 +183,9 @@ using UnityEngine.Playables;
         }
 
         waitingForCondition = true;
+        // On mémorise la timeline actuellement gérée afin de vérifier plus tard
+        // qu'elle est toujours pertinente.
+        waitingDirector = TimelineManager.Instance.CurrentDirector;
         TimelineManager.Instance.PauseCurrentTimeline();
 
         // Si la condition en cours est DialogueClosed et qu'aucun dialogue n'est actuellement ouvert,
@@ -192,6 +207,13 @@ using UnityEngine.Playables;
         if (!waitingForCondition || TimelineManager.Instance == null)
             return;
 
+        // Annule la reprise si une autre timeline est devenue active entre-temps.
+        if (TimelineManager.Instance.CurrentDirector != waitingDirector)
+        {
+            waitingForCondition = false;
+            return;
+        }
+
         if (currentConditionIndex < 0 || currentConditionIndex >= resumeConditions.Count)
             return;
 
@@ -211,6 +233,7 @@ using UnityEngine.Playables;
 
         waitingForCondition = false;
         waitingForDialogueToClose = false;
+        waitingDirector = null;
         TimelineManager.Instance.ResumeCurrentTimeline();
     }
 }


### PR DESCRIPTION
## Résumé
- Expose `CurrentDirector` dans `TimelineManager` pour suivre la timeline active
- Mémorise et vérifie la timeline attendue dans `TimelinePauseResumeOnInteract`
- Annule l'attente si une autre timeline est lancée afin d'éviter les reprises intempestives

## Tests
- `dotnet test` *(échec : dotnet absent)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68b72d6041b88325890c22a7ab4dd483