### PR TITLE
Ajout de la notion de MusicalMove aérien

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -56,6 +56,10 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Nombre maximum d'utilisations par combat (0 = illimité)")]
     public int maxUsesPerBattle = 0;
 
+    [Header("Condition d'altitude")]
+    [Tooltip("Détermine si le move est utilisable lorsque la cible est au sol, en l'air ou dans les deux cas")]
+    public AltitudeCondition altitudeCondition = AltitudeCondition.GroundOrAir; // Par défaut: aucune restriction
+
     [Header("Ciblage")]
     public TargetType targetType = TargetType.SingleEnemy;
     public TargetType defaultTargetType = TargetType.SingleEnemy;
@@ -183,3 +187,8 @@ public class MusicalMoveSO : ScriptableObject
 public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
 
 public enum RelativePosition { Front, Back, Left, Right , NC}
+
+/// <summary>
+/// Définit dans quel contexte d'altitude un <see cref="MusicalMoveSO"/> est réalisable.
+/// </summary>
+public enum AltitudeCondition { GroundOnly, AirOnly, GroundOrAir }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -26,6 +26,28 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public bool IsAwake => awakeState != null && awakeState.IsAwake;
 
+    /// <summary>
+    /// Indique si l'unité touche actuellement le sol.
+    /// </summary>
+    public bool IsGrounded
+    {
+        get
+        {
+            // Tente d'abord de récupérer l'information depuis le contrôleur 3D personnalisé.
+            var controller3D = GetComponent<CharacterController3D>();
+            if (controller3D != null)
+                return controller3D.isGrounded;
+
+            // Sinon, se rabat sur le CharacterController classique utilisé en combat/cinématique.
+            var cc = GetComponent<CharacterController>();
+            if (cc != null)
+                return cc.isGrounded;
+
+            // Par défaut, on considère l'unité au sol pour éviter les blocages.
+            return true;
+        }
+    }
+
     public CharacterType characterType => Data.characterType;
 
     private float _currentHP;

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -914,6 +914,16 @@ public class NewBattleManager : MonoBehaviour
             yield break;
         }
 
+        if (!IsTargetAltitudeValid(target, move))
+        {
+            // Message spécifique selon la contrainte de hauteur définie sur le move.
+            if (move.altitudeCondition == AltitudeCondition.AirOnly)
+                ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être en l'air");
+            else if (move.altitudeCondition == AltitudeCondition.GroundOnly)
+                ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être au sol");
+            yield break;
+        }
+
         if (move.enterAwake && (caster.IsAwake ||
             caster.GetHarmonicCount(caster.Data.harmonicType) < caster.Data.resonancePoint))
         {
@@ -1072,6 +1082,28 @@ public class NewBattleManager : MonoBehaviour
         float distance = Vector3.Distance(caster.transform.position, target.transform.position);
         float maxReach = caster.Data.currentRange + item.castDistance;
         return distance <= maxReach;
+    }
+
+    /// <summary>
+    /// Vérifie si la hauteur actuelle de la cible correspond aux exigences du mouvement.
+    /// </summary>
+    public bool IsTargetAltitudeValid(CharacterUnit target, MusicalMoveSO move)
+    {
+        if (target == null || move == null)
+            return false;
+
+        switch (move.altitudeCondition)
+        {
+            case AltitudeCondition.AirOnly:
+                // Mouvement aérien : uniquement si la cible ne touche pas le sol.
+                return !target.IsGrounded;
+            case AltitudeCondition.GroundOnly:
+                // Mouvement terrien : uniquement si la cible est au sol.
+                return target.IsGrounded;
+            default:
+                // Aucune restriction : mouvement utilisable dans toutes les configurations.
+                return true;
+        }
     }
 
     private CharacterUnit CheckForInterception(CharacterUnit caster, CharacterUnit target, float range)

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -7,6 +7,15 @@ Chaque MusicalMove ou Item peut maintenant définir un nombre maximal d'utilisat
 `maxUsesPerTurn` et `maxUsesPerBattle` des ScriptableObjects permettent de configurer ces limites. Une valeur de `0` indique
 une utilisation illimitée.
 
+## Conditions d'altitude
+Les MusicalMoves peuvent désormais spécifier une contrainte de hauteur :
+- **Aériens** : réalisables uniquement si la cible ne touche pas le sol.
+- **Terriens** : réalisables uniquement si la cible est au sol.
+- **Aériens et terriens** : utilisables dans toutes les situations.
+
+Cette classification aide les débutants à comprendre rapidement les restrictions tout en offrant aux joueurs avancés des
+combinaisons plus techniques impliquant des changements d'altitude.
+
 ## MusicalMove : Crescendo Fulgurant
 - **Type** : Attaque
 - **Effet** : inflige 30 points de dégâts à une cible unique.


### PR DESCRIPTION
## Résumé
- Permet de définir pour chaque attaque musicale si elle est utilisable au sol, en l'air ou dans les deux contextes
- Ajoute une vérification de la hauteur de la cible avant l'exécution d'un move
- Documente les nouvelles conditions d'altitude des MusicalMoves

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f771296083259bc8407de1475b64