### PR TITLE
Ajout d'une option de game over après défaite

### DIFF
--- a/Assets/GameDatas/GameData.asset
+++ b/Assets/GameDatas/GameData.asset
@@ -18,3 +18,4 @@ MonoBehaviour:
   enemiesDefeatedCount: 0
   muninName: Munin
   muninMet: 0
+  gameOverOnDefeat: 0

--- a/Assets/Scripts/Classes/GameData.cs
+++ b/Assets/Scripts/Classes/GameData.cs
@@ -14,6 +14,7 @@ public class GameData : ScriptableObject
     public int enemiesDefeatedCount;
     public string muninName = "Munin"; // Nom de la caméra contrôlée par le joueur
     public bool muninMet; // Succès : indique si le joueur a déjà rencontré Munin
+    public bool gameOverOnDefeat; // Si vrai, un combat perdu renvoie au menu principal
 
     /// <summary>
     /// Sauvegarde les données dans un fichier JSON situé dans le dossier persistant.
@@ -27,7 +28,8 @@ public class GameData : ScriptableObject
             squadXP = squadXP,
             enemiesDefeatedCount = enemiesDefeatedCount,
             muninName = muninName,
-            muninMet = muninMet // Persistance du succès "Munin rencontré"
+            muninMet = muninMet, // Persistance du succès "Munin rencontré"
+            gameOverOnDefeat = gameOverOnDefeat // Sauvegarde du comportement en cas de défaite
         };
 
         string json = JsonUtility.ToJson(save, true);
@@ -58,6 +60,7 @@ public class GameData : ScriptableObject
         enemiesDefeatedCount = loaded.enemiesDefeatedCount;
         muninName = loaded.muninName; // Recharge le nom personnalisé de Munin
         muninMet = loaded.muninMet;   // Recharge le succès "Munin rencontré"
+        gameOverOnDefeat = loaded.gameOverOnDefeat; // Recharge le comportement de défaite
         Debug.Log($"[GameData] Données chargées depuis : {path}");
     }
 
@@ -72,6 +75,7 @@ public class GameData : ScriptableObject
         enemiesDefeatedCount = 0;
         muninName = "Munin"; // Réinitialise le nom de Munin par défaut
         muninMet = false;     // Réinitialise le succès
+        gameOverOnDefeat = false; // Par défaut, la défaite n'entraîne pas de game over
         Debug.Log("GameData has been reset.");
     }
 }

--- a/Assets/Scripts/Classes/GameDataSave.cs
+++ b/Assets/Scripts/Classes/GameDataSave.cs
@@ -12,4 +12,5 @@ public class GameDataSave
     public int enemiesDefeatedCount;
     public string muninName; // Nom sauvegardé de Munin
     public bool muninMet;    // Sauvegarde du succès "Munin rencontré"
+    public bool gameOverOnDefeat; // Indique si une défaite met fin au jeu
 }

--- a/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/GameManager.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro; // Nécessaire pour utiliser TMP_InputField
+using UnityEngine.SceneManagement; // Pour charger le menu principal lors d'un game over
 
 /// <summary>
 /// États possibles du déroulement du jeu.
@@ -169,5 +170,22 @@ public class GameManager : MonoBehaviour
 
         if (namePanel != null)
             namePanel.SetActive(false); // Cache le panneau après validation
+    }
+
+    /// <summary>
+    /// Déclenche un game over et retourne au menu principal.
+    /// </summary>
+    public void TriggerGameOver()
+    {
+        // Mise à jour de l'état du jeu
+        ChangeGameState(GameState.GameOver);
+        Debug.Log("[GameManager] Game Over déclenché, retour au menu principal.");
+
+        // Restaure la vitesse du temps au cas où elle aurait été modifiée
+        Time.timeScale = 1f;
+        Time.fixedDeltaTime = 0.02f;
+
+        // Charge la scène du menu principal
+        SceneManager.LoadScene("MainMenu");
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1584,8 +1584,19 @@ public class NewBattleManager : MonoBehaviour
         else if (allSquadDead)
         {
             Debug.Log("[BattleTurnManager] 💀 Tous les alliés sont morts...");
-            ChangeBattleState(BattleState.GameOverScreen_Await);
-            StartCoroutine(ShowGameOverPanel());
+            // Vérifie si la défaite doit mettre fin au jeu ou permettre la poursuite
+            if (GameManager.Instance != null && GameManager.Instance.gameData.gameOverOnDefeat)
+            {
+                // Passage direct au menu principal
+                CleanupAllSpawnedUnits();
+                GameManager.Instance.TriggerGameOver();
+            }
+            else
+            {
+                // Affichage du panneau Game Over permettant de continuer la partie
+                ChangeBattleState(BattleState.GameOverScreen_Await);
+                StartCoroutine(ShowGameOverPanel());
+            }
         }
     }
 


### PR DESCRIPTION
## Résumé
- possibilité de choisir si une défaite mène au menu principal
- sauvegarde du choix dans les données persistantes
- nettoyage et retour au menu via GameManager

## Tests
- `dotnet test` *(échec : dotnet introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68c1be10e7f48325a25c97a49af5acd5