### PR TITLE
Synchroniser le démarrage de combat via Timeline avec la détection classique

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -280,6 +280,10 @@ public class BattleTransitionManager : MonoBehaviour
         {
             playerDetection.detectionOn = false;
             playerDetection.detectedEnemies.Clear();
+            playerDetection.enemiesInFight.Clear();
+            // Réplique l'état que PlayerDetection met en place lorsque le joueur
+            // déclenche un combat afin d'éviter toute redétection pendant la Timeline.
+            playerDetection.battleEngaged = true;
         }
 
         // ------------------------------------------------------------------


### PR DESCRIPTION
## Résumé
- Empêche la redétection en vidant les listes et en désactivant l'IA lors d'un combat lancé par une Timeline
- Aligne StartTimelineBattle sur le flux de détection du joueur en marquant le combat comme engagé

## Test
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5d764c5083258aa3c28b5852b7fb