### PR TITLE
Ajout d'une timeline de repli et nouveaux indicateurs d'interception/évasion

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -19,6 +19,12 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Battlefield")]
     public int battlefieldIndex = 0; // Indice du battlefield dans la zone
 
+    [Header("Comportement en combat")]
+    [Tooltip("Si vrai, ce personnage peut être intercepté lors de ses actions")]
+    public bool interceptable = true;
+    [Tooltip("Si vrai, ses attaques sont inévitables et ne peuvent être esquivées")]
+    public bool avoidable = true;
+
     [Header("Stats")]
     [Header("Attributs")]
     public float baseReflex;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -111,6 +111,8 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset preparingTimeline;
     [Tooltip("Timeline à jouer lors de l'exécution du move")]
     public TimelineAsset performingTimeline;
+    [Tooltip("Timeline jouée lors du repli après l'exécution du move")]
+    public TimelineAsset retreatTimeline;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -853,7 +853,8 @@ public class NewBattleManager : MonoBehaviour
             yield break;
         }
 
-        if (move.interceptable && !enemy.isInterceptionImmune)
+        // Interception possible uniquement si le move et l'attaquant l'autorisent
+        if (move.interceptable && enemy.Data.interceptable && !enemy.isInterceptionImmune)
         {
             yield return TryPlayerInterception(enemy, target, move);
             if (interceptionSucceeded)
@@ -933,7 +934,8 @@ public class NewBattleManager : MonoBehaviour
 
         OrientUnitTowardTarget(caster, target);
 
-        if (move.interceptable && !caster.isInterceptionImmune)
+        // Vérifie si le move et le lanceur peuvent être interceptés
+        if (move.interceptable && caster.Data.interceptable && !caster.isInterceptionImmune)
         {
             var interceptor = CheckForInterception(caster, target, caster.Data.currentInterceptionRange);
             if (interceptor != null)
@@ -1108,8 +1110,8 @@ public class NewBattleManager : MonoBehaviour
 
     private CharacterUnit CheckForInterception(CharacterUnit caster, CharacterUnit target, float range)
     {
-        if (caster != null && caster.isInterceptionImmune)
-            return null;
+        if (caster != null && (!caster.Data.interceptable || caster.isInterceptionImmune))
+            return null; // Attaquant non interceptable
         foreach (var unit in activeCharacterUnits)
         {
             if (unit == null || unit == caster || unit == target) continue;
@@ -1131,8 +1133,8 @@ public class NewBattleManager : MonoBehaviour
 
     private CharacterUnit FindPlayerInterceptor(CharacterUnit caster, CharacterUnit target, float range)
     {
-        if (caster != null && caster.isInterceptionImmune)
-            return null;
+        if (caster != null && (!caster.Data.interceptable || caster.isInterceptionImmune))
+            return null; // Attaquant non interceptable
         CharacterUnit best = null;
         float bestChance = 0f;
         foreach (var unit in activeCharacterUnits)
@@ -1160,8 +1162,8 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator TryPlayerInterception(CharacterUnit caster, CharacterUnit target, MusicalMoveSO move)
     {
         interceptionSucceeded = false;
-        if (caster != null && caster.isInterceptionImmune)
-            yield break;
+        if (caster != null && (!caster.Data.interceptable || caster.isInterceptionImmune))
+            yield break; // Impossible d'intercepter ce lanceur
         var interceptor = FindPlayerInterceptor(caster, target, caster.Data.currentInterceptionRange);
         if (interceptor == null)
             yield break;

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -236,6 +236,11 @@ public class RhythmQTEManager : MonoBehaviour
                           BattleTimelineManager.Instance != null &&
                           TimelineManager.Instance != null &&
                           casterAnimatorGO != null;
+        // Timeline jouée lors du repli après retour éventuel
+        bool hasRetreatTimeline = move.retreatTimeline != null &&
+                                  BattleTimelineManager.Instance != null &&
+                                  TimelineManager.Instance != null &&
+                                  casterAnimatorGO != null;
 
         if (hasTimeline)
         {
@@ -305,6 +310,28 @@ public class RhythmQTEManager : MonoBehaviour
         if (!move.stayInPlace && !hasTimeline)
             // Retourne le lanceur à sa position de départ enregistrée
             yield return ReturnToInitialPosition(move, caster, target, originPosition);
+
+        // Lecture éventuelle de la timeline de repli
+        if (hasRetreatTimeline)
+        {
+            string cameraTag = caster.characterType == CharacterType.EnemyUnit ? null : "BattleCamera";
+            BattleTimelineManager.Instance.PlayTimeline(move.retreatTimeline, casterAnimatorGO, cameraTag);
+
+            float maxRetreatDuration = (float)move.retreatTimeline.duration;
+            float retreatTimer = 0f;
+            while (TimelineManager.Instance != null &&
+                   TimelineManager.Instance.IsTimelineActive &&
+                   retreatTimer < maxRetreatDuration)
+            {
+                retreatTimer += Time.deltaTime;
+                yield return null;
+            }
+
+            if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelineActive)
+            {
+                Debug.LogWarning($"[MusicalMoveRoutine] Timeline '{move.retreatTimeline.name}' encore active après {maxRetreatDuration}s. Suite forcée.");
+            }
+        }
 
         isActive = false;
         bool critical = successResults != null && successResults.Count > 0 && successResults.All(s => s);
@@ -734,27 +761,36 @@ public class RhythmQTEManager : MonoBehaviour
 
         var note = currentMove.notes[index];
 
-        // Si l'attaquant est un ennemi, la cible doit exécuter le QTE défensif
+        // Si l'attaquant est un ennemi
         if (currentCaster.Data.characterType == CharacterType.EnemyUnit)
         {
-            StartCoroutine(WaitForDefenseQTE(result =>
+            // Si l'ennemi est marqué comme inévitable, aucun QTE défensif n'est proposé
+            if (currentCaster.Data.avoidable)
             {
-                defenseResult = result;
-                switch (result)
-                {
-                    case DefenseResult.Parry:
-                        currentTarget.TakeParry();
-                        break;
-                    case DefenseResult.Dodge:
-                        currentTarget.TakeDodge();
-                        break;
-                    default:
-                        currentMove.ApplyEffect(currentCaster, currentTarget);
-                        break;
-                }
-
+                currentMove.ApplyEffect(currentCaster, currentTarget);
                 pendingNotes = Mathf.Max(0, pendingNotes - 1);
-            }));
+            }
+            else
+            {
+                StartCoroutine(WaitForDefenseQTE(result =>
+                {
+                    defenseResult = result;
+                    switch (result)
+                    {
+                        case DefenseResult.Parry:
+                            currentTarget.TakeParry();
+                            break;
+                        case DefenseResult.Dodge:
+                            currentTarget.TakeDodge();
+                            break;
+                        default:
+                            currentMove.ApplyEffect(currentCaster, currentTarget);
+                            break;
+                    }
+
+                    pendingNotes = Mathf.Max(0, pendingNotes - 1);
+                }));
+            }
         }
         else
         {


### PR DESCRIPTION
## Résumé
- Ajout d'une timeline de repli pour les MusicalMoves, jouée après l'exécution et le retour éventuel
- Introduction des flags `interceptable` et `avoidable` dans `CharacterData`
- Prise en compte de ces flags dans la gestion des interceptions et des QTE défensifs

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68c44edfa9288325b39bac5fdcbd798e