### PR TITLE
Empêche la coupure de musique pour les timelines d'items et de MusicalMoves

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -72,6 +72,10 @@ public class BattleTimelineManager : MonoBehaviour
         // S'assure que le TimelineManager utilise bien ce PlayableDirector
         // avant de lancer la lecture de la timeline.
         TimelineManager.Instance.SetExternalDirector(director);
-        TimelineManager.Instance.PlayTimeline(timeline, caster, cameraTag, false);
+        // Les timelines d'Item et de MusicalMove ne doivent ni couper la musique
+        // ni afficher de fondu au noir : on force donc l'absence de fondu
+        // (paramètre withFade = false) et on conserve la bande-son actuelle
+        // en désactivant l'interruption musicale (interruptMusic = false).
+        TimelineManager.Instance.PlayTimeline(timeline, caster, cameraTag, false, false);
     }
 }


### PR DESCRIPTION
## Résumé
- Empêche les timelines d'objets et de MusicalMoves de couper la musique en conservant `interruptMusic = false`.
- Ajoute des commentaires clarifiant l'absence de fondu et d'interruption musicale lors des cinématiques de combat.

## Tests
- `dotnet test` *(échec : dotnet absent dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6aafa92c8325a3681d8be7033a93