### PR TITLE
Assure le repositionnement de la WorldCamera après chaque timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -39,7 +39,7 @@ public class CameraController : MonoBehaviour
     private Transform forcedLookTarget;
     private Camera activeCamera;
     private Camera worldCamera; // Référence directe à la WorldCamera
-    private Vector3 worldCamDefaultPosition;    // Position initiale de la WorldCamera au lancement du jeu
+    private Vector3 worldCamDefaultOffset;      // Décalage initial par rapport au joueur
     private Quaternion worldCamDefaultRotation; // Rotation initiale de la WorldCamera au lancement du jeu
 
     [Header("---------- Effet de respiration ----------")]
@@ -134,11 +134,12 @@ public class CameraController : MonoBehaviour
             ? worldCamera.transform.parent
             : worldCamera?.transform; // fallback si aucun parent
 
-        // Sauvegarde la position et la rotation initiales de la caméra
-        // afin de pouvoir les restaurer après l'exécution d'une Timeline.
-        if (worldCamera != null)
+        // Sauvegarde le décalage initial de la WorldCamera par rapport au joueur
+        // ainsi que sa rotation. Ces valeurs serviront à la replacer correctement
+        // une fois une Timeline terminée.
+        if (worldCamera != null && player != null)
         {
-            worldCamDefaultPosition = worldCamera.transform.position;
+            worldCamDefaultOffset = worldCamera.transform.position - player.position;
             worldCamDefaultRotation = worldCamera.transform.rotation;
         }
 
@@ -649,10 +650,13 @@ public class CameraController : MonoBehaviour
     /// </summary>
     public void ResetWorldCameraToDefault()
     {
-        if (worldCamera == null) return; // Sécurité supplémentaire
+        if (worldCamera == null || player == null) return; // Sécurité supplémentaire
 
-        // Replacement direct de la caméra dans l'espace monde
-        worldCamera.transform.SetPositionAndRotation(worldCamDefaultPosition, worldCamDefaultRotation);
+        // Replace la WorldCamera relativement au joueur en réappliquant
+        // le décalage enregistré au lancement du jeu.
+        worldCamera.transform.SetPositionAndRotation(
+            player.position + worldCamDefaultOffset,
+            worldCamDefaultRotation);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -39,6 +39,8 @@ public class CameraController : MonoBehaviour
     private Transform forcedLookTarget;
     private Camera activeCamera;
     private Camera worldCamera; // Référence directe à la WorldCamera
+    private Vector3 worldCamDefaultPosition;    // Position initiale de la WorldCamera au lancement du jeu
+    private Quaternion worldCamDefaultRotation; // Rotation initiale de la WorldCamera au lancement du jeu
 
     [Header("---------- Effet de respiration ----------")]
     [Tooltip("Amplitude du mouvement vertical simulant la respiration.")]
@@ -131,6 +133,14 @@ public class CameraController : MonoBehaviour
         worldCameraParent = worldCamera != null && worldCamera.transform.parent != null
             ? worldCamera.transform.parent
             : worldCamera?.transform; // fallback si aucun parent
+
+        // Sauvegarde la position et la rotation initiales de la caméra
+        // afin de pouvoir les restaurer après l'exécution d'une Timeline.
+        if (worldCamera != null)
+        {
+            worldCamDefaultPosition = worldCamera.transform.position;
+            worldCamDefaultRotation = worldCamera.transform.rotation;
+        }
 
         // Recherche de la BattleCamera et de son parent pour gérer séparément forçage et respiration
         battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
@@ -631,6 +641,18 @@ public class CameraController : MonoBehaviour
 
         // Mémorise l'offset pour le prochain frame
         lastOffset = newOffset;
+    }
+
+    /// <summary>
+    /// Remet immédiatement la WorldCamera à sa position et rotation de départ.
+    /// Utile notamment après l'utilisation d'une Timeline qui aurait déplacé la caméra.
+    /// </summary>
+    public void ResetWorldCameraToDefault()
+    {
+        if (worldCamera == null) return; // Sécurité supplémentaire
+
+        // Replacement direct de la caméra dans l'espace monde
+        worldCamera.transform.SetPositionAndRotation(worldCamDefaultPosition, worldCamDefaultRotation);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -741,8 +741,9 @@ public class TimelineManager : MonoBehaviour
         if (CameraController.Instance != null)
         {
             CameraController.Instance.enabled = true;
-            // ↩️ Remise en place de la WorldCamera à sa position d'origine
-            // afin d'éviter qu'elle ne reste décalée par la Timeline précédente.
+            // ↩️ Remise en place de la WorldCamera autour du joueur
+            // pour qu'elle retrouve exactement le décalage qu'elle avait
+            // avant l'exécution de la Timeline.
             CameraController.Instance.ResetWorldCameraToDefault();
         }
 

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -739,7 +739,12 @@ public class TimelineManager : MonoBehaviour
 
         // 3) Réactivation du CameraController pour rendre la main après la cinématique
         if (CameraController.Instance != null)
+        {
             CameraController.Instance.enabled = true;
+            // ↩️ Remise en place de la WorldCamera à sa position d'origine
+            // afin d'éviter qu'elle ne reste décalée par la Timeline précédente.
+            CameraController.Instance.ResetWorldCameraToDefault();
+        }
 
         // 4) Une fois tout rétabli en arrière-plan, on peut revenir progressivement à l'image.
         if (useFade)


### PR DESCRIPTION
## Résumé
- Sauvegarde la position et la rotation initiales de la WorldCamera dès le lancement.
- Ajoute une méthode de réinitialisation pour replacer la WorldCamera à son état de départ.
- Restaure automatiquement la WorldCamera à la fin d'une Timeline.

## Tests
- `dotnet test` *(échec : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68bdc71bfa5083259545c2d53526f037