### PR TITLE
Centralisation et simplification de la timeline de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUIManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUIManager.cs
@@ -28,6 +28,14 @@ public class BattleTimelineUIManager : MonoBehaviour
     /// </summary>
     public RectTransform TimelineContainer => timelineContainer;
 
+    /// <summary>
+    /// Objet racine de la timeline (parent du conteneur) utilisé pour
+    /// afficher ou masquer facilement l'interface complète.
+    /// </summary>
+    private GameObject TimelineRoot => timelineContainer != null
+        ? timelineContainer.parent?.parent?.gameObject
+        : null;
+
     private void Awake()
     {
         // Mise en place du singleton
@@ -58,6 +66,19 @@ public class BattleTimelineUIManager : MonoBehaviour
         // de passage prévu afin d'éviter un affichage incohérent si des
         // valeurs d'ATB étaient déjà présentes (cas de reprises ou tests).
         SortTimelineByATB();
+    }
+
+    /// <summary>
+    /// Active ou désactive l'affichage de la timeline complète.
+    /// </summary>
+    /// <param name="visible">true pour afficher, false pour masquer.</param>
+    public void SetVisible(bool visible)
+    {
+        // On récupère l'objet racine (parent du parent) afin d'éviter
+        // que d'autres scripts doivent connaître la hiérarchie précise.
+        GameObject root = TimelineRoot;
+        if (root != null)
+            root.SetActive(visible);
     }
 
     /// <summary>
@@ -109,7 +130,7 @@ public class BattleTimelineUIManager : MonoBehaviour
     /// <summary>
     /// Met en évidence l'unité actuellement active.
     /// </summary>
-    public void UpdateHighlight(CharacterUnit activeUnit)
+    private void UpdateHighlight(CharacterUnit activeUnit)
     {
         foreach (var ui in timelineUIObjects)
         {
@@ -122,7 +143,7 @@ public class BattleTimelineUIManager : MonoBehaviour
     /// Réorganise la timeline pour placer l'unité active en première position et
     /// afficher ensuite les suivantes selon l'ordre réel de passage.
     /// </summary>
-    public void UpdateWheel(CharacterUnit activeUnit)
+    private void UpdateWheel(CharacterUnit activeUnit)
     {
         if (timelineUIObjects.Count == 0)
             return;
@@ -155,6 +176,18 @@ public class BattleTimelineUIManager : MonoBehaviour
             // Met à jour la jauge d'ATB pour refléter l'avancée réelle.
             timelineUIObjects[i].UpdateATBGauge();
         }
+    }
+
+    /// <summary>
+    /// Point d'entrée unique pour mettre à jour l'ordre et la mise en
+    /// évidence de la timeline. Les scripts externes n'ont plus à se
+    /// soucier de l'ordre des appels.
+    /// </summary>
+    /// <param name="activeUnit">Unité actuellement active (peut être nulle).</param>
+    public void Refresh(CharacterUnit activeUnit)
+    {
+        UpdateHighlight(activeUnit);
+        UpdateWheel(activeUnit);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -475,13 +475,8 @@ public class NewBattleManager : MonoBehaviour
 
         //2 Initialise l’UI de la timeline de combat via le gestionnaire dédié
         BattleTimelineUIManager.Instance?.Initialize(unitsInBattle);
-        // Cache l'UI de timeline jusqu'au premier tour du joueur
-        if (BattleTimelineUIManager.Instance != null)
-        {
-            var container = BattleTimelineUIManager.Instance.TimelineContainer;
-            if (container != null && container.parent != null && container.parent.parent != null)
-                container.parent.parent.gameObject.SetActive(false);
-        }
+        // Cache l'UI de timeline jusqu'au premier tour du joueur via le gestionnaire centralisé
+        BattleTimelineUIManager.Instance?.SetVisible(false);
 
         //3 Affecter currentTarget au premier ennemi de la liste
         SetDefaultCurrentTarget();
@@ -669,6 +664,8 @@ public class NewBattleManager : MonoBehaviour
 
         // Affiche l'interface principale au premier tour du joueur
         BattleTransitionManager.Instance?.ShowBattleUIIfNeeded();
+        // S'assure que la timeline devienne visible dès qu'un tour joueur commence
+        BattleTimelineUIManager.Instance?.SetVisible(true);
 
         ChangeCurrentCharacterUnit(characterUnit);
 
@@ -729,9 +726,8 @@ public class NewBattleManager : MonoBehaviour
 
             // 2) Mise à jour de l’unité courante
             currentCharacterUnit = unit;
-            // Mise à jour de la timeline visuelle pour refléter l'unité active
-            BattleTimelineUIManager.Instance?.UpdateHighlight(unit);
-            BattleTimelineUIManager.Instance?.UpdateWheel(unit);
+            // Mise à jour de la timeline visuelle via le gestionnaire centralisé
+            BattleTimelineUIManager.Instance?.Refresh(unit);
 
             ChangeBattleState(BattleState.NewTurn);
 
@@ -1198,8 +1194,8 @@ public class NewBattleManager : MonoBehaviour
         ChangeBattleState(BattleState.EndTurn);
         // Cache tous les menus à la fin du tour
         ToggleMenuContainers(false, false, false);
-        // Réinitialise la mise en évidence de la timeline visuelle
-        BattleTimelineUIManager.Instance?.UpdateHighlight(null);
+        // Réinitialise la timeline visuelle (ordre + surbrillance)
+        BattleTimelineUIManager.Instance?.Refresh(null);
         isTurnResolving = false;
         HandleEndOfBattle();
 


### PR DESCRIPTION
## Résumé
- Ajout d'un gestionnaire unifié pour la timeline de combat avec méthodes `SetVisible` et `Refresh`.
- Mise à jour du `NewBattleManager` pour utiliser ces méthodes centralisées et clarifier l'affichage de la timeline.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés / accès interdit)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d187fac8325ab79b409804e6569