### PR TITLE
docs: détailler le combat contre l'Ange Pleureur

### DIFF
--- a/Docs/AngePleureur.md
+++ b/Docs/AngePleureur.md
@@ -1,0 +1,43 @@
+# 🎭 Scénario : Le combat contre l’Ange Pleureur
+
+<!-- Document décrivant la scène d'ouverture et servant de référence narrative. -->
+
+## Mise en scène
+- **Lieu** : Lucian quitte son monde figé et atteint une clairière irréelle où la pluie coule sans bruit sous une voûte liquide.
+- **Apparition** : une silhouette agenouillée se redresse lentement ; un ange aux ailes ternies révèle un visage sans traits dont jaillissent des larmes lumineuses.
+- Munin vibre face à cette douleur incompréhensible pour Lucian.
+
+## Phase 1 : Tutoriel inversé
+- **Objectif gameplay** : enseigner attaque, esquive et parade.
+- **Attaques** :
+  - *Pluie de larmes* : projectiles lumineux tombant en rythme.
+  - *Étreinte désespérée* : bras translucides retenant Lucian, libération via QTE.
+  - *Cri muet* : onde désorientante supprimant temporairement le menu d’action.
+- La barre de vie de l’ange est immense, signalant l’impossibilité de victoire.
+
+## Phase 2 : Désespérance
+- Les attaques deviennent rapides et écrasantes ; seule la maîtrise des mécaniques permet de survivre.
+- La caméra de Munin bouge nerveusement, laissant parfois entendre un souffle : « tiens bon… ».
+
+## Intervention du père
+- Des flashes montrent un homme détournant le regard en tenant un enfant par la main.
+- Munin interprète ce souvenir comme une indifférence, alors que le père tente de paraître fort tout en portant un lourd fardeau.
+- Ce contraste renforce la puissance de l’ange, nourrie par la douleur maternelle face au silence paternel.
+
+## Climax : Défaite inévitable
+- Une vague de larmes submerge tout et met Lucian à genoux.
+- Munin téléporte Lucian hors du champ de bataille pour empêcher une nouvelle mort.
+
+## Après-combat : La brèche
+- Lucian se réveille dans une zone fissurée du Rêve.
+- Une première entité instable, obsédée par les imperfections, cherche à « réparer » Lucian.
+- L’Ange Pleureur résulte du deuil non résolu de la mère ; l’incompréhension du père en amplifie la fracture émotionnelle.
+- Cette fracture attire les entités du Rêve et ouvre la voie vers le conflit cosmique lié à Azazel et aux âmes incomplètes.
+
+## Répercussions dans l’histoire
+- L’ange révèle plus tard son identité : la mère de Lucian incapable de faire son deuil.
+- Lucian a dû fuir son étreinte, seconde mort symbolique.
+- Les souvenirs du père, apparemment froid, dévoilent progressivement son sacrifice pour Munin.
+- Azazel cherche à sauver ces âmes piégées dans le deuil ; l’ange pleureur prépare la compréhension de ses motivations.
+- Boss tutoriel tragique, impossible à vaincre, il introduit la double image parentale et la transition vers l’arc principal.
+

--- a/Docs/HistoireSymphonie.md
+++ b/Docs/HistoireSymphonie.md
@@ -66,6 +66,18 @@ Lorsqu’il accomplit cette Convocation, l’entité qui répond n’est pas Aza
 - Témoin silencieux et affectueux du périple de Lucian.
 - Ne peut pas se regarder lui-même.
 
+### 👼 La Mère — L’Ange Pleureur
+- <!-- La mère de Lucian apparaît sous cette forme lors de la scène d'ouverture. -->
+- Incapable de faire son deuil, elle se manifeste dans le Rêve sous la forme d’un ange aux larmes inépuisables.
+- Sert de boss d’introduction impossible à vaincre ; ses attaques forment un tutoriel tragique.
+- Ses larmes nourrissent les entités du Rêve et symbolisent une âme incomplète que cherche à sauver Azazel.
+
+### 🧔 Le Père
+- <!-- Figure paternelle dont le recul apparent nourrit la détresse familiale. -->
+- Fait semblant d’aller de l’avant mais porte un lourd fardeau émotionnel.
+- Son éloignement est perçu par Munin comme de l’indifférence, accentuant la douleur maternelle.
+- Les souvenirs de son sacrifice surgissent durant le combat contre l’Ange Pleureur.
+
 ### 🕯️ Le Traqueur (nouvel antagoniste secondaire)
 - Une autre âme oubliée, rejetée deux fois : par l’Univers, puis par Azazel.
 - Traque les Séraphins par haine de l’effacement et de l’indifférence.
@@ -74,6 +86,14 @@ Lorsqu’il accomplit cette Convocation, l’entité qui répond n’est pas Aza
 - Pourra jouer un rôle capital dans la fin.
 
 ⸻
+
+## 🎬 Scène d’ouverture : L’Ange Pleureur
+- <!-- Résumé de la scène d'ouverture pour assurer la cohérence avec le document détaillé AngePleureur.md -->
+- Lucian quitte son îlot figé pour affronter un ange aux ailes ternies qui pleure sans fin.
+- Cet ennemi représente sa mère incapable de faire son deuil ; il s’agit d’un boss-tutoriel impossible à vaincre.
+- Munin ressent la douleur maternelle et téléporte Lucian pour éviter sa destruction.
+- Les souvenirs d’un père apparemment distant renforcent la détresse de l’ange.
+- La fracture émotionnelle issue de ce combat attire les entités du Rêve et amorce l’arc sur les âmes incomplètes et Azazel.
 
 ## 🎭 Thèmes principaux
 


### PR DESCRIPTION
## Résumé
- Documenter le combat d'ouverture contre l'Ange Pleureur
- Préciser les rôles de la mère et du père dans l'histoire
- Relier cette scène au fil narratif des âmes incomplètes et d'Azazel

## Tests
- `npm test` (échec : package.json introuvable)
- `dotnet test` (échec : commande manquante)


------
https://chatgpt.com/codex/tasks/task_e_68c1d51e0198832586427f7898f1f106