### PR TITLE
Déblocage de succès via PointOfInterest

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -60,6 +60,10 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
     [Tooltip("GameObjects désactivés lorsque ce point d'intérêt est déclenché. Utile pour faire disparaître des éléments de la scène après l'interaction.")]
     [SerializeField] private List<GameObject> objectsToDisable = new();
 
+    [Header("Succès")]
+    [Tooltip("Succès à débloquer lors du déclenchement de ce point d'intérêt.")]
+    [SerializeField] private AchievementSO achievementToUnlock; // Référence vers le succès optionnel à déverrouiller
+
     [Header("Local InfoBox")]
     [Tooltip("Décalage appliqué à la LocalInfoBox pour ce point d'intérêt.")]
     public Vector3 localInfoBoxOffset;
@@ -198,6 +202,16 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
                 if (item != null)
                     GameManager.Instance?.AddItemToInventory(item);
             }
+        }
+
+        // 2.c) Déblocage éventuel d'un succès
+        if (achievementToUnlock != null)
+        {
+            // Vérifie la présence d'un AchievementManager avant de tenter le déblocage
+            if (AchievementManager.Instance != null)
+                AchievementManager.Instance.Unlock(achievementToUnlock);
+            else
+                Debug.LogWarning("[PointOfInterest] Aucun AchievementManager dans la scène pour débloquer le succès.");
         }
 
         // 3) Fin d’orbite

--- a/Docs/SystemeSuccesPointOfInterest.md
+++ b/Docs/SystemeSuccesPointOfInterest.md
@@ -1,0 +1,16 @@
+# Système de succès via PointOfInterest
+
+Ce document décrit la procédure pour débloquer un succès lorsque le joueur interagit avec un **PointOfInterest**.
+
+1. **Préparer les succès**
+   - Créez un `AchievementSO` pour chaque succès dans `Assets/Achievements`.
+   - Définissez un identifiant, un nom et une description en accord avec l'histoire (voir `Docs/HistoireSymphonie.md`).
+
+2. **Placer le gestionnaire**
+   - Assurez-vous qu'un `AchievementManager` est présent dans la scène et que la liste `achievements` contient tous les succès disponibles.
+
+3. **Configurer le PointOfInterest**
+   - Sur le composant `PointOfInterest`, renseignez le champ **Succès** avec l'`AchievementSO` à débloquer.
+   - Lors de l'interaction, le succès sera automatiquement débloqué si un `AchievementManager` actif est trouvé.
+
+Grâce à cette fonctionnalité, chaque point d'intérêt peut récompenser le joueur par un succès, renforçant ainsi la progression narrative et ludique.


### PR DESCRIPTION
## Résumé
- ajout d'un champ `achievementToUnlock` dans `PointOfInterest` pour déclencher un succès lors de l'interaction
- nouvelle documentation expliquant comment configurer les succès depuis un `PointOfInterest`

## Tests
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68bf112772f08325aac6f5178bed16dd