### PR TITLE
Empêche les attaques terrestres sur cibles aériennes

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -187,6 +187,23 @@ public class InputsManager : MonoBehaviour
                 return;
             }
 
+            // Vérifie que l'altitude de la cible correspond aux exigences du mouvement.
+            // Exemple : un mouvement terrestre ne peut pas toucher une cible en l'air.
+            if (!bm.IsTargetAltitudeValid(bm.currentTargetCharacter, bm.currentMove))
+            {
+                if (bm.currentMove.altitudeCondition == AltitudeCondition.AirOnly)
+                {
+                    // Indique que la cible doit être aérienne.
+                    ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être en l'air");
+                }
+                else if (bm.currentMove.altitudeCondition == AltitudeCondition.GroundOnly)
+                {
+                    // Indique que la cible doit être au sol.
+                    ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être au sol");
+                }
+                return;
+            }
+
             bm.ChangeBattleState(BattleState.SquadUnit_PerformingMusicalMove);
             bm.StartCoroutine(bm.ExecuteMoveOnTarget(bm.currentMove, bm.currentCharacterUnit, bm.currentTargetCharacter));
             bm.ToggleMenuContainers(false, false, false);

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2220,7 +2220,11 @@ public class NewBattleManager : MonoBehaviour
                     bool inRange = distance <= maxReach;
                     // Vérifie que la position relative est libre avant d'autoriser l'action.
                     bool hasSpace = HasSpaceForMove(currentCharacterUnit, currentTargetCharacter, currentMove);
-                    UpdateTargetCursorColor(inRange && hasSpace);
+                    // Vérifie si la cible possède l'altitude adéquate pour ce mouvement.
+                    bool altitudeValid = IsTargetAltitudeValid(currentTargetCharacter, currentMove);
+                    // La couleur du curseur devient noire si l'une des conditions n'est pas remplie :
+                    // distance, espace disponible ou altitude.
+                    UpdateTargetCursorColor(inRange && hasSpace && altitudeValid);
                 }
                 else if (isItemTargeting)
                 {
@@ -2730,7 +2734,9 @@ public class NewBattleManager : MonoBehaviour
         foreach (var ps in systems)
         {
             var main = ps.main;
-            main.startColor = inRange ? Color.white : Color.red;
+            // Blanc lorsque la cible est valide, noir lorsqu'elle ne peut être touchée
+            // (hors de portée, mauvaise altitude, etc.).
+            main.startColor = inRange ? Color.white : Color.black;
         }
     }
 


### PR DESCRIPTION
## Résumé
- Empêche les compétences terrestres d'être lancées sur des ennemis en l'air
- Affiche un message d'invalidité et colore le curseur de cible en noir en cas d'altitude incorrecte
- Ajoute une vérification d'altitude lors de la confirmation d'une attaque

## Test
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c304155b848325bf34c0932fadc964