### PR TITLE
Activation du bouton Pass et masquage des infobox sur POI consommés

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
@@ -169,23 +169,28 @@ public class InteractionManager : MonoBehaviour
 
         Collider[] hits = Physics.OverlapSphere(playerTransform.position, interactionRange, interactableLayer);
 
-        if (hits.Length > 0)
+        // Recherche du point interactif valide le plus proche.
+        GameObject nearest = null;
+        float minDistance = float.MaxValue;
+        foreach (Collider hit in hits)
         {
-            // Recherche de l'objet interactif le plus proche du joueur.
-            GameObject nearest = hits[0].gameObject;
-            float minDistance = Vector3.Distance(playerTransform.position, nearest.transform.position);
+            GameObject obj = hit.gameObject;
 
-            foreach (Collider hit in hits)
+            // Ignore les Points of Interest déjà consommés afin de ne plus afficher leur LocalInfoBox
+            PointOfInterest poi = obj.GetComponent<PointOfInterest>();
+            if (poi != null && !poi.CanInteract)
+                continue;
+
+            float dist = Vector3.Distance(playerTransform.position, obj.transform.position);
+            if (dist < minDistance)
             {
-                float dist = Vector3.Distance(playerTransform.position, hit.transform.position);
-                if (dist < minDistance)
-                {
-                    // Mémorise l'objet le plus proche trouvé jusqu'à présent.
-                    nearest = hit.gameObject;
-                    minDistance = dist;
-                }
+                nearest = obj;
+                minDistance = dist;
             }
+        }
 
+        if (nearest != null)
+        {
             // Met à jour l'interactable courant uniquement s'il change.
             if (currentInteractable != nearest)
             {
@@ -205,6 +210,7 @@ public class InteractionManager : MonoBehaviour
         }
         else if (currentInteractable != null)
         {
+            // Aucun objet valide détecté : on cache l'invite.
             currentInteractable = null;
 
             if (localInfoBox != null)

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -69,6 +69,13 @@ public class TimelineManager : MonoBehaviour
     private GameObject timelineCanvas;
 
     /// <summary>
+    /// Bouton permettant de passer la cinématique. Il est rendu visible uniquement
+    /// lorsque qu'une Timeline est en cours de lecture afin d'éviter toute
+    /// interaction inutile en dehors des cinématiques.
+    /// </summary>
+    private GameObject passButton;
+
+    /// <summary>
     /// Vrai si la timeline a été accélérée via maintien de Cancel.
     /// Permet d'éviter un double fondu au noir.
     /// </summary>
@@ -223,6 +230,9 @@ public class TimelineManager : MonoBehaviour
         // Le Canvas n'a plus lieu d'être lorsque la timeline est passée
         if (timelineCanvas != null)
             timelineCanvas.SetActive(false);
+        // Le bouton Passer est également désactivé immédiatement
+        if (passButton != null)
+            passButton.SetActive(false);
 
         // Arrête d'écouter l'entrée Cancel pendant l'accélération
         skipCoroutine = null;
@@ -325,6 +335,14 @@ public class TimelineManager : MonoBehaviour
             {
                 // Le Canvas ne doit pas être visible tant qu'aucune Timeline n'est jouée
                 timelineCanvas.SetActive(false);
+
+                // Récupère le bouton "Passer" pour le contrôler dynamiquement
+                var passTransform = timelineCanvas.transform.Find("Passer");
+                if (passTransform != null)
+                {
+                    passButton = passTransform.gameObject;
+                    passButton.SetActive(false); // caché par défaut hors cinématique
+                }
 
                 // Recherche automatique de l'image de remplissage si elle n'est pas assignée dans l'inspecteur
                 if (skipFillImage == null)
@@ -600,6 +618,9 @@ public class TimelineManager : MonoBehaviour
         // Affiche le Canvas de gestion des timelines pendant la lecture
         if (timelineCanvas != null)
             timelineCanvas.SetActive(true);
+        // Active le bouton Passer seulement pendant une Timeline
+        if (passButton != null)
+            passButton.SetActive(true);
         // Désactive le CameraController pour laisser la Timeline contrôler totalement la caméra
         if (CameraController.Instance != null)
             CameraController.Instance.enabled = false;
@@ -640,6 +661,9 @@ public class TimelineManager : MonoBehaviour
         // Masque le Canvas car la timeline est terminée
         if (timelineCanvas != null)
             timelineCanvas.SetActive(false);
+        // Cache aussi le bouton Passer pour les prochaines cinématiques
+        if (passButton != null)
+            passButton.SetActive(false);
 
         // 1) Fondu vers le noir pour cacher le "snap" de fin de Timeline.
         //    Si la timeline a déjà été accélérée, l'écran est noir : on évite un second fondu.


### PR DESCRIPTION
## Summary
- Active/désactive le bouton Pass lors des timelines
- Ignore les Points of Interest consommés pour ne plus afficher leur LocalInfoBox

## Testing
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ab395a8832582976639cd059f02