### PR TITLE
Arrêt automatique des timelines lors du lancement d'un combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -224,6 +224,10 @@ public class BattleTransitionManager : MonoBehaviour
     /// <param name="timelineEnemies">ScriptableObject contenant jusqu'à trois ennemis.</param>
     public void StartTimelineBattle(TimelineEnemiesSO timelineEnemies)
     {
+        // ✅ Dès qu'une timeline demande un combat, on arrête immédiatement
+        // la timeline en cours pour éviter tout chevauchement d'actions.
+        TimelineManager.Instance?.StopTimeline();
+
         if (timelineEnemies == null)
         {
             Debug.LogWarning("[BattleTransitionManager] TimelineEnemiesSO non fourni pour StartTimelineBattle.");
@@ -285,6 +289,10 @@ public class BattleTransitionManager : MonoBehaviour
     /// </summary>
     public void StartCombatTransition()
     {
+        // ✅ Sécurité supplémentaire : s'assure qu'aucune timeline ne
+        // continue pendant la transition de combat.
+        TimelineManager.Instance?.StopTimeline();
+
         CombatSkyboxManager.Instance?.ApplyBattleSkybox();
 
         // Masque l'interface jusqu'au premier tour du joueur


### PR DESCRIPTION
## Résumé
- Termine immédiatement la timeline ayant déclenché un combat
- Coupe toute timeline restante lors de la transition vers le mode combat

## Tests
- `dotnet test` *(échec : dotnet introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd680102a8832580c916ad706c23c6