### PR TITLE
Empêcher les dialogues persistants après passage de timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DialogueManager.cs
@@ -148,6 +148,19 @@ public class DialogueManager : MonoBehaviour
         TogglePlayerMovement(true);
     }
 
+    /// <summary>
+    /// Force la fermeture immédiate et complète de tout dialogue en cours.
+    /// Utile lorsque l'on souhaite interrompre brutalement une séquence
+    /// (par exemple lors du passage d'une Timeline) sans laisser de
+    /// bulles persistantes ou de coroutines actives.
+    /// </summary>
+    public void ForceCloseDialogue()
+    {
+        // Réutilise la logique centralisée afin de garantir que tous les
+        // états internes et contrôles joueur sont correctement réinitialisés.
+        ResetDialogueState();
+    }
+
     //==============================================================
     // API publique : LECTURE D'UN CONTAINER (MANUELLE)
     //==============================================================

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -234,6 +234,11 @@ public class TimelineManager : MonoBehaviour
         if (passButton != null)
             passButton.SetActive(false);
 
+        // Ferme immédiatement tout dialogue encore affiché afin
+        // d'éviter qu'il ne persiste après le passage de la Timeline.
+        if (DialogueManager.Instance != null)
+            DialogueManager.Instance.ForceCloseDialogue();
+
         // Arrête d'écouter l'entrée Cancel pendant l'accélération
         skipCoroutine = null;
         DisableTimelineSkip();
@@ -664,6 +669,11 @@ public class TimelineManager : MonoBehaviour
         // Cache aussi le bouton Passer pour les prochaines cinématiques
         if (passButton != null)
             passButton.SetActive(false);
+
+        // S'assure qu'aucun dialogue résiduel ne reste affiché à la fin
+        // d'une Timeline, qu'elle ait été jouée jusqu'au bout ou passée.
+        if (DialogueManager.Instance != null)
+            DialogueManager.Instance.ForceCloseDialogue();
 
         // 1) Fondu vers le noir pour cacher le "snap" de fin de Timeline.
         //    Si la timeline a déjà été accélérée, l'écran est noir : on évite un second fondu.


### PR DESCRIPTION
## Résumé
- Ajout d'une méthode `ForceCloseDialogue` pour réinitialiser proprement l'UI de dialogue
- Appel automatique de cette méthode lors du skip ou de la fin d'une timeline afin d'éviter toute bulle persistante

## Tests
- `npm test` *(erreur : package.json introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb318ecee08325a97b46cdc77aca1a