### PR TITLE
Gestion des limites d'utilisation des attaques et objets

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -17,6 +17,12 @@ public class ItemData : ScriptableObject
     public float moveSpeed;
     public float castDistance;
 
+    [Header("Limitations d'utilisation")]
+    [Tooltip("Nombre maximum d'utilisations par tour (0 = illimité)")]
+    public int maxUsesPerTurn = 0;
+    [Tooltip("Nombre maximum d'utilisations par combat (0 = illimité)")]
+    public int maxUsesPerBattle = 0;
+
     [Header("Coup Critique")]
     [Tooltip("Active une variante lorsque le QTE est réussi")]
     public bool useCriticalVariant = false;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -50,6 +50,12 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Nombre de tours avant de pouvoir réutiliser le move")]
     public int cooldown = 0;
 
+    [Header("Limitations d'utilisation")]
+    [Tooltip("Nombre maximum d'utilisations par tour (0 = illimité)")]
+    public int maxUsesPerTurn = 0;
+    [Tooltip("Nombre maximum d'utilisations par combat (0 = illimité)")]
+    public int maxUsesPerBattle = 0;
+
     [Header("Ciblage")]
     public TargetType targetType = TargetType.SingleEnemy;
     public TargetType defaultTargetType = TargetType.SingleEnemy;

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -62,6 +62,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     // Nouvelle réserve d'harmoniques par type
     public Dictionary<HarmonicType, int> harmonicReserve = new();
     public Dictionary<MusicalMoveSO, int> moveCooldowns = new();
+    // Compteurs d'utilisation des attaques musicales
+    // Clé : move, Valeur : nombre d'utilisations
+    public Dictionary<MusicalMoveSO, int> moveUsesThisTurn = new();
+    public Dictionary<MusicalMoveSO, int> moveUsesThisBattle = new();
     public float currentFatigue { get => Data.currentFatigue; set => Data.currentFatigue = value; }
 
     // Gestion de l'initiative
@@ -548,6 +552,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             .Where(m => !m.onlyAwake || IsAwake)
             .Where(m => !m.enterAwake || !IsAwake)
             .Where(m => !m.enterAwake || GetHarmonicCount(Data.harmonicType) >= Data.resonancePoint)
+            .Where(m => CanUseMove(m))
             .ToArray();
 
         if (availableAttacks == null || availableAttacks.Length == 0)
@@ -632,6 +637,71 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         if (move.cooldown > 0)
             moveCooldowns[move] = move.cooldown;
+    }
+
+    // ---------------------------------------------------------------------
+    // Gestion des limitations d'utilisation des attaques musicales
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// Vérifie si ce move peut être utilisé en fonction des limites par tour
+    /// et par combat.
+    /// </summary>
+    public bool CanUseMove(MusicalMoveSO move)
+    {
+        if (move == null)
+            return false;
+
+        if (move.maxUsesPerTurn > 0)
+        {
+            moveUsesThisTurn.TryGetValue(move, out int usedTurn);
+            if (usedTurn >= move.maxUsesPerTurn)
+                return false;
+        }
+
+        if (move.maxUsesPerBattle > 0)
+        {
+            moveUsesThisBattle.TryGetValue(move, out int usedBattle);
+            if (usedBattle >= move.maxUsesPerBattle)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Enregistre l'utilisation d'un move pour tenir à jour les compteurs.
+    /// </summary>
+    public void RegisterMoveUse(MusicalMoveSO move)
+    {
+        if (move.maxUsesPerTurn > 0)
+        {
+            moveUsesThisTurn.TryGetValue(move, out int usedTurn);
+            moveUsesThisTurn[move] = usedTurn + 1;
+        }
+
+        if (move.maxUsesPerBattle > 0)
+        {
+            moveUsesThisBattle.TryGetValue(move, out int usedBattle);
+            moveUsesThisBattle[move] = usedBattle + 1;
+        }
+    }
+
+    /// <summary>
+    /// Réinitialise les compteurs par tour. À appeler au début de chaque tour.
+    /// </summary>
+    public void ResetTurnMoveUsage()
+    {
+        moveUsesThisTurn.Clear();
+    }
+
+    /// <summary>
+    /// Réinitialise les compteurs globaux du combat. À appeler au début du combat.
+    /// </summary>
+    public void ResetBattleMoveUsage()
+    {
+        moveUsesThisTurn.Clear();
+        moveUsesThisBattle.Clear();
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -10,6 +10,10 @@ public class InventoryManager : MonoBehaviour
     [Header("Items actuellement en inventaire")]
     [SerializeField] private List<ItemData> inventoryItems = new();
 
+    // Suivi des limitations d'utilisation des items
+    private Dictionary<ItemData, int> itemUsesThisTurn = new();
+    private Dictionary<ItemData, int> itemUsesThisBattle = new();
+
     private void Awake()
     {
         if (Instance != null && Instance != this)
@@ -34,7 +38,7 @@ public class InventoryManager : MonoBehaviour
     /// Renvoie la liste des items possédés et utilisables en combat.
     /// </summary>
     public List<ItemData> GetUsableItems()
-        => inventoryItems.Where(item => item.isUsableInBattle).ToList();
+        => inventoryItems.Where(item => item.isUsableInBattle && CanUseItem(item)).ToList();
 
     /// <summary>
     /// Ajoute un item à l'inventaire (uniquement si c'est un item valide du jeu).
@@ -59,9 +63,16 @@ public class InventoryManager : MonoBehaviour
             return;
         }
 
+        if (!CanUseItem(item))
+        {
+            Debug.LogWarning($"Limite d'utilisation atteinte pour {item.itemName}.");
+            return;
+        }
+
         Debug.Log($"[Inventory] Utilisation de l'objet : {item.itemName} sur {target.Data.characterName}");
 
         item.ApplyEffect(caster, target, isCritical);
+        RegisterItemUse(item);
         inventoryItems.Remove(item);
     }
 
@@ -164,5 +175,69 @@ public class InventoryManager : MonoBehaviour
         var sleep = target.GetComponent<SleepStatus>();
         if (sleep != null)
             sleep.WakeUp();
+    }
+
+    // ------------------------------------------------------------------
+    // Gestion des limitations d'utilisation des items
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Vérifie si l'item peut être utilisé en fonction des limites définies.
+    /// </summary>
+    public bool CanUseItem(ItemData item)
+    {
+        if (item == null)
+            return false;
+
+        if (item.maxUsesPerTurn > 0)
+        {
+            itemUsesThisTurn.TryGetValue(item, out int usedTurn);
+            if (usedTurn >= item.maxUsesPerTurn)
+                return false;
+        }
+
+        if (item.maxUsesPerBattle > 0)
+        {
+            itemUsesThisBattle.TryGetValue(item, out int usedBattle);
+            if (usedBattle >= item.maxUsesPerBattle)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Enregistre l'utilisation de l'item.
+    /// </summary>
+    public void RegisterItemUse(ItemData item)
+    {
+        if (item.maxUsesPerTurn > 0)
+        {
+            itemUsesThisTurn.TryGetValue(item, out int usedTurn);
+            itemUsesThisTurn[item] = usedTurn + 1;
+        }
+
+        if (item.maxUsesPerBattle > 0)
+        {
+            itemUsesThisBattle.TryGetValue(item, out int usedBattle);
+            itemUsesThisBattle[item] = usedBattle + 1;
+        }
+    }
+
+    /// <summary>
+    /// Réinitialise les compteurs d'utilisation par tour.
+    /// </summary>
+    public void ResetTurnItemUsage()
+    {
+        itemUsesThisTurn.Clear();
+    }
+
+    /// <summary>
+    /// Réinitialise les compteurs d'utilisation par combat.
+    /// </summary>
+    public void ResetBattleItemUsage()
+    {
+        itemUsesThisTurn.Clear();
+        itemUsesThisBattle.Clear();
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -467,6 +467,11 @@ public class NewBattleManager : MonoBehaviour
         //1 Filtrer pour ne garder que les unités dont les HP sont > 0
         activeCharacterUnits = ReturnActiveUnits();
 
+        // Réinitialise les compteurs d'utilisation des moves et items pour le combat
+        foreach (var unit in activeCharacterUnits)
+            unit.ResetBattleMoveUsage();
+        InventoryManager.Instance?.ResetBattleItemUsage();
+
         foreach (var unit in activeCharacterUnits.Where(u => u.Data.isPlayerControlled))
         {
             if (!totalDamageDealt.ContainsKey(unit))
@@ -719,6 +724,9 @@ public class NewBattleManager : MonoBehaviour
             }
 
             unit.ReduceCooldowns();
+            // Réinitialisation des limites par tour
+            unit.ResetTurnMoveUsage();
+            InventoryManager.Instance?.ResetTurnItemUsage();
             isTurnResolving = true;
 
             // 1) On stocke l’unité qui jouait juste avant (champ de classe)
@@ -868,6 +876,12 @@ public class NewBattleManager : MonoBehaviour
     {
         Debug.Log($"{caster} exécute le mouvement {move.moveName} sur {target}");
         ToggleMenuContainers(false, false, false);
+        // Vérifie les limites d'utilisation avant de lancer le QTE
+        if (!caster.CanUseMove(move))
+        {
+            ActionUIDisplayManager.Instance.DisplayInstruction("Limite d'utilisation atteinte");
+            yield break;
+        }
         if (!IsTargetInRange(caster, target, move))
         {
             ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
@@ -942,6 +956,12 @@ public class NewBattleManager : MonoBehaviour
 
     public IEnumerator UseItemOnTarget(ItemData item, CharacterUnit caster, CharacterUnit target)
     {
+        if (!InventoryManager.Instance.CanUseItem(item))
+        {
+            ActionUIDisplayManager.Instance.DisplayInstruction("Limite d'utilisation atteinte");
+            yield break;
+        }
+
         if (!IsTargetInRange(caster, target, item))
         {
             ActionUIDisplayManager.Instance.DisplayInstruction_TargetTooFar();
@@ -1223,6 +1243,7 @@ public class NewBattleManager : MonoBehaviour
             caster.ConsumeHarmonic(caster.Data.harmonicType, cost);
             caster.AddHarmonic(caster.Data.harmonicType, generation);
             caster.SetMoveCooldown(move);
+            caster.RegisterMoveUse(move);
 
             // Activation du mode Awake si le move le permet
             if (move.enterAwake && !caster.IsAwake &&
@@ -1800,10 +1821,12 @@ public class NewBattleManager : MonoBehaviour
         skillChoices = currentCharacterUnit.Data.musicalAttacks
             .Where(m => !m.onlyAwake || currentCharacterUnit.IsAwake)
             .Where(m => !m.enterAwake || !currentCharacterUnit.IsAwake)
+            .Where(m => currentCharacterUnit.CanUseMove(m))
             .ToList();
 
-        // Ajoute le move spécial s'il existe
-        if (currentCharacterUnit.Data.specialMusicalMove != null)
+        // Ajoute le move spécial s'il existe et est autorisé
+        if (currentCharacterUnit.Data.specialMusicalMove != null &&
+            currentCharacterUnit.CanUseMove(currentCharacterUnit.Data.specialMusicalMove))
             skillChoices.Add(currentCharacterUnit.Data.specialMusicalMove);
 
         // 7) Création des boutons de compétences
@@ -1816,7 +1839,8 @@ public class NewBattleManager : MonoBehaviour
             bool resonanceOk = true;
             if (move.enterAwake)
                 resonanceOk = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.resonancePoint;
-            bool available = enoughHarmonic && resonanceOk;
+            bool usageOk = currentCharacterUnit.CanUseMove(move);
+            bool available = enoughHarmonic && resonanceOk && usageOk;
             bool highlight = move == currentCharacterUnit.Data.specialMusicalMove && available;
             SetButtonAvailability(currentSkillsMenuSlots[i], available, highlight);
         }

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -2,6 +2,11 @@
 
 Ce document décrit les nouvelles actions musicales et objets utilisables ajoutés au projet **Symphonie**.
 
+## Limites d'utilisation
+Chaque MusicalMove ou Item peut maintenant définir un nombre maximal d'utilisations par tour et par combat. Les champs
+`maxUsesPerTurn` et `maxUsesPerBattle` des ScriptableObjects permettent de configurer ces limites. Une valeur de `0` indique
+une utilisation illimitée.
+
 ## MusicalMove : Crescendo Fulgurant
 - **Type** : Attaque
 - **Effet** : inflige 30 points de dégâts à une cible unique.


### PR DESCRIPTION
## Résumé
- Ajout des champs de limitation d'utilisation pour chaque MusicalMove et Item
- Suivi des utilisations par tour et par combat dans les unités et l'inventaire
- Vérification et réinitialisation des limites lors des sélections et exécutions
- Documentation mise à jour sur les nouvelles limites

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6c0db83883259b393586d2b9a781