### PR TITLE
Centralisation des timelines de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEngine.Playables;
+using UnityEngine.Timeline;
+
+/// <summary>
+/// Gestionnaire dédié au lancement des timelines en combat.
+/// Toutes les timelines de <c>MusicalMove</c> et d'<c>Item</c>
+/// sont lues via ce <see cref="PlayableDirector"/> unique pour
+/// garantir un comportement cohérent.
+/// </summary>
+public class BattleTimelineManager : MonoBehaviour
+{
+    /// <summary>
+    /// Instance statique accessible depuis les autres scripts.
+    /// </summary>
+    public static BattleTimelineManager Instance { get; private set; }
+
+    /// <summary>
+    /// PlayableDirector utilisé pour lancer les timelines de combat.
+    /// </summary>
+    private PlayableDirector director;
+
+    private void Awake()
+    {
+        // Mise en place du singleton classique.
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+
+        // Récupère le PlayableDirector présent sur ce GameObject.
+        director = GetComponent<PlayableDirector>();
+
+        // Enregistre ce director auprès du TimelineManager global
+        // afin qu'il soit utilisé pour toutes les timelines.
+        if (TimelineManager.Instance != null)
+            TimelineManager.Instance.SetExternalDirector(director);
+    }
+
+    /// <summary>
+    /// Lance une timeline via le PlayableDirector de combat.
+    /// </summary>
+    /// <param name="timeline">Timeline à exécuter.</param>
+    /// <param name="caster">GameObject jouant la timeline.</param>
+    /// <param name="cameraTag">Tag de la caméra à animer. Peut être nul.</param>
+    public void PlayTimeline(TimelineAsset timeline, GameObject caster, string cameraTag)
+    {
+        if (timeline == null || TimelineManager.Instance == null || director == null)
+            return;
+
+        // S'assure que le TimelineManager utilise bien ce PlayableDirector
+        // avant de lancer la lecture de la timeline.
+        TimelineManager.Instance.SetExternalDirector(director);
+        TimelineManager.Instance.PlayTimeline(timeline, caster, cameraTag);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1986,12 +1986,13 @@ public class NewBattleManager : MonoBehaviour
     /// </summary>
     private void StartItemPreparingTimeline()
     {
-        if (itemPreparingTimeline == null || TimelineManager.Instance == null || itemMenuTimelineActive)
+        // S'assure qu'une Timeline et un gestionnaire existent avant de lancer quoi que ce soit
+        if (itemPreparingTimeline == null || BattleTimelineManager.Instance == null || TimelineManager.Instance == null || itemMenuTimelineActive)
             return;
 
         GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
         // Démarre la Timeline qui boucle tant que le menu est ouvert
-        TimelineManager.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
+        BattleTimelineManager.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
         itemMenuTimelineActive = true;
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -191,8 +191,9 @@ public class RhythmQTEManager : MonoBehaviour
         // afin d'éviter tout souci si l'Animator change de référence pendant la téléportation.
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
 
-        // Si une Timeline est disponible, on la lit via le TimelineManager centralisé
+        // Si une Timeline est disponible, on la lit via le BattleTimelineManager
         bool hasTimeline = move.performingTimeline != null &&
+                          BattleTimelineManager.Instance != null &&
                           TimelineManager.Instance != null &&
                           casterAnimatorGO != null;
 
@@ -200,7 +201,7 @@ public class RhythmQTEManager : MonoBehaviour
         {
             // Les ennemis utilisent la timeline mais sans animer la caméra (cameraTag nul)
             string cameraTag = caster.characterType == CharacterType.EnemyUnit ? null : "BattleCamera";
-            TimelineManager.Instance.PlayTimeline(move.performingTimeline, casterAnimatorGO, cameraTag);
+            BattleTimelineManager.Instance.PlayTimeline(move.performingTimeline, casterAnimatorGO, cameraTag);
         }
 
         if (pendingNotes == 0)
@@ -312,12 +313,15 @@ public class RhythmQTEManager : MonoBehaviour
 
         Animator animator = caster.GetComponentInChildren<Animator>();
 
-        // Lecture d'une Timeline ou d'une animation d'intro
-        bool hasTimeline = item.performingTimeline != null && TimelineManager.Instance != null && animator != null;
+        // Lecture d'une Timeline ou d'une animation d'intro via le BattleTimelineManager
+        bool hasTimeline = item.performingTimeline != null &&
+                           BattleTimelineManager.Instance != null &&
+                           TimelineManager.Instance != null &&
+                           animator != null;
 
         if (hasTimeline)
         {
-            TimelineManager.Instance.PlayTimeline(item.performingTimeline, animator.gameObject, "BattleCamera");
+            BattleTimelineManager.Instance.PlayTimeline(item.performingTimeline, animator.gameObject, "BattleCamera");
 
             // Attendre la fin réelle de la Timeline, en prévoyant un délai maximum
             // pour éviter les blocages si celle-ci reste en pause sur la dernière frame

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -374,6 +374,20 @@ public class TimelineManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Assigne explicitement un <see cref="PlayableDirector"/> externe
+    /// à utiliser pour la lecture des timelines.
+    /// Utilisé notamment par le <c>BattleTimelineManager</c> pour
+    /// centraliser la lecture des timelines de combat.
+    /// </summary>
+    /// <param name="externalDirector">Le PlayableDirector à utiliser.</param>
+    public void SetExternalDirector(PlayableDirector externalDirector)
+    {
+        // Aucune vérification complexe : si null est fourni, la lecture
+        // échouera proprement lors de l'appel à PlayTimeline.
+        reusableDirector = externalDirector;
+    }
+
+    /// <summary>
     /// Joue une nouvelle Timeline. Arrête proprement la précédente.
     /// </summary>
     /// <param name="withFade">


### PR DESCRIPTION
## Résumé
- Ajout d'un `BattleTimelineManager` dédié au combat et enregistrement de son `PlayableDirector` auprès du `TimelineManager`.
- Exposition d'une méthode `SetExternalDirector` dans `TimelineManager` pour permettre l'utilisation d'un directeur externe.
- Utilisation de ce gestionnaire pour lancer les timelines des `MusicalMove` et des `Items`, ainsi que la timeline de préparation des objets.

## Test
- `dotnet test` *(échec : dotnet introuvable)*
- `apt-get update` *(échec : dépôts inaccessibles, erreurs 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0c1054b483258992d3a3903ffa78