### PR TITLE
feat: interdire la course dans certaines zones

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/MovementInputHandler.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MovementInputHandler.cs
@@ -9,6 +9,13 @@ public class MovementInputHandler : MonoBehaviour
     public bool isRunning;
     public bool isWalking;
 
+    /// <summary>
+    /// Indique si la course est autorisée. Permet à d'autres scripts (zones, cinématiques...) 
+    /// de désactiver temporairement le sprint du joueur.
+    /// </summary>
+    [Tooltip("Si désactivé, l'input de course est ignoré et le joueur marche uniquement.")]
+    public bool canRun = true;
+
     [Tooltip("Transform de la caméra utilisée pour orienter le déplacement.")]
     public Transform cameraTransform;
 
@@ -61,7 +68,10 @@ public class MovementInputHandler : MonoBehaviour
         }
         moveInput = (camForward * input2D.y + camRight * input2D.x).normalized;
 
-        isRunning = inputs.World.Run.IsPressed();
+        // Lecture de l'input de course uniquement si celle-ci est autorisée.
+        isRunning = canRun && inputs.World.Run.IsPressed();
+
+        // Si la course est désactivée, le personnage est considéré comme marchant.
         isWalking = !isRunning;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NoRunZone.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NoRunZone.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Empêche le joueur de courir tant qu'il reste dans la zone délimitée par ce collider.
+/// Il suffit d'attacher ce script à un GameObject possédant un <see cref="Collider"/> en mode
+/// "Is Trigger". Lorsque le joueur entre, la course est désactivée; elle redevient
+/// possible à la sortie.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class NoRunZone : MonoBehaviour
+{
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!other.CompareTag("Player"))
+            return;
+
+        // Récupère les composants de contrôle du joueur et désactive la course.
+        var controller = other.GetComponentInParent<ThirdPersonPlayerController>();
+        if (controller != null)
+            controller.canRun = false;
+
+        var inputHandler = other.GetComponentInParent<MovementInputHandler>();
+        if (inputHandler != null)
+            inputHandler.canRun = false;
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (!other.CompareTag("Player"))
+            return;
+
+        // Réactive la possibilité de courir une fois la zone quittée.
+        var controller = other.GetComponentInParent<ThirdPersonPlayerController>();
+        if (controller != null)
+            controller.canRun = true;
+
+        var inputHandler = other.GetComponentInParent<MovementInputHandler>();
+        if (inputHandler != null)
+            inputHandler.canRun = true;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/NoRunZone.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/NoRunZone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: af64f4bf738e4db8b1c77e2acd2163e5

--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -49,6 +49,12 @@ public class ThirdPersonPlayerController : MonoBehaviour
     public bool isRunning;
     public bool isJumping;
 
+    /// <summary>
+    /// Autorise ou non la course. Peut être modifié par d'autres composants (zones, scripts...).
+    /// </summary>
+    [Tooltip("Si faux, l'input de sprint est ignoré et Lucian marche uniquement.")]
+    public bool canRun = true;
+
     /// <summary>Indique si le personnage touche le sol.</summary>
     public bool isGrounded => controller.isGrounded;
 
@@ -203,11 +209,17 @@ public class ThirdPersonPlayerController : MonoBehaviour
 
         // Axes de déplacement (WASD / stick gauche).
         Vector2 input = InputsManager.Instance.playerInputs.World.Move.ReadValue<Vector2>();
-        bool runPressed = InputsManager.Instance.playerInputs.World.Run.IsPressed();
+
+        // Lecture du bouton de sprint uniquement si la course est autorisée.
+        bool runPressed = canRun && InputsManager.Instance.playerInputs.World.Run.IsPressed();
 
         // Buffer de relâchement du sprint (évite ping-pong marche/course).
         if (runPressed) runReleaseTimer = runReleaseDelay;
         else runReleaseTimer = Mathf.Max(runReleaseTimer - Time.deltaTime, 0f);
+
+        // Si la course est désactivée par une zone, on vide immédiatement le buffer.
+        if (!canRun)
+            runReleaseTimer = 0f;
 
         // Direction voulue relative à la caméra (plan XZ).
         Vector3 camForward = Vector3.ProjectOnPlane(cameraTransform.forward, Vector3.up).normalized;
@@ -217,8 +229,9 @@ public class ThirdPersonPlayerController : MonoBehaviour
         bool hasInput = input.sqrMagnitude > 0.01f;
         bool runBuffered = runPressed || runReleaseTimer > 0f;
 
-        isRunning = hasInput && runBuffered;
-        isWalking = hasInput && !runBuffered;
+        // La course est possible uniquement si canRun est vrai.
+        isRunning = hasInput && runBuffered && canRun;
+        isWalking = hasInput && (!runBuffered || !canRun);
 
         float targetSpeed = isRunning ? runSpeed : (isWalking ? walkSpeed : 0f);
         float accelRate = targetSpeed > currentSpeed ? acceleration : deceleration;


### PR DESCRIPTION
## Résumé
- permettre de désactiver la course via un booléen `canRun`
- ajouter le script `NoRunZone` pour bloquer la course dans un collider `isTrigger`

## Tests
- `apt-get update` *(échec : dépôt non signé)*
- `apt-get install -y dotnet-sdk-7.0` *(échec : paquet introuvable)*
- `dotnet build` *(échec : commande absente)*

------
https://chatgpt.com/codex/tasks/task_e_68bd366c9aa48325ba8107b65b528e48