### PR TITLE
Permettre de définir la destination de téléportation depuis la Timeline

### DIFF
--- a/Assets/TeleportToPoint.cs
+++ b/Assets/TeleportToPoint.cs
@@ -1,19 +1,50 @@
 using UnityEngine;
 
+/// <summary>
+/// Composant permettant de téléporter un ou plusieurs objets vers un point donné.
+/// La destination peut être définie à l'avance via l'inspecteur ou transmise
+/// dynamiquement (par exemple depuis une Timeline) grâce à la surcharge de Teleport.
+/// </summary>
 public class TeleportToPoint : MonoBehaviour
 {
-    [Header("Point de destination")]
+    [Header("Point de destination par défaut")]
+    [Tooltip("Si aucun Transform n'est passé en paramètre à Teleport(), ce point est utilisé.")]
     public Transform targetPoint;
 
-    [Header("Objets � t�l�porter (laisser vide pour t�l�porter uniquement ce GameObject)")]
+    [Header("Objets à téléporter (laisser vide pour téléporter uniquement ce GameObject)")]
     public Transform[] objectsToTeleport;
 
-    [ContextMenu("T�l�porter maintenant")]
+    /// <summary>
+    /// Téléporte les objets vers le point 'targetPoint' défini dans l'inspecteur.
+    /// Cette version sans paramètre est utile pour les appels depuis le menu contextuel.
+    /// </summary>
+    [ContextMenu("Téléporter maintenant")]
     public void Teleport()
     {
-        if (targetPoint == null)
+        // On réutilise la logique commune en fournissant le point défini dans l'inspecteur
+        TeleportInternal(targetPoint);
+    }
+
+    /// <summary>
+    /// Téléporte les objets vers le <see cref="Transform"/> fourni en paramètre.
+    /// Cette méthode permet notamment aux Signaux de Timeline d'indiquer directement
+    /// la destination de la téléportation.
+    /// </summary>
+    /// <param name="destination">Point de destination où téléporter les objets.</param>
+    public void Teleport(Transform destination)
+    {
+        TeleportInternal(destination);
+    }
+
+    /// <summary>
+    /// Contient la logique partagée de téléportation entre les différentes surcharges.
+    /// </summary>
+    /// <param name="point">Point final de la téléportation.</param>
+    private void TeleportInternal(Transform point)
+    {
+        if (point == null)
         {
-            Debug.LogWarning("Aucun point de destination assign� !");
+            Debug.LogWarning("Aucun point de destination assigné !");
             return;
         }
 
@@ -22,13 +53,16 @@ public class TeleportToPoint : MonoBehaviour
             foreach (Transform obj in objectsToTeleport)
             {
                 if (obj != null)
-                    obj.position = targetPoint.position;
+                {
+                    // Déplacement de chaque objet explicitement renseigné
+                    obj.position = point.position;
+                }
             }
         }
         else
         {
-            // Si aucun objet n'est d�fini, on d�place juste celui qui a ce script
-            transform.position = targetPoint.position;
+            // Si aucun objet n'est défini, on déplace juste celui qui possède ce script
+            transform.position = point.position;
         }
     }
 }


### PR DESCRIPTION
## Résumé
- Ajout d'une surcharge de `Teleport` acceptant un `Transform` pour indiquer la cible depuis la Timeline.
- Centralisation de la logique de téléportation dans une méthode privée `TeleportInternal`.
- Ajout de nombreux commentaires et amélioration des messages d'avertissement.

## Tests
- `dotnet test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd99230004832580f63c3ecb12dace