### PR TITLE
Ajout d’un délai configurable pour les téléportations

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -17,6 +17,12 @@ public class ItemData : ScriptableObject
     public float moveSpeed;
     public float castDistance;
 
+    [Header("Effets spéciaux")]
+    // Délai entre disparition et réapparition lors d'un téléport
+    // Utile pour synchroniser les effets visuels/sonores
+    [Tooltip("Durée en secondes avant la réapparition après un téléport (0 = instantané)")]
+    public float teleportDelay = 0.2f;
+
     [Header("Limitations d'utilisation")]
     [Tooltip("Nombre maximum d'utilisations par tour (0 = illimité)")]
     public int maxUsesPerTurn = 0;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -76,6 +76,11 @@ public class MusicalMoveSO : ScriptableObject
     public float moveSpeed = 20f;
     public float castDistance;
 
+    // Temps entre la disparition et la réapparition lors d'une téléportation
+    // Permet de laisser les effets visuels/sonores se jouer avant le déplacement
+    [Tooltip("Délai en secondes entre la disparition et la réapparition (0 = instantané)")]
+    public float teleportDelay = 0.2f;
+
     [Tooltip("Si vrai, le lanceur reste à la position cible en fin de move")] public bool stayInPlace = false;
 
     [Tooltip("Si faux, le move ne peut pas être intercepté")]

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -44,8 +44,9 @@ public class RhythmQTEManager : MonoBehaviour
     // MoveTo
     float elapsed = 0f;
 
-    // Délai entre les effets de téléportation départ et arrivée
-    private const float returnDelay = 0.2f;
+    // Durée par défaut utilisée si aucun délai n'est défini dans les données
+    // Conserve l'ancien comportement en cas d'oubli de paramétrage
+    private const float defaultTeleportDelay = 0.2f;
 
     // Tag de la caméra de combat à utiliser pour toutes les timelines
     private const string battleCameraTag = "BattleCamera";
@@ -493,8 +494,9 @@ public class RhythmQTEManager : MonoBehaviour
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
 
-            // Petit délai pour laisser apparaître l'effet
-            yield return new WaitForSeconds(returnDelay);
+            // Délai configurable pour laisser apparaître l'effet de téléport
+            float delay = item.teleportDelay >= 0f ? item.teleportDelay : defaultTeleportDelay;
+            yield return new WaitForSeconds(delay);
 
             // Téléportation instantanée
             caster.transform.position = destination;
@@ -552,7 +554,9 @@ public class RhythmQTEManager : MonoBehaviour
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
 
-            yield return new WaitForSeconds(returnDelay);
+            // Délai configurable avant la réapparition à la position initiale
+            float delay = item.teleportDelay >= 0f ? item.teleportDelay : defaultTeleportDelay;
+            yield return new WaitForSeconds(delay);
 
             caster.transform.position = origin;
 
@@ -633,7 +637,9 @@ public class RhythmQTEManager : MonoBehaviour
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
 
-            yield return new WaitForSeconds(returnDelay);
+            // Délai configurable pour la téléportation du MusicalMove
+            float delay = move.teleportDelay >= 0f ? move.teleportDelay : defaultTeleportDelay;
+            yield return new WaitForSeconds(delay);
 
             caster.transform.position = targetPos;
 
@@ -702,7 +708,9 @@ public class RhythmQTEManager : MonoBehaviour
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
 
-            yield return new WaitForSeconds(returnDelay);
+            // Délai configurable avant de revenir à la position de départ
+            float delay = move.teleportDelay >= 0f ? move.teleportDelay : defaultTeleportDelay;
+            yield return new WaitForSeconds(delay);
 
             if (caster == null)
             {


### PR DESCRIPTION
## Résumé
- Ajout d’un paramètre `teleportDelay` pour les Items et MusicalMoves afin d’espacer disparition et réapparition.
- Utilisation de ce délai dans le `RhythmQTEManager` avec une valeur par défaut en cas d’omission.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé / accès refusé)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fe5441ec8325b2b8e62ca80d9053