### PR TITLE
Déplace le start delay avant la timeline de préparation

### DIFF
--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -104,7 +104,11 @@ public class MusicalMoveSO : ScriptableObject
     public AudioClip warningClip;
 
     [Header("Timing")]
-    [Tooltip("Temps en secondes à attendre après la téléportation avant d'exécuter le move")]
+    // ⏱️ Délai ajouté avant toute timeline de préparation.
+    //    Permet d'insérer un temps mort contrôlé (par exemple pour une
+    //    annonce ou un effet visuel) avant que le move ne commence
+    //    réellement.
+    [Tooltip("Temps en secondes à attendre AVANT de lancer la timeline de préparation du move")]
     public float startDelay = 2f;
 
     [Header("Awake")]

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -326,7 +326,15 @@ public class RhythmQTEManager : MonoBehaviour
                           TimelineManager.Instance != null &&
                           casterAnimatorGO != null;
 
-        // Lance la timeline globale de caméra si présente.
+        // Éventuel délai de pré-animation.
+        // 🔄 Cette attente se produit désormais AVANT toute timeline
+        //     afin d'éviter un à-coup juste avant la téléportation.
+        //     Elle laisse ainsi le temps de mettre en place des effets
+        //     ou des annonces avant même le début de la préparation.
+        if (move.startDelay > 0f)
+            yield return new WaitForSeconds(move.startDelay);
+
+        // Lance la timeline globale de caméra si présente, une fois le délai écoulé.
         if (useOverlay)
             BattleTimelineManager.Instance.PlayTimeline(
                 move.fullTimeline,
@@ -345,10 +353,6 @@ public class RhythmQTEManager : MonoBehaviour
             move.performingTimeline == null && move.retreatTimeline == null,
             initialRotation);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay);
-
-        // Éventuel délai de pré-animation.
-        if (move.startDelay > 0f)
-            yield return new WaitForSeconds(move.startDelay);
 
         // Déplacement ou téléportation vers la cible.
         if (caster != null && target != null)


### PR DESCRIPTION
## Résumé
- Décale l'attente `startDelay` avant toute timeline afin de lancer la téléportation immédiatement après la préparation
- Documente le nouveau comportement de `startDelay` dans `MusicalMoveSO`

## Test
- `dotnet test` *(échec : commande indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_68c511ee9bec8325b9841341da2b6d2a