### PR TITLE
Gestion parallèle des timelines de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -1,37 +1,30 @@
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
-using System.Collections; // Nécessaire pour les coroutines
-using System.Collections.Generic; // Gestion des files d'attente de timelines
+using System.Collections;
+using System.Collections.Generic;
 
 /// <summary>
 /// Gestionnaire dédié au lancement des <see cref="TimelineAsset"/> durant les combats.
-/// Toutes les timelines de <c>MusicalMove</c> et d'<c>Item</c>
-/// sont lues via ce <see cref="PlayableDirector"/> unique pour
-/// garantir un comportement cohérent.
-/// <para>
-/// À ne pas confondre avec la timeline d'interface qui affiche l'ordre
-/// des tours : cette dernière est gérée par <see cref="BattleTimelineUIManager"/>.
-/// </para>
-
+/// Toutes les timelines de <c>MusicalMove</c> et d'<c>Item</c> sont lues via deux
+/// <see cref="PlayableDirector"/> spécialisés :
+/// <list type="bullet">
+/// <item>PlayableDirector_Camera pour les mouvements de caméra globaux.</item>
+/// <item>PlayableDirector_Caster pour les animations du lanceur.</item>
+/// </list>
 /// </summary>
 public class BattleTimelineManager : MonoBehaviour
 {
-    /// <summary>
-    /// Instance statique accessible depuis les autres scripts.
-    /// </summary>
+    /// <summary>Instance statique accessible depuis les autres scripts.</summary>
     public static BattleTimelineManager Instance { get; private set; }
 
-    /// <summary>
-    /// PlayableDirector utilisé pour lancer les timelines de combat.
-    /// </summary>
-    private PlayableDirector director;
+    /// <summary>Director dédié aux timelines de caméra globales.</summary>
+    private PlayableDirector directorCamera;
 
-    /// <summary>
-    /// Représente une demande de lecture de Timeline.
-    /// Chaque appel à <see cref="PlayTimeline"/> est empilé ici afin
-    /// d'être joué séquentiellement sans perdre la caméra.
-    /// </summary>
+    /// <summary>Director chargé des animations du lanceur.</summary>
+    private PlayableDirector directorCaster;
+
+    /// <summary>Structure interne représentant une demande de lecture de timeline caméra.</summary>
     private class TimelineRequest
     {
         public TimelineAsset timeline;
@@ -41,16 +34,10 @@ public class BattleTimelineManager : MonoBehaviour
         public Quaternion? fixedRotation;
     }
 
-    /// <summary>
-    /// File d'attente des timelines à jouer. Permet le cumul automatique
-    /// lorsque plusieurs moves se déclenchent successivement.
-    /// </summary>
+    /// <summary>File d'attente des timelines caméra à jouer séquentiellement.</summary>
     private readonly Queue<TimelineRequest> timelineQueue = new Queue<TimelineRequest>();
 
-    /// <summary>
-    /// Référence vers la coroutine de traitement de la file d'attente
-    /// pour éviter les doublons.
-    /// </summary>
+    /// <summary>Référence vers la coroutine de traitement de la file.</summary>
     private Coroutine queueCoroutine;
 
     private void Awake()
@@ -63,46 +50,34 @@ public class BattleTimelineManager : MonoBehaviour
         }
         Instance = this;
 
-        // Récupère le PlayableDirector présent sur ce GameObject.
-        director = GetComponent<PlayableDirector>();
+        // Récupération des deux PlayableDirectors enfants.
+        Transform camChild = transform.Find("PlayableDirector_Camera");
+        Transform casterChild = transform.Find("PlayableDirector_Caster");
+        directorCamera = camChild != null ? camChild.GetComponent<PlayableDirector>() : null;
+        directorCaster = casterChild != null ? casterChild.GetComponent<PlayableDirector>() : null;
 
-        // 🔧 Si aucun PlayableDirector n'est trouv\u00e9 (objet oubli\u00e9 ou supprim\u00e9),
-        // on en ajoute un dynamiquement afin d'\u00e9viter que les timelines
-        // ne restent silencieuses en combat.
-        if (director == null)
-        {
-            director = gameObject.AddComponent<PlayableDirector>();
-            Debug.LogWarning("[BattleTimelineManager] Aucun PlayableDirector trouv\u00e9, ajout d'un composant par d\u00e9faut.");
-        }
+        if (directorCamera == null)
+            Debug.LogError("[BattleTimelineManager] PlayableDirector_Camera introuvable.");
+        if (directorCaster == null)
+            Debug.LogError("[BattleTimelineManager] PlayableDirector_Caster introuvable.");
 
-        // Enregistre ce director aupr\u00e8s du TimelineManager global afin qu'il soit
-        // utilis\u00e9 pour toutes les timelines lanc\u00e9es pendant les combats.
-        if (TimelineManager.Instance != null)
-            TimelineManager.Instance.SetExternalDirector(director);
+        // Le TimelineManager global utilise le director de caméra pour gérer les timelines principales.
+        if (TimelineManager.Instance != null && directorCamera != null)
+            TimelineManager.Instance.SetExternalDirector(directorCamera);
     }
 
     /// <summary>
-    /// Lance une timeline via le PlayableDirector de combat.
+    /// Lance une timeline caméra via le PlayableDirector dédié et la file d'attente.
     /// </summary>
-    /// <param name="timeline">Timeline à exécuter.</param>
-    /// <param name="caster">GameObject jouant la timeline.</param>
-    /// <param name="cameraTag">Tag de la caméra à animer. Peut être nul.</param>
-    /// <param name="autoRestore">False pour chaîner plusieurs timelines sans rendre la main au contrôleur caméra.</param>
-    /// <param name="fixedRotation">Rotation imposée pour la caméra. Si non spécifiée, la rotation actuelle du
-    /// caster est utilisée à chaque appel. Ce paramètre permet de conserver l'orientation initiale du lanceur
-    /// sur toute la durée d'un move même si plusieurs timelines se succèdent.</param>
-    
-    public void PlayTimeline(TimelineAsset timeline, GameObject caster, string cameraTag, bool autoRestore = true, Quaternion? fixedRotation = null)
+    public void PlayTimeline(TimelineAsset timeline, GameObject caster, string cameraTag,
+                             bool autoRestore = true, Quaternion? fixedRotation = null)
     {
-        if (timeline == null || TimelineManager.Instance == null)
+        if (timeline == null || TimelineManager.Instance == null || directorCamera == null)
         {
-            // Pas de timeline ou de gestionnaire disponible : on abandonne
-            // proprement pour éviter toute NullReferenceException.
             Debug.LogWarning("[BattleTimelineManager] Lecture annulée : gestionnaire ou timeline manquante.");
             return;
         }
 
-        // Empile la demande de lecture pour une exécution séquentielle.
         timelineQueue.Enqueue(new TimelineRequest
         {
             timeline = timeline,
@@ -112,28 +87,21 @@ public class BattleTimelineManager : MonoBehaviour
             fixedRotation = fixedRotation
         });
 
-        // Si aucune coroutine ne traite actuellement la file, on en démarre une.
         if (queueCoroutine == null)
             queueCoroutine = StartCoroutine(ProcessQueue());
     }
 
-    /// <summary>
-    /// Traite séquentiellement toutes les timelines en attente dans la file.
-    /// Cette coroutine garantit qu'une timeline ne démarre qu'une fois la
-    /// précédente terminée, permettant ainsi un véritable cumul.
-    /// </summary>
+    /// <summary>Traite séquentiellement toutes les timelines caméra en attente.</summary>
     private IEnumerator ProcessQueue()
     {
         while (timelineQueue.Count > 0)
         {
             var request = timelineQueue.Dequeue();
 
-            // S'assure que le TimelineManager utilise bien ce PlayableDirector
-            // avant chaque lecture.
-            TimelineManager.Instance.SetExternalDirector(director);
+            // Assure l'utilisation du director caméra par le TimelineManager global.
+            TimelineManager.Instance.SetExternalDirector(directorCamera);
 
-            // Si d'autres timelines sont déjà en file, on empêche la
-            // restauration automatique afin de conserver la position de la caméra.
+            // Restaure la caméra uniquement à la fin de la dernière timeline de la file.
             bool restore = request.autoRestore && timelineQueue.Count == 0;
 
             TimelineManager.Instance.PlayTimeline(request.timeline, request.caster, request.cameraTag,
@@ -142,91 +110,57 @@ public class BattleTimelineManager : MonoBehaviour
             // Attente de la fin de la timeline en cours.
             while (TimelineManager.Instance.IsTimelinePlaying)
             {
-                // Si une nouvelle timeline arrive durant la lecture, on désactive
-                // immédiatement la restauration pour la timeline active.
                 if (timelineQueue.Count > 0)
                     TimelineManager.Instance.SetAutoRestore(false);
                 yield return null;
             }
         }
 
-        // Toutes les timelines ont été jouées : la coroutine peut s'arrêter.
+        // Toutes les timelines ont été jouées : on libère la coroutine.
         queueCoroutine = null;
     }
 
     /// <summary>
-    /// Joue une timeline additionnelle sans interrompre celle déjà active.
-    /// Permet une superposition ponctuelle d'animations durant un combat.
+    /// Joue une timeline d'animation pour le lanceur en parallèle de la caméra.
     /// </summary>
-    public void PlayTimelineOverlay(TimelineAsset timeline, GameObject caster)
+    public void PlayCasterTimeline(TimelineAsset timeline, GameObject caster)
     {
-        // Ignore la demande si aucune timeline n'est fournie
-        if (timeline == null)
+        if (timeline == null || directorCaster == null)
             return;
 
-        // \u26a0\ufe0f  Il arrive que cette m\u00e9thode soit appel\u00e9e alors que le
-        // gestionnaire a été détruit (changement de sc\u00e8ne, objet d\u00e9sactiv\u00e9...).
-        // Dans ce cas, toute tentative d'ajouter un composant provoquerait
-        // une NullReferenceException. On v\u00e9rifie donc que le GameObject est
-        // toujours valide avant de continuer.
-        if (this == null || gameObject == null)
-        {
-            Debug.LogWarning("[BattleTimelineManager] PlayTimelineOverlay ignor\u00e9e : gestionnaire inexistant.");
-            return;
-        }
+        directorCaster.playableAsset = timeline;
 
-        // Cr\u00e9e un PlayableDirector temporaire pour cette timeline.
-        // Si, pour une raison quelconque, l'ajout du composant échoue,
-        // on abandonne la lecture pour éviter de nouveaux plantages.
-        var overlayDirector = gameObject.AddComponent<PlayableDirector>();
-        if (overlayDirector == null)
-        {
-            Debug.LogError("[BattleTimelineManager] Impossible de cr\u00e9er un PlayableDirector pour la timeline overlay.");
-            return;
-        }
-
-        // Associe la timeline à ce PlayableDirector temporaire.
-        overlayDirector.playableAsset = timeline;
-
-        // Lie uniquement les pistes pertinentes. Les pistes sans Caster sont ignorées.
+        // Binding explicite des pistes vers l'Animator ou le GameObject du lanceur.
         foreach (var output in timeline.outputs)
         {
             string lower = output.streamName.ToLower();
             if (lower.Contains("camera"))
-                continue; // Caméra gérée ailleurs
+                continue; // Les pistes caméra sont ignorées ici.
 
             if (lower.Contains("caster") || lower.Contains("pnj"))
             {
-                // Si aucun caster n'est fourni, on ignore simplement la piste
                 if (caster == null)
                     continue;
 
                 var animator = caster.GetComponentInChildren<Animator>();
                 if (animator != null)
-                    overlayDirector.SetGenericBinding(output.sourceObject, animator);
+                    directorCaster.SetGenericBinding(output.sourceObject, animator);
                 else
-                    Debug.LogWarning("[BattleTimelineManager] Animator manquant sur le caster pour la timeline overlay.");
+                    Debug.LogWarning("[BattleTimelineManager] Animator manquant sur le caster pour la timeline.");
             }
             else
             {
-                // Les autres pistes nécessitent également la référence du caster
                 if (caster != null)
-                    overlayDirector.SetGenericBinding(output.sourceObject, caster);
+                    directorCaster.SetGenericBinding(output.sourceObject, caster);
             }
         }
 
-        overlayDirector.Play();
-        StartCoroutine(CleanupOverlay(overlayDirector));
+        directorCaster.time = 0;
+        directorCaster.Play();
     }
 
-    /// <summary>
-    /// Détruit le PlayableDirector temporaire lorsqu'il a terminé sa lecture.
-    /// </summary>
-    private IEnumerator CleanupOverlay(PlayableDirector dir)
-    {
-        while (dir != null && dir.state == PlayState.Playing)
-            yield return null;
-        if (dir != null)
-            Destroy(dir);
-    }
+    /// <summary>Indique si le director du lanceur joue actuellement une timeline.</summary>
+    public bool IsCasterTimelinePlaying =>
+        directorCaster != null && directorCaster.state == PlayState.Playing;
 }
+

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -198,7 +198,9 @@ public class RhythmQTEManager : MonoBehaviour
             return;
 
         if (overlay)
-            BattleTimelineManager.Instance.PlayTimelineOverlay(timeline, animatorGO);
+            // Lecture via le PlayableDirector dédié au lanceur lorsque la caméra
+            // suit déjà la timeline complète.
+            BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
         else
             BattleTimelineManager.Instance.PlayTimeline(timeline, animatorGO, battleCameraTag, autoRestore, initialRotation);
     }
@@ -215,9 +217,19 @@ public class RhythmQTEManager : MonoBehaviour
 
         if (overlay)
         {
-            // Les timelines en superposition ne sont pas gérées par le TimelineManager
-            // global : on attend simplement leur durée déclarée.
-            yield return new WaitForSeconds((float)timeline.duration);
+            // Suivi de la timeline via le PlayableDirector du lanceur.
+            float maxDuration = (float)timeline.duration;
+            float timer = 0f;
+            while (BattleTimelineManager.Instance != null &&
+                   BattleTimelineManager.Instance.IsCasterTimelinePlaying &&
+                   timer < maxDuration)
+            {
+                timer += Time.deltaTime;
+                yield return null;
+            }
+
+            if (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePlaying)
+                Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
         }
         else
         {
@@ -232,9 +244,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
 
             if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelineActive)
-            {
                 Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
-            }
         }
     }
 


### PR DESCRIPTION
## Résumé
- Séparation des timelines de combat entre directeur caméra et directeur lanceur
- Nouvelle méthode `PlayCasterTimeline` pour animer le lanceur en parallèle
- Adaptation du `RhythmQTEManager` pour lancer et surveiller ces timelines dédiées

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fb40450883258b714009a0116c0b