### PR TITLE
Ajout d'un script de limitation des FPS

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/FrameRateLimiter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FrameRateLimiter.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+/// <summary>
+/// Limite le nombre d'images par seconde afin de stabiliser l'expérience utilisateur.
+/// Placé sur un GameObject persistant, ce script applique automatiquement la limitation au démarrage.
+/// </summary>
+public class FrameRateLimiter : MonoBehaviour
+{
+    // Cadence cible que l'on souhaite imposer.
+    // Exposée dans l'inspecteur pour ajuster facilement sans modifier le code.
+    [Tooltip("Nombre maximal de frames par seconde que le jeu essaiera de maintenir.")]
+    [SerializeField] private int targetFrameRate = 60;
+
+    /// <summary>
+    /// Méthode appelée dès l'initialisation du script avant la première frame.
+    /// C'est ici que l'on force les paramètres de rendu pour verrouiller les FPS.
+    /// </summary>
+    private void Awake()
+    {
+        // Désactive la synchronisation verticale afin que Application.targetFrameRate soit pris en compte.
+        // Sans cette ligne, certains appareils ignorent la limitation si la VSync est active.
+        QualitySettings.vSyncCount = 0;
+
+        // Applique la cadence d'images souhaitée au moteur Unity.
+        Application.targetFrameRate = targetFrameRate;
+
+        // Message de debug pour confirmer que la limitation est en place.
+        Debug.Log($"Limitation des FPS activée : {targetFrameRate} fps maximum.");
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/FrameRateLimiter.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/FrameRateLimiter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 880430aeffef3836511de22c83ba86be


### PR DESCRIPTION
## Résumé
- limite les FPS à une valeur cible (60 par défaut) pour stabiliser l'expérience
- désactive la VSync afin d'appliquer correctement la limite

## Tests
- `dotnet test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf41308f1c8325bb3b71bb5b8d3908