### PR TITLE
Ajout de MusicalMoves de manipulation du sol

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique.meta
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b4a7ad2bc4c4de5a5af497d24c6ae7b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_AbimeHarmonique
+  m_EditorClassIdentifier:
+  moveName: "Abîme Harmonique"
+  moveType: 3
+  onlyAwake: 0
+  moveIcon: {fileID: 0}
+  description: "Fait disparaître le sol sous la cible."
+  stayFaceToTarget: 0
+  notes: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 0
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  effectType: 9
+  effectValue: 0
+  effectPrefab: {fileID: 100000, guid: 6e5de56a4c4f4adbb612238f8f4ad971, type: 3}
+  moveSpeed: 20
+  castDistance: 1.5
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 2
+  enterAwake: 0
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e2ee6af79574e63a41d11f5ce02f4c2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique.meta
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ce8e1f2828b4c7e9d9b3f40f1f93a1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -1,0 +1,55 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_PontHarmonique
+  m_EditorClassIdentifier:
+  moveName: Pont Harmonique
+  moveType: 3
+  onlyAwake: 0
+  moveIcon: {fileID: 0}
+  description: "Crée un sol temporaire sous la cible."
+  stayFaceToTarget: 0
+  notes: []
+  power: 0
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 0
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  effectType: 8
+  effectValue: 0
+  effectPrefab: {fileID: 100000, guid: a9e8b7c3f95d4f278b1a412be0c8e3a1, type: 3}
+  moveSpeed: 20
+  castDistance: 1.5
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: 79d3634b81de0b747bee2ee9f3358e80, type: 3}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 2
+  enterAwake: 0
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5d7b6fc3f0d4cc095fd27160e6ef5e5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BattleGroundTile.prefab
+++ b/Assets/Prefabs/BattleGroundTile.prefab
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 200000}
+  m_Layer: 20
+  m_Name: BattleGroundTile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &200000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/BattleGroundTile.prefab.meta
+++ b/Assets/Prefabs/BattleGroundTile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a9e8b7c3f95d4f278b1a412be0c8e3a1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BattleVoidTile.prefab
+++ b/Assets/Prefabs/BattleVoidTile.prefab
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 200000}
+  m_Layer: 21
+  m_Name: BattleVoidTile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &200000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/BattleVoidTile.prefab.meta
+++ b/Assets/Prefabs/BattleVoidTile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e5de56a4c4f4adbb612238f8f4ad971
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -69,6 +69,10 @@ public class MusicalMoveSO : ScriptableObject
     public MusicalEffectType effectType = MusicalEffectType.Damage;
     public int effectValue = 10;
 
+    [Header("Effets spéciaux")]
+    [Tooltip("Prefab instancié pour certains effets spéciaux comme la création ou la suppression de sol.")]
+    public GameObject effectPrefab;
+
     public float moveSpeed = 20f;
     public float castDistance;
 
@@ -176,6 +180,26 @@ public class MusicalMoveSO : ScriptableObject
             if (target.GetComponent<LinkMark>() == null)
                 target.gameObject.AddComponent<LinkMark>();
         }
+        else if (typeToUse == MusicalEffectType.SpawnGround)
+        {
+            // Crée un sol temporaire sous la cible afin de permettre l'utilisation de moves terrestres
+            // sur des unités normalement en vol.
+            if (effectPrefab != null && target != null)
+            {
+                GameObject ground = Instantiate(effectPrefab, target.transform.position, Quaternion.identity);
+                // Assure que l'objet utilise bien le layer Battle_Ground pour être reconnu comme sol.
+                ground.layer = LayerMask.NameToLayer("Battle_Ground");
+            }
+        }
+        else if (typeToUse == MusicalEffectType.RemoveGround)
+        {
+            // Supprime visuellement le sol sous la cible en instanciant un prefab dédié,
+            // la forçant ainsi à être considérée comme aérienne.
+            if (effectPrefab != null && target != null)
+            {
+                Instantiate(effectPrefab, target.transform.position, Quaternion.identity);
+            }
+        }
 
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
@@ -184,7 +208,7 @@ public class MusicalMoveSO : ScriptableObject
     }
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark, SpawnGround, RemoveGround }
 
 public enum RelativePosition { Front, Back, Left, Right , NC}
 

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -54,3 +54,17 @@ combinaisons plus techniques impliquant des changements d'altitude.
 - **Effet** : inflige 15 points de dégâts à tous les ennemis.
 - **Coût** : aucun.
 - **Utilisation conseillée** : permet d'affaiblir tout un groupe d'ennemis avant d'utiliser des attaques ciblées plus puissantes.
+
+## MusicalMove : Pont Harmonique
+- **Type** : Soutien
+- **Effet** : crée un pont éphémère sous une cible volante afin de la considérer comme au sol.
+- **Coût** : 1 point d'harmonie et 1 point de fatigue.
+- **Gain** : aucun.
+- **Utilisation conseillée** : parfait pour les débutants qui peinent à atteindre les adversaires aériens. Les joueurs expérimentés pourront l'enchaîner avec des attaques terrestres pour réaliser des combinaisons originales.
+
+## MusicalMove : Abîme Harmonique
+- **Type** : Débuff
+- **Effet** : annule le sol sous la cible, la forçant à flotter et la rendant sensible aux stratégies aériennes.
+- **Coût** : 1 point d'harmonie et 1 point de fatigue.
+- **Gain** : aucun.
+- **Utilisation conseillée** : utile pour isoler un ennemi trop bien protégé au sol. Les stratèges confirmés l'utiliseront pour préparer des enchaînements de MusicalMoves aériens.

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -36,13 +36,13 @@ TagManager:
   - Battle_Unit
   - Battle_UI
   - Battle_VFX
-  - 
-  - 
+  - Battle_Ground
+  - Battle_Void
   - Versus
-  - 
-  - 
-  - 
-  - 
+  -
+  -
+  -
+  -
   - 
   - 
   - 


### PR DESCRIPTION
## Résumé
- Extension de `MusicalMoveSO` pour gérer l'apparition ou la suppression de sol via des prefabs.
- Ajout des MusicalMoves **Pont Harmonique** et **Abîme Harmonique** avec leurs prefabs et documentation.
- Déclaration des couches `Battle_Ground` et `Battle_Void` dans le projet.

## Tests
- `dotnet test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c300b5fea48325aa8a096050c1b2a5