### PR TITLE
Ajout du MoveType Altération

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: MusicalMove_AbimeHarmonique
   m_EditorClassIdentifier: 
   moveName: "Ab\xEEme Harmonique"
-  moveType: 3
+  moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 0}
   description: "Fait dispara\xEEtre le sol sous la cible."

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: MusicalMove_PontHarmonique
   m_EditorClassIdentifier: 
   moveName: Pont Harmonique
-  moveType: 3
+  moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 0}
   description: "Cr\xE9e un sol temporaire sous la cible."

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -10,7 +10,21 @@ public class MusicalMoveSO : ScriptableObject
 {
     [Header("Identité")]
     public string moveName;
-    public enum MoveType { Empty, Attack, Buff, Debuff}
+
+    // Enumeration des catégories de moves disponibles dans le jeu.
+    // Chaque type permet de classer les actions pour offrir aux joueurs
+    // novices comme expérimentés une meilleure compréhension tactique.
+    public enum MoveType
+    {
+        Empty,      // Move factice utilisé comme espace réservé.
+        Attack,     // Mouvement offensif infligeant des dégâts directs.
+        Buff,       // Action accordant un effet bénéfique à un allié.
+        Debuff,     // Action affaiblissant un adversaire.
+        Alteration  // Modifie le terrain ou l'état d'une cible sans être
+                    // purement offensif ou défensif.
+    }
+
+    // Type actuel de l'action musicale.
     public MoveType moveType;
     [Tooltip("Vrai si l'attaque n'est disponible qu'en état Awake")]
     public bool onlyAwake = false;

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -16,6 +16,12 @@ Les MusicalMoves peuvent désormais spécifier une contrainte de hauteur :
 Cette classification aide les débutants à comprendre rapidement les restrictions tout en offrant aux joueurs avancés des
 combinaisons plus techniques impliquant des changements d'altitude.
 
+## Nouveau MoveType : Altération
+Ce type regroupe les actions qui transforment le terrain ou l'état d'une cible
+sans infliger directement un bonus ou un malus classique. Elles ouvrent des
+opportunités tactiques que les novices peuvent appréhender facilement tout en
+permettant aux vétérans de créer des enchaînements complexes.
+
 ## Timeline caméra continue
 Un champ `fullTimeline` est disponible dans chaque **MusicalMove** et désormais dans chaque **Item**. Il définit un
 mouvement de caméra couvrant l'ensemble de l'action (préparation, utilisation/exécution et repli) pour assurer un
@@ -72,14 +78,14 @@ fluide de l'action.
 - **Utilisation conseillée** : permet d'affaiblir tout un groupe d'ennemis avant d'utiliser des attaques ciblées plus puissantes.
 
 ## MusicalMove : Pont Harmonique
-- **Type** : Soutien
+- **Type** : Altération
 - **Effet** : crée un pont éphémère sous une cible volante afin de la considérer comme au sol.
 - **Coût** : 1 point d'harmonie et 1 point de fatigue.
 - **Gain** : aucun.
 - **Utilisation conseillée** : parfait pour les débutants qui peinent à atteindre les adversaires aériens. Les joueurs expérimentés pourront l'enchaîner avec des attaques terrestres pour réaliser des combinaisons originales.
 
 ## MusicalMove : Abîme Harmonique
-- **Type** : Débuff
+- **Type** : Altération
 - **Effet** : annule le sol sous la cible, la forçant à flotter et la rendant sensible aux stratégies aériennes.
 - **Coût** : 1 point d'harmonie et 1 point de fatigue.
 - **Gain** : aucun.


### PR DESCRIPTION
## Résumé
- ajout du MoveType `Alteration` dans `MusicalMoveSO` avec commentaires
- classification de Pont Harmonique et Abîme Harmonique en `Alteration`
- documentation mise à jour pour refléter le nouveau type

## Tests
- `apt-get update` *(échec : dépôts non signés)*
- `apt-get install -y dotnet-sdk-7.0` *(échec : paquet introuvable)*
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c51750d4588325b66135d842dbf840