### PR TITLE
Empêche la reprise de la Timeline hors Play Mode

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueSignalReceiver.cs
@@ -28,7 +28,9 @@ public class DialogueSignalReceiver : MonoBehaviour
     private void OnDialogueEnded()
     {
         // Reprise après fermeture du dialogue (Play Mode uniquement)
-        if (timeline != null)
+        // Application.isPlaying évite d'appeler Resume en mode prévisualisation,
+        // où le PlayableDirector ne suit pas le cycle complet de la scène.
+        if (Application.isPlaying && timeline != null)
         {
             timeline.Resume();
         }


### PR DESCRIPTION
## Résumé
- Empêche la reprise automatique des PlayableDirector lorsqu'on prévisualise la Timeline hors Play Mode.
- Ajout d'un commentaire expliquant la condition Application.isPlaying pour clarifier le comportement.

## Test
- ⚠️ `dotnet test` (commande introuvable)
- ⚠️ `npm test` (package.json manquant)


------
https://chatgpt.com/codex/tasks/task_e_68b744804be0832591c5a296f9c8cd2e