### PR TITLE
Correctif du recentrage de la BattleCamera selon la phase

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -68,6 +68,31 @@ public class BattleTimelineManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Repositionne immédiatement l'origine de la caméra de combat sur une cible fournie.
+    /// Utilisé lorsque seule l'animation du lanceur est jouée (overlay) afin de
+    /// conserver une mise en scène cohérente malgré l'absence de timeline caméra
+    /// spécifique à la phase en cours.
+    /// </summary>
+    /// <param name="cameraTarget">Objet servant de nouvelle ancre pour la caméra.</param>
+    /// <param name="cameraTag">Tag de la caméra à déplacer.</param>
+    /// <param name="fixedRotation">Rotation imposée, ou null pour reprendre celle de la cible.</param>
+    public void AlignCameraToTarget(GameObject cameraTarget, string cameraTag, Quaternion? fixedRotation = null)
+    {
+        if (cameraTarget == null || string.IsNullOrEmpty(cameraTag))
+            return;
+
+        // Recherche de la caméra puis de son parent direct (BattleCamera_Origin).
+        GameObject cameraGO = GameObject.FindGameObjectWithTag(cameraTag);
+        Transform cameraParent = cameraGO != null ? cameraGO.transform.parent : null;
+
+        if (cameraParent != null)
+        {
+            cameraParent.position = cameraTarget.transform.position;
+            cameraParent.rotation = fixedRotation ?? cameraTarget.transform.rotation;
+        }
+    }
+
+    /// <summary>
     /// Lance une timeline caméra via le PlayableDirector dédié et la file d'attente.
     /// </summary>
     public void PlayTimeline(

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -200,11 +200,25 @@ public class RhythmQTEManager : MonoBehaviour
             return;
 
         if (overlay)
-            // Lecture via le PlayableDirector dédié au lanceur lorsque la caméra
-            // suit déjà la timeline complète.
+        {
+            // 🎥 Lorsque la caméra globale (overlay) est utilisée, la timeline du lanceur
+            // est lue via le PlayableDirector dédié. Cependant, l'origine de la caméra
+            // (BattleCamera_Origin) ne se repositionnait pas, ce qui provoquait un ancrage
+            // incorrect durant les phases de préparation et de repli. Nous ré-alignons donc
+            // explicitement l'origine avant de lancer l'animation du caster.
+            BattleTimelineManager.Instance.AlignCameraToTarget(
+                cameraTarget ?? animatorGO, // Fallback sur le lanceur si la cible est absente
+                battleCameraTag,
+                initialRotation);
+
+            // Lecture via le PlayableDirector du lanceur en parallèle de la timeline caméra complète.
             BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
+        }
         else
+        {
+            // Cas classique : la timeline contrôle également la caméra.
             BattleTimelineManager.Instance.PlayTimeline(timeline, animatorGO, cameraTarget, battleCameraTag, autoRestore, initialRotation);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- Ajout d'une méthode `AlignCameraToTarget` dans `BattleTimelineManager` pour repositionner l'origine de la caméra de combat.
- Réalignement automatique de la caméra lors des phases de timeline même en mode overlay, garantissant que le caster ou la cible soient correctement suivis.

## Tests
- `dotnet test` *(échec : `dotnet` absent)*
- `apt-get update` *(échec : dépôts non signés / accès interdit)*

------
https://chatgpt.com/codex/tasks/task_e_68c50e8867b08325bf4c1f6cdfe602ca