### PR TITLE
Empêche la vision du joueur à travers les obstacles pendant les timelines

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraOcclusionMask.cs
@@ -84,6 +84,14 @@ public class CameraOcclusionMask_ConeLookAtTarget_UIAligned : MonoBehaviour
 
     private void LateUpdate()
     {
+        // Désactive l'occlusion si une Timeline est en cours de lecture pour
+        // empêcher la visibilité du joueur à travers les obstacles pendant les cinématiques.
+        if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)
+        {
+            ClearAll();
+            return;
+        }
+
         if (!target || !maskCamera) { ClearAll(); return; }
 
         // --- Géométrie de base ---


### PR DESCRIPTION
## Résumé
- Coupe l'effet d'occlusion de la caméra quand une Timeline est en cours
- Permet de conserver les obstacles opaques lors des cinématiques

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `apt-get update` *(échoue : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4534aa288325a95b4a26eba57549