### PR TITLE
Gestion des timelines de combat : ignorer casters/caméras manquants

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -160,14 +160,15 @@ public class BattleTimelineManager : MonoBehaviour
     /// </summary>
     public void PlayTimelineOverlay(TimelineAsset timeline, GameObject caster)
     {
-        if (timeline == null || caster == null)
+        // Ignore la demande si aucune timeline n'est fournie
+        if (timeline == null)
             return;
 
         // Crée un PlayableDirector temporaire pour cette timeline
         var overlayDirector = gameObject.AddComponent<PlayableDirector>();
         overlayDirector.playableAsset = timeline;
 
-        // Lie uniquement les pistes liées au lanceur et ignore la caméra
+        // Lie uniquement les pistes pertinentes. Les pistes sans Caster sont ignorées.
         foreach (var output in timeline.outputs)
         {
             string lower = output.streamName.ToLower();
@@ -176,13 +177,21 @@ public class BattleTimelineManager : MonoBehaviour
 
             if (lower.Contains("caster") || lower.Contains("pnj"))
             {
+                // Si aucun caster n'est fourni, on ignore simplement la piste
+                if (caster == null)
+                    continue;
+
                 var animator = caster.GetComponentInChildren<Animator>();
                 if (animator != null)
                     overlayDirector.SetGenericBinding(output.sourceObject, animator);
+                else
+                    Debug.LogWarning("[BattleTimelineManager] Animator manquant sur le caster pour la timeline overlay.");
             }
             else
             {
-                overlayDirector.SetGenericBinding(output.sourceObject, caster);
+                // Les autres pistes nécessitent également la référence du caster
+                if (caster != null)
+                    overlayDirector.SetGenericBinding(output.sourceObject, caster);
             }
         }
 

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -509,18 +509,28 @@ public class TimelineManager : MonoBehaviour
         foreach (var output in timelineAsset.outputs)
         {
             string trackName = output.streamName;
+            string lower = trackName.ToLower();
             System.Type type = output.outputTargetType;
 
-            // Pour les timelines de PNJ, le track d'animation s'appelle "PNJ" au lieu de "Caster"
-            if ((trackName.ToLower().Contains("caster") || trackName.ToLower().Contains("pnj")) && caster != null)
+            // Gestion des pistes liées au lanceur (Caster ou PNJ)
+            if (lower.Contains("caster") || lower.Contains("pnj"))
             {
-                BindObjectToTrack(output, caster);
+                if (caster != null)
+                {
+                    BindObjectToTrack(output, caster);
+                }
+                else
+                {
+                    // Aucune référence valide : on ignore cette piste
+                    Debug.LogWarning($"[TimelineManager] Caster introuvable pour la track : {trackName}, piste ignorée.");
+                }
             }
-            else if (trackName.ToLower().Contains("camera"))
+            // Gestion des pistes liées à la caméra
+            else if (lower.Contains("camera"))
             {
-                // L'animation de la caméra doit utiliser l'Animator situé sur le parent de la WorldCamera.
                 if (cameraGO != null)
                 {
+                    // L'animation de la caméra doit utiliser l'Animator situé sur le parent de la WorldCamera.
                     Animator camAnimator = cameraParent != null
                         ? cameraParent.GetComponent<Animator>()
                         : cameraGO.GetComponent<Animator>();
@@ -534,16 +544,13 @@ public class TimelineManager : MonoBehaviour
                         Debug.LogWarning($"[TimelineManager] Animator manquant pour la caméra {cameraTag}");
                     }
                 }
-                else if (caster != null)
-                {
-                    // Aucun tag de caméra fourni : on se rabat sur le PNJ.
-                    BindObjectToTrack(output, caster);
-                }
                 else
                 {
-                    Debug.LogWarning($"[TimelineManager] Aucun GameObject trouvé pour la track camera : {trackName}");
+                    // Aucune caméra correspondante : on ignore la piste
+                    Debug.LogWarning($"[TimelineManager] Caméra introuvable pour la track : {trackName}, piste ignorée.");
                 }
             }
+            // Gestion des receveurs de signaux
             else if (type != null && typeof(Component).IsAssignableFrom(type) && type.Name.Contains("SignalReceiver"))
             {
                 // Récupère le SignalReceiver présent sur le même GameObject que le PlayableDirector


### PR DESCRIPTION
## Résumé
- Ignore les timelines overlay lorsque le caster est absent afin d'éviter les blocages
- Évite de binder les pistes caméra ou caster quand les objets correspondants sont manquants

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c49317adb08325b4a6c34375dc90a4