### PR TITLE
La caméra de combat se centre sur la cible

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -27,11 +27,12 @@ public class BattleTimelineManager : MonoBehaviour
     /// <summary>Structure interne représentant une demande de lecture de timeline caméra.</summary>
     private class TimelineRequest
     {
-        public TimelineAsset timeline;
-        public GameObject caster;
-        public string cameraTag;
-        public bool autoRestore;
-        public Quaternion? fixedRotation;
+        public TimelineAsset timeline;      // Timeline à jouer
+        public GameObject caster;           // Objet utilisé pour les bindings (animations, signaux...)
+        public GameObject cameraTarget;     // Nouvelle cible pour positionner et suivre la caméra
+        public string cameraTag;            // Tag de la caméra à animer
+        public bool autoRestore;            // Faut-il restaurer la caméra à la fin ?
+        public Quaternion? fixedRotation;   // Rotation imposée pour conserver l'orientation
     }
 
     /// <summary>File d'attente des timelines caméra à jouer séquentiellement.</summary>
@@ -69,8 +70,13 @@ public class BattleTimelineManager : MonoBehaviour
     /// <summary>
     /// Lance une timeline caméra via le PlayableDirector dédié et la file d'attente.
     /// </summary>
-    public void PlayTimeline(TimelineAsset timeline, GameObject caster, string cameraTag,
-                             bool autoRestore = true, Quaternion? fixedRotation = null)
+    public void PlayTimeline(
+        TimelineAsset timeline,
+        GameObject caster,
+        GameObject cameraTarget,
+        string cameraTag,
+        bool autoRestore = true,
+        Quaternion? fixedRotation = null)
     {
         if (timeline == null || TimelineManager.Instance == null || directorCamera == null)
         {
@@ -82,6 +88,7 @@ public class BattleTimelineManager : MonoBehaviour
         {
             timeline = timeline,
             caster = caster,
+            cameraTarget = cameraTarget,
             cameraTag = cameraTag,
             autoRestore = autoRestore,
             fixedRotation = fixedRotation
@@ -104,8 +111,16 @@ public class BattleTimelineManager : MonoBehaviour
             // Restaure la caméra uniquement à la fin de la dernière timeline de la file.
             bool restore = request.autoRestore && timelineQueue.Count == 0;
 
-            TimelineManager.Instance.PlayTimeline(request.timeline, request.caster, request.cameraTag,
-                                                  false, false, true, restore, request.fixedRotation);
+            TimelineManager.Instance.PlayTimeline(
+                request.timeline,
+                request.caster,
+                request.cameraTag,
+                false,
+                false,
+                true,
+                restore,
+                request.fixedRotation,
+                request.cameraTarget);
 
             // Attente de la fin de la timeline en cours.
             while (TimelineManager.Instance.IsTimelinePlaying)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2037,7 +2037,11 @@ public class NewBattleManager : MonoBehaviour
 
         GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
         // Démarre la Timeline qui boucle tant que le menu est ouvert
-        BattleTimelineManager.Instance.PlayTimeline(itemPreparingTimeline, animGO, "BattleCamera");
+        BattleTimelineManager.Instance.PlayTimeline(
+            itemPreparingTimeline,
+            animGO,
+            animGO,
+            "BattleCamera");
         itemMenuTimelineActive = true;
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -190,10 +190,11 @@ public class RhythmQTEManager : MonoBehaviour
     /// </summary>
     /// <param name="timeline">Timeline à jouer.</param>
     /// <param name="overlay">Vrai pour une timeline en superposition.</param>
-    /// <param name="animatorGO">Objet de référence pour le binding.</param>
+    /// <param name="animatorGO">Objet de référence pour le binding (caster).</param>
+    /// <param name="cameraTarget">Objet servant d'ancre pour la caméra.</param>
     /// <param name="autoRestore">Indique si la caméra doit être restaurée automatiquement.</param>
     /// <param name="initialRotation">Rotation de référence à conserver.</param>
-    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, GameObject animatorGO, bool autoRestore, Quaternion initialRotation)
+    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation)
     {
         if (timeline == null || BattleTimelineManager.Instance == null || animatorGO == null)
             return;
@@ -203,7 +204,7 @@ public class RhythmQTEManager : MonoBehaviour
             // suit déjà la timeline complète.
             BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
         else
-            BattleTimelineManager.Instance.PlayTimeline(timeline, animatorGO, battleCameraTag, autoRestore, initialRotation);
+            BattleTimelineManager.Instance.PlayTimeline(timeline, animatorGO, cameraTarget, battleCameraTag, autoRestore, initialRotation);
     }
 
     /// <summary>
@@ -294,6 +295,23 @@ public class RhythmQTEManager : MonoBehaviour
         }
         
         GameObject casterAnimatorGO = caster.GetComponentInChildren<Animator>()?.gameObject;
+        // 🎯 Détermination de l'ancre de caméra : on privilégie le point "Camera_TargetedPoint"
+        // de la cible (pour centrer l'action sur elle), sinon son Animator, et à défaut le
+        // GameObject de la cible. Si aucune cible n'est fournie, on se rabat sur le lanceur.
+        GameObject cameraTargetGO = null;
+        if (target != null)
+        {
+            // Recherche récursive d'un point de focus spécifique sur la cible
+            Transform targetedPoint = FindChildRecursive(target.transform, "Camera_TargetedPoint");
+            if (targetedPoint != null)
+                cameraTargetGO = targetedPoint.gameObject;
+            else
+                cameraTargetGO = target.GetComponentInChildren<Animator>()?.gameObject ?? target.gameObject;
+        }
+        else
+        {
+            cameraTargetGO = casterAnimatorGO;
+        }
         // Détermine si une timeline caméra couvrant toute l'action est disponible.
         bool useOverlay = move.fullTimeline != null &&
                           BattleTimelineManager.Instance != null &&
@@ -302,11 +320,22 @@ public class RhythmQTEManager : MonoBehaviour
 
         // Lance la timeline globale de caméra si présente.
         if (useOverlay)
-            BattleTimelineManager.Instance.PlayTimeline(move.fullTimeline, casterAnimatorGO, battleCameraTag, true, initialRotation);
+            BattleTimelineManager.Instance.PlayTimeline(
+                move.fullTimeline,
+                casterAnimatorGO,
+                cameraTargetGO,
+                battleCameraTag,
+                true,
+                initialRotation);
 
         // --- Phase de préparation ---
-        StartTimelinePhase(move.preparingTimeline, useOverlay, casterAnimatorGO,
-                           move.performingTimeline == null && move.retreatTimeline == null, initialRotation);
+        StartTimelinePhase(
+            move.preparingTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            move.performingTimeline == null && move.retreatTimeline == null,
+            initialRotation);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay);
 
         // Éventuel délai de pré-animation.
@@ -318,8 +347,13 @@ public class RhythmQTEManager : MonoBehaviour
             yield return MoveTo(caster, target, move);
 
         // --- Phase d'exécution ---
-        StartTimelinePhase(move.performingTimeline, useOverlay, casterAnimatorGO,
-                           move.retreatTimeline == null, initialRotation);
+        StartTimelinePhase(
+            move.performingTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            move.retreatTimeline == null,
+            initialRotation);
 
         if (pendingNotes == 0)
         {
@@ -351,7 +385,13 @@ public class RhythmQTEManager : MonoBehaviour
             yield return ReturnToInitialPosition(move, caster, target, originPosition);
 
         // --- Phase de repli ---
-        StartTimelinePhase(move.retreatTimeline, useOverlay, casterAnimatorGO, true, initialRotation);
+        StartTimelinePhase(
+            move.retreatTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            true,
+            initialRotation);
         yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay);
 
         // Attente finale de la timeline caméra complète.
@@ -410,6 +450,22 @@ public class RhythmQTEManager : MonoBehaviour
         
         Animator animator = caster.GetComponentInChildren<Animator>();
         GameObject casterAnimatorGO = animator != null ? animator.gameObject : null;
+        // 🎯 Choisit la cible pour l'ancrage de caméra. On vise d'abord le point
+        // "Camera_TargetedPoint" de la cible, puis son Animator, puis le GameObject.
+        // Sans cible, la caméra suit simplement le lanceur.
+        GameObject cameraTargetGO = null;
+        if (target != null)
+        {
+            Transform targetedPoint = FindChildRecursive(target.transform, "Camera_TargetedPoint");
+            if (targetedPoint != null)
+                cameraTargetGO = targetedPoint.gameObject;
+            else
+                cameraTargetGO = target.GetComponentInChildren<Animator>()?.gameObject ?? target.gameObject;
+        }
+        else
+        {
+            cameraTargetGO = casterAnimatorGO;
+        }
 
         // Détermine si une timeline caméra complète est disponible pour l'objet.
         bool useOverlay = item.fullTimeline != null &&
@@ -419,11 +475,22 @@ public class RhythmQTEManager : MonoBehaviour
 
         // Lance la timeline globale si présente.
         if (useOverlay)
-            BattleTimelineManager.Instance.PlayTimeline(item.fullTimeline, casterAnimatorGO, battleCameraTag, true, initialRotation);
+            BattleTimelineManager.Instance.PlayTimeline(
+                item.fullTimeline,
+                casterAnimatorGO,
+                cameraTargetGO,
+                battleCameraTag,
+                true,
+                initialRotation);
 
         // --- Phase de préparation ---
-        StartTimelinePhase(item.preparingTimeline, useOverlay, casterAnimatorGO,
-                           item.performingTimeline == null && item.retreatTimeline == null, initialRotation);
+        StartTimelinePhase(
+            item.preparingTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            item.performingTimeline == null && item.retreatTimeline == null,
+            initialRotation);
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay);
 
         // Déplacement ou téléportation éventuel vers la cible.
@@ -431,8 +498,13 @@ public class RhythmQTEManager : MonoBehaviour
             yield return SimpleMoveTo(caster, target, item);
 
         // --- Phase d'utilisation ---
-        StartTimelinePhase(item.performingTimeline, useOverlay, casterAnimatorGO,
-                           item.retreatTimeline == null, initialRotation);
+        StartTimelinePhase(
+            item.performingTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            item.retreatTimeline == null,
+            initialRotation);
 
         // QTE associé à l'objet durant l'utilisation.
         LastItemSuccess = true;
@@ -455,7 +527,13 @@ public class RhythmQTEManager : MonoBehaviour
             yield return SimpleReturnToInitialPosition(caster, target, item, originPosition);
 
         // --- Phase de repli ---
-        StartTimelinePhase(item.retreatTimeline, useOverlay, casterAnimatorGO, true, initialRotation);
+        StartTimelinePhase(
+            item.retreatTimeline,
+            useOverlay,
+            casterAnimatorGO,
+            cameraTargetGO,
+            true,
+            initialRotation);
         yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay);
 
         // Attente finale de la timeline caméra complète.
@@ -1230,6 +1308,27 @@ public class RhythmQTEManager : MonoBehaviour
     {
         yield return new WaitForSeconds(delay);
         AudioManager.Instance?.PlayVoice(clip);
+    }
+
+    /// <summary>
+    /// Recherche récursivement un enfant portant un nom donné.
+    /// Utilisée ici pour trouver "Camera_TargetedPoint" sur la cible suivie.
+    /// </summary>
+    private Transform FindChildRecursive(Transform parent, string targetName)
+    {
+        if (parent == null) return null;
+
+        foreach (Transform child in parent)
+        {
+            if (child.name == targetName)
+                return child;
+
+            Transform result = FindChildRecursive(child, targetName);
+            if (result != null)
+                return result;
+        }
+
+        return null;
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -471,7 +471,16 @@ public class TimelineManager : MonoBehaviour
     /// <param name="autoRestore">True pour restaurer automatiquement la caméra et les entrées à la fin.</param>
     /// <param name="fixedRotation">Rotation imposée pour la caméra. Lorsque renseignée, elle remplace la rotation
     /// du caster et reste utilisée pour toutes les timelines successives d'un même move.</param>
-    public void PlayTimeline(TimelineAsset timelineAsset, GameObject caster, string cameraTag, bool withFade = true, bool interruptMusic = true, bool allowSkip = true, bool autoRestore = true, Quaternion? fixedRotation = null)
+    public void PlayTimeline(
+        TimelineAsset timelineAsset,
+        GameObject caster,
+        string cameraTag,
+        bool withFade = true,
+        bool interruptMusic = true,
+        bool allowSkip = true,
+        bool autoRestore = true,
+        Quaternion? fixedRotation = null,
+        GameObject cameraTarget = null)
     {
         if (timelineAsset == null || reusableDirector == null)
         {
@@ -495,14 +504,16 @@ public class TimelineManager : MonoBehaviour
                 CameraController.Instance?.SaveWorldCameraTransform();
             }
 
-            if (caster != null && cameraParent != null)
+            // 🔄 La caméra se place désormais sur la cible fournie (cameraTarget) plutôt que sur le caster
+            GameObject anchor = cameraTarget ?? caster;
+            if (anchor != null && cameraParent != null)
             {
-                // Place la caméra sur le lanceur et capture l'orientation de référence.
+                // Place la caméra sur la cible et capture l'orientation de référence.
                 // Si une rotation fixe est fournie (début de la phase de préparation),
                 // elle est utilisée pour tout le move afin de garantir une cohérence
-                // malgré les téléportations ou changements d'orientation du caster.
-                cameraParent.position = caster.transform.position;
-                cameraParent.rotation = fixedRotation ?? caster.transform.rotation; // ✅ Rotation initiale conservée
+                // malgré les téléportations ou changements d'orientation de l'ancre.
+                cameraParent.position = anchor.transform.position;
+                cameraParent.rotation = fixedRotation ?? anchor.transform.rotation; // ✅ Rotation initiale conservée
             }
         }
 
@@ -580,12 +591,13 @@ public class TimelineManager : MonoBehaviour
         // Joue la timeline en profitant de toute la gestion centralisée (skip, fondu, musique...)
         PlayTimeline(reusableDirector, withFade, interruptMusic, allowSkip, autoRestore);
 
-        // Suit le lanceur si une caméra est attachée
-        if (caster != null && cameraParent != null)
+        // Suit la cible choisie si une caméra est attachée
+        Transform follow = (cameraTarget ?? caster)?.transform;
+        if (follow != null && cameraParent != null)
         {
             if (followCoroutine != null)
                 StopCoroutine(followCoroutine);
-            followCoroutine = StartCoroutine(FollowCaster(cameraParent, caster.transform));
+            followCoroutine = StartCoroutine(FollowTarget(cameraParent, follow));
         }
     }
 
@@ -632,18 +644,18 @@ public class TimelineManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Suit la position du lanceur pour animer correctement la caméra parentée.
+    /// Suit la position de l'ancre (cible ou caster) pour animer correctement la caméra parentée.
     /// </summary>
-    private IEnumerator FollowCaster(Transform cameraParent, Transform caster)
+    private IEnumerator FollowTarget(Transform cameraParent, Transform target)
     {
         while (reusableDirector != null && reusableDirector.state == PlayState.Playing)
         {
-            if (cameraParent != null && caster != null)
+            if (cameraParent != null && target != null)
             {
-                // Suit uniquement la position du lanceur ; la rotation de la caméra reste fixe
-                // afin que les mouvements du caster n'influencent pas l'orientation visuelle.
-                cameraParent.position = caster.position;
-                // cameraParent.rotation = caster.rotation; // ❌ Rotation ignorée volontairement
+                // Suit uniquement la position de l'ancre ; la rotation de la caméra reste fixe
+                // afin que les mouvements de la cible n'influencent pas l'orientation visuelle.
+                cameraParent.position = target.position;
+                // cameraParent.rotation = target.rotation; // ❌ Rotation ignorée volontairement
             }
             yield return null;
         }


### PR DESCRIPTION
## Résumé
- Ancre la caméra sur le point `Camera_TargetedPoint` de la cible pour les MusicalMoves
- Ajuste l'utilisation d'objets pour focaliser la caméra sur leur cible prioritaire
- Ajoute un utilitaire récursif pour rechercher l'ancre caméra sur la cible

## Tests
- `dotnet test` *(échoue : commande introuvable)*
- `apt-get update` *(échoue : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68c5050caf4883259fa3e3b2d7ff298d