### PR TITLE
Permettre le déclenchement de combats via les Timelines

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/EventSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/EventSignalReceiver.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic; // Permet l'utilisation de listes génériques pour gérer les ennemis
 
 /// <summary>
 /// Récepteur générique pour déclencher des évènements depuis une Timeline.
@@ -108,5 +109,54 @@ public class EventSignalReceiver : MonoBehaviour
         {
             Debug.LogWarning("[EventSignalReceiver] Joueur non trouvé !");
         }
+    }
+
+    /// <summary>
+    /// Lance un combat directement depuis une Timeline en spécifiant
+    /// manuellement les ennemis à affronter. Cette méthode contourne la
+    /// détection automatique du joueur et permet de contrôler totalement
+    /// les combats déclenchés par des cinématiques.
+    /// </summary>
+    /// <param name="enemy1">Premier ennemi à invoquer.</param>
+    /// <param name="enemy2">Second ennemi optionnel.</param>
+    /// <param name="enemy3">Troisième ennemi optionnel.</param>
+    public void StartTimelineBattle(CharacterData enemy1, CharacterData enemy2 = null, CharacterData enemy3 = null)
+    {
+        // Rassemble tous les ennemis fournis dans une liste afin de les
+        // transmettre au gestionnaire de combat.
+        List<CharacterData> enemies = new();
+        if (enemy1 != null) enemies.Add(enemy1);
+        if (enemy2 != null) enemies.Add(enemy2);
+        if (enemy3 != null) enemies.Add(enemy3);
+
+        // Si aucun ennemi n'est renseigné, on annule la procédure et on loggue un avertissement.
+        if (enemies.Count == 0)
+        {
+            Debug.LogWarning("[EventSignalReceiver] Aucun ennemi spécifié pour le combat déclenché par Timeline.");
+            return;
+        }
+
+        // Copie des ennemis dans le NewBattleManager afin qu'ils soient utilisés lors de l'initialisation du combat.
+        if (NewBattleManager.Instance != null)
+        {
+            NewBattleManager.Instance.enemyTemplates.Clear();
+            NewBattleManager.Instance.enemyTemplates.AddRange(enemies);
+        }
+        else
+        {
+            Debug.LogWarning("[EventSignalReceiver] NewBattleManager introuvable, lancement du combat annulé.");
+            return;
+        }
+
+        // Désactive la détection automatique pour éviter tout conflit pendant la transition.
+        PlayerDetection pd = FindFirstObjectByType<PlayerDetection>();
+        if (pd != null)
+        {
+            pd.detectionOn = false;
+            pd.detectedEnemies.Clear();
+        }
+
+        // Démarre la transition de combat avec les ennemis spécifiés.
+        BattleTransitionManager.Instance.StartCombatTransition();
     }
 }


### PR DESCRIPTION
## Résumé
- Ajout d'une méthode `StartTimelineBattle` dans `EventSignalReceiver` pour démarrer un combat depuis une Timeline avec une liste d'ennemis définie manuellement.
- Désactivation de `PlayerDetection` lors de ces combats afin de shunter la détection automatique.
- Ajout de l'using `System.Collections.Generic` et nombreux commentaires pour clarifier le fonctionnement.

## Tests
- `dotnet build` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés / accès interdit)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4bda0e50832585f086143ce23d4c