### PR TITLE
Pause initiale conditionnelle pour PointOfInterest

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -124,16 +124,29 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
 
         // 0) Fades optionnels
         var fader = FadeChildrenOpacity.Instance;
-        if (fader != null)
-        {
-            if (blackFade) fader.ChangeOpacity(0, 1f, 1f);
-            if (whiteFade) fader.ChangeOpacity(1, 1f, 1f);
-        }
-
-        yield return new WaitForSeconds(3f);
+        bool fadeTriggered = false; // Indique si un fade a réellement été lancé
 
         if (fader != null)
         {
+            // Lance un fondu entrant si demandé et note que l'on devra patienter
+            if (blackFade)
+            {
+                fader.ChangeOpacity(0, 1f, 1f);
+                fadeTriggered = true;
+            }
+
+            if (whiteFade)
+            {
+                fader.ChangeOpacity(1, 1f, 1f);
+                fadeTriggered = true;
+            }
+
+            // En cas de fade (opacité différente de 0), on laisse le temps au joueur
+            // d'observer le fondu avant de poursuivre.
+            if (fadeTriggered)
+                yield return new WaitForSeconds(3f);
+
+            // On relance ensuite un fondu pour revenir progressivement à la transparence.
             if (blackFade) fader.ChangeOpacity(0, 0f, 2f);
             if (whiteFade) fader.ChangeOpacity(1, 0f, 2f);
         }


### PR DESCRIPTION
## Résumé
- n'attend plus que si un fade a été déclenché afin d'éviter un délai inutile

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68bf10e8a4cc83259c44188577867af1