### PR TITLE
Empêche la caméra de traverser le sol

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -83,6 +83,28 @@ public class CameraController : MonoBehaviour
     private float forcedCamDistance = 5f;
     private Vector3 forcedCamOffset = Vector3.zero; // Décalage monde utilisé en mode forcé
 
+    // --- Sauvegarde de la configuration "normale" ---
+    // Ces valeurs sont enregistrées lorsque la caméra ne touche pas le sol afin
+    // de pouvoir y revenir si le joueur déplace la caméra après une adaptation
+    // automatique au terrain.
+    private float lastNormalForcedCamYaw;
+    private float lastNormalForcedCamPitch;
+    private float lastNormalForcedCamDistance;
+    private Vector3 lastNormalForcedCamOffset;
+
+    // Indique si la caméra a été modifiée pour éviter une collision avec le sol
+    private bool forcedCamGroundAdjusted;
+
+    [Header("Forced Camera - Ground Collision")]
+    [Tooltip("Distance minimale autorisée entre la caméra forcée et le sol.")]
+    [SerializeField] private float forcedCamMinGroundDistance = 0.5f;
+    [Tooltip("Vitesse à laquelle la caméra se rapproche du joueur lorsqu'elle touche le sol.")]
+    [SerializeField] private float forcedCamGroundApproachSpeed = 2f;
+    [Tooltip("Vitesse de redressement de la caméra vers le haut lorsque le sol est atteint.")]
+    [SerializeField] private float forcedCamGroundLookUpSpeed = 30f;
+    [Tooltip("Couches considérées comme du sol pour la détection de collision.")]
+    [SerializeField] private LayerMask groundLayerMask = ~0; // Par défaut toutes les couches
+
     [Header("Orbit Settings")]
     public Transform orbitTarget;
     public float orbitDistance = 5f;
@@ -457,8 +479,79 @@ public class CameraController : MonoBehaviour
         Transform camOrigin = worldCamera.transform.parent;
         Transform look = forceLookPoint != null ? forceLookPoint : player;
 
-        // Position collée aux déplacements du joueur mais indépendante de sa rotation
-        camOrigin.position = player.position + forcedCamOffset;
+        // Position désirée de la caméra basée sur l'offset calculé
+        Vector3 desiredPos = player.position + forcedCamOffset;
+
+        bool collidingGround = false;
+
+        // --- Détection de collision entre le joueur et la caméra ---
+        // Empêche la caméra de traverser un sol ou un obstacle situé entre elle et le joueur.
+        if (Physics.Linecast(player.position, desiredPos, out RaycastHit lineHit, groundLayerMask))
+        {
+            collidingGround = true;
+
+            // Positionne la caméra juste au-dessus du point d'impact
+            desiredPos = lineHit.point + lineHit.normal * forcedCamMinGroundDistance;
+
+            // Rapproche la caméra du joueur et incline le regard vers le haut
+            forcedCamDistance = Mathf.MoveTowards(
+                forcedCamDistance,
+                forcedCamMinDistance,
+                forcedCamGroundApproachSpeed * Time.deltaTime
+            );
+
+            forcedCamPitch = Mathf.MoveTowards(
+                forcedCamPitch,
+                forcedCamMaxPitch,
+                forcedCamGroundLookUpSpeed * Time.deltaTime
+            );
+
+            // Recalcule l'offset avec les nouvelles valeurs
+            RecalculateForcedCamOffset();
+            desiredPos = player.position + forcedCamOffset;
+        }
+        // --- Vérification supplémentaire de la hauteur par rapport au sol ---
+        else if (Physics.Raycast(desiredPos, Vector3.down, out RaycastHit groundHit, forcedCamMinGroundDistance + 0.1f, groundLayerMask))
+        {
+            collidingGround = true;
+
+            if (desiredPos.y < groundHit.point.y + forcedCamMinGroundDistance)
+            {
+                desiredPos = groundHit.point + Vector3.up * forcedCamMinGroundDistance;
+
+                forcedCamDistance = Mathf.MoveTowards(
+                    forcedCamDistance,
+                    forcedCamMinDistance,
+                    forcedCamGroundApproachSpeed * Time.deltaTime
+                );
+
+                forcedCamPitch = Mathf.MoveTowards(
+                    forcedCamPitch,
+                    forcedCamMaxPitch,
+                    forcedCamGroundLookUpSpeed * Time.deltaTime
+                );
+
+                RecalculateForcedCamOffset();
+                desiredPos = player.position + forcedCamOffset;
+            }
+        }
+
+        if (!collidingGround)
+        {
+            // Enregistre la dernière configuration jugée "normale" pour pouvoir y revenir
+            lastNormalForcedCamYaw = forcedCamYaw;
+            lastNormalForcedCamPitch = forcedCamPitch;
+            lastNormalForcedCamDistance = forcedCamDistance;
+            lastNormalForcedCamOffset = forcedCamOffset;
+            forcedCamGroundAdjusted = false;
+        }
+        else
+        {
+            forcedCamGroundAdjusted = true;
+        }
+
+        // Application finale de la position et de la rotation de la caméra
+        camOrigin.position = desiredPos;
         camOrigin.rotation = Quaternion.LookRotation(look.position - camOrigin.position);
     }
 
@@ -472,20 +565,24 @@ public class CameraController : MonoBehaviour
         Vector2 input = InputsManager.Instance.playerInputs.World.ForcedCamMove.ReadValue<Vector2>();
         isForcedCamMoving = input.magnitude > 0.1f;
 
+        // Si la caméra a été ajustée à cause du sol et que le joueur la bouge,
+        // on revient à la dernière position "normale" mémorisée.
+        if (isForcedCamMoving && forcedCamGroundAdjusted)
+        {
+            forcedCamYaw = lastNormalForcedCamYaw;
+            forcedCamPitch = lastNormalForcedCamPitch;
+            forcedCamDistance = lastNormalForcedCamDistance;
+            forcedCamOffset = lastNormalForcedCamOffset;
+            forcedCamGroundAdjusted = false;
+        }
+
         // Rotation horizontale et verticale autour du joueur
         forcedCamYaw += input.x * forcedCamRotationSpeed * Time.deltaTime;
         forcedCamPitch -= input.y * forcedCamRotationSpeed * Time.deltaTime;
         forcedCamPitch = Mathf.Clamp(forcedCamPitch, forcedCamMinPitch, forcedCamMaxPitch);
 
-        float yawRad = forcedCamYaw * Mathf.Deg2Rad;
-        float pitchRad = forcedCamPitch * Mathf.Deg2Rad;
-
-        // Conversion sphérique → cartésienne pour obtenir le décalage monde
-        forcedCamOffset = new Vector3(
-            forcedCamDistance * Mathf.Sin(yawRad) * Mathf.Cos(pitchRad),
-            forcedCamDistance * Mathf.Sin(pitchRad),
-            forcedCamDistance * Mathf.Cos(yawRad) * Mathf.Cos(pitchRad)
-        );
+        // Recalcule l'offset monde en fonction des nouvelles valeurs de yaw/pitch
+        RecalculateForcedCamOffset();
     }
 
     /// <summary>
@@ -549,6 +646,24 @@ public class CameraController : MonoBehaviour
     #endregion
 
     #region Utilitaires
+    /// <summary>
+    /// Recalcule l'offset de la caméra forcée à partir de l'angle actuel et de la distance.
+    /// Centralise la conversion sphérique → cartésienne pour faciliter les modifications.
+    /// </summary>
+    void RecalculateForcedCamOffset()
+    {
+        // Conversion des angles en radians pour les fonctions trigonométriques
+        float yawRad = forcedCamYaw * Mathf.Deg2Rad;
+        float pitchRad = forcedCamPitch * Mathf.Deg2Rad;
+
+        // Calcule l'offset relatif dans l'espace monde
+        forcedCamOffset = new Vector3(
+            forcedCamDistance * Mathf.Sin(yawRad) * Mathf.Cos(pitchRad),
+            forcedCamDistance * Mathf.Sin(pitchRad),
+            forcedCamDistance * Mathf.Cos(yawRad) * Mathf.Cos(pitchRad)
+        );
+    }
+
     /// <summary>
     /// Applique un léger mouvement sinusoïdal pour simuler la respiration.
     /// </summary>


### PR DESCRIPTION
## Résumé
- Mémorise la configuration normale de la caméra forcée
- Empêche toute traversée de sol via un Linecast et ajuste distance/angle
- Restaure la dernière position normale lorsque le joueur bouge la caméra

## Tests
- `dotnet test` *(échoué : command not found)*
- `apt-get update` *(échoué : repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6f7a1e088325937fed989b79842f