### PR TITLE
Corrige conflit dans TagManager

### DIFF
--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -37,11 +37,7 @@ TagManager:
   - Battle_UI
   - Battle_VFX
   - Battle_Ground
-<<<<<<< Updated upstream
-  - Battle_Void
-=======
-  - 
->>>>>>> Stashed changes
+  - Battle_Void # Couche pour zones vides en bataille
   - Versus
   -
   -


### PR DESCRIPTION
## Résumé
- supprime les marqueurs de conflit dans TagManager et restaure la couche `Battle_Void`

## Tests
- ⚠️ `dotnet test` (commande indisponible)

------
https://chatgpt.com/codex/tasks/task_e_68c3215d7c148325b149b6fcb4454f27