### PR TITLE
Fix: respect des moves au sol sur cibles aériennes

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -33,26 +33,20 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         get
         {
-            // Tente d'abord de récupérer l'information depuis le contrôleur 3D personnalisé.
-            var controller3D = GetComponent<CharacterController3D>();
-            if (controller3D != null)
-                return controller3D.isGrounded;
+            // Les unités en combat n'utilisent pas de CharacterController. On se base donc
+            // uniquement sur un raycast vertical pour détecter la présence d'un sol sous
+            // leurs pieds.
 
-            // Sinon, se rabat sur le CharacterController classique utilisé en combat/cinématique.
-            var cc = GetComponent<CharacterController>();
-            if (cc != null)
-                return cc.isGrounded;
+            // Distance maximum pour rechercher le sol. Une petite valeur suffit car les
+            // unités sont légèrement au-dessus de la surface lorsqu'elles touchent le sol.
+            const float checkDistance = 0.1f;
 
-            // En dernier recours, effectue un petit raycast vertical pour détecter
-            // la présence d'un sol sous l'unité. Cela évite de considérer par
-            // défaut les unités sans contrôleur comme étant au sol, ce qui
-            // permettrait d'attaquer à tort une cible aérienne avec un move
-            // réservé aux cibles terrestres.
-            if (Physics.Raycast(transform.position, Vector3.down, 0.1f))
+            // Effectue le raycast vers le bas depuis la position de l'unité.
+            if (Physics.Raycast(transform.position, Vector3.down, checkDistance))
                 return true;
 
-            // Si aucune information n'est disponible, on considère l'unité en l'air
-            // afin d'empêcher l'utilisation de mouvements réservés aux cibles au sol.
+            // Aucun sol détecté : l'unité est considérée en l'air afin d'empêcher les
+            // mouvements réservés aux cibles terrestres de se déclencher à tort.
             return false;
         }
     }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -43,8 +43,17 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             if (cc != null)
                 return cc.isGrounded;
 
-            // Par défaut, on considère l'unité au sol pour éviter les blocages.
-            return true;
+            // En dernier recours, effectue un petit raycast vertical pour détecter
+            // la présence d'un sol sous l'unité. Cela évite de considérer par
+            // défaut les unités sans contrôleur comme étant au sol, ce qui
+            // permettrait d'attaquer à tort une cible aérienne avec un move
+            // réservé aux cibles terrestres.
+            if (Physics.Raycast(transform.position, Vector3.down, 0.1f))
+                return true;
+
+            // Si aucune information n'est disponible, on considère l'unité en l'air
+            // afin d'empêcher l'utilisation de mouvements réservés aux cibles au sol.
+            return false;
         }
     }
 


### PR DESCRIPTION
## Résumé
- Corrige la propriété `IsGrounded` afin de détecter correctement la présence de sol pour les unités sans contrôleur.
- Empêche les attaques prévues pour le sol d'être déclenchées sur des ennemis en l'air et le curseur devient noir si la cible n'est pas valide.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68c305e786708325b68ac9f913398160