### PR TITLE
Gestion de la gravité des unités en combat

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -19,6 +19,10 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Battlefield")]
     public int battlefieldIndex = 0; // Indice du battlefield dans la zone
 
+    [Header("Déplacement")]
+    [Tooltip("Vrai si l'unité évolue dans les airs et n'est pas affectée par la gravité.")]
+    public bool isAirUnit = false;
+
     [Header("Comportement en combat")]
     [Tooltip("Si vrai, ce personnage peut être intercepté lors de ses actions")]
     public bool interceptable = true;

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -3,6 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
+/// <summary>
+/// Représente une unité de combat. L'ajout d'un <see cref="CharacterController"/>
+/// permet de déléguer la gestion de la gravité à Unity pour plus de cohérence.
+/// </summary>
+[RequireComponent(typeof(CharacterController))]
 public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, IDebuffable
 {
     public CharacterData Data;
@@ -26,29 +31,29 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public bool IsAwake => awakeState != null && awakeState.IsAwake;
 
+    // Gestionnaire de physique pour déléguer les collisions et la gravité à Unity.
+    private CharacterController controller;
+    // Vitesse verticale utilisée pour la chute des unités terrestres.
+    private Vector3 fallVelocity = Vector3.zero;
+    // Intensité de la gravité appliquée.
+    private const float gravity = -9.81f;
+
     /// <summary>
-    /// Indique si l'unité touche actuellement le sol.
+    /// Indique si l'unité touche actuellement un support solide.
     /// </summary>
-    public bool IsGrounded
+    public bool IsGrounded => controller != null && controller.isGrounded;
+
+    /// <summary>
+    /// Indique si l'unité est de type aérien.
+    /// </summary>
+    public bool IsAirUnit => Data != null && Data.isAirUnit;
+
+    private void Awake()
     {
-        get
-        {
-            // Les unités en combat n'utilisent pas de CharacterController. On se base donc
-            // uniquement sur un raycast vertical pour détecter la présence d'un sol sous
-            // leurs pieds.
-
-            // Distance maximum pour rechercher le sol. Une petite valeur suffit car les
-            // unités sont légèrement au-dessus de la surface lorsqu'elles touchent le sol.
-            const float checkDistance = 0.1f;
-
-            // Effectue le raycast vers le bas depuis la position de l'unité.
-            if (Physics.Raycast(transform.position, Vector3.down, checkDistance))
-                return true;
-
-            // Aucun sol détecté : l'unité est considérée en l'air afin d'empêcher les
-            // mouvements réservés aux cibles terrestres de se déclencher à tort.
-            return false;
-        }
+        // S'assure qu'un CharacterController est présent pour gérer la physique.
+        controller = GetComponent<CharacterController>();
+        if (controller == null)
+            controller = gameObject.AddComponent<CharacterController>();
     }
 
     public CharacterType characterType => Data.characterType;
@@ -185,6 +190,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         HandleDeath();
         HandleCustomBarValue();
+        ApplyGravity();
     }
 
     void HandleCustomBarValue()
@@ -196,6 +202,31 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
                 customBar.SetValue(concentration.currentConcentration);
             else
                 customBar.SetValue(currentFatigue);
+        }
+    }
+
+    /// <summary>
+    /// Applique une gravité basique aux unités terrestres afin qu'elles tombent
+    /// naturellement lorsqu'elles ne sont plus soutenues.
+    /// </summary>
+    private void ApplyGravity()
+    {
+        // Les unités aériennes ne sont pas soumises à la gravité.
+        if (IsAirUnit || controller == null)
+            return;
+
+        if (controller.isGrounded)
+        {
+            // Lorsque l'unité touche le sol, on réinitialise la vitesse de chute
+            // afin d'éviter une accumulation négative.
+            if (fallVelocity.y < 0f)
+                fallVelocity.y = -2f; // Petite force vers le bas pour coller au sol
+        }
+        else
+        {
+            // Accumule la gravité au fil du temps lorsque l'unité est en l'air.
+            fallVelocity.y += gravity * Time.deltaTime;
+            controller.Move(fallVelocity * Time.deltaTime);
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1097,11 +1097,11 @@ public class NewBattleManager : MonoBehaviour
         switch (move.altitudeCondition)
         {
             case AltitudeCondition.AirOnly:
-                // Mouvement aérien : uniquement si la cible ne touche pas le sol.
-                return !target.IsGrounded;
+                // Attaque réservée aux unités aériennes ou aux unités momentanément en l'air.
+                return target.IsAirUnit || !target.IsGrounded;
             case AltitudeCondition.GroundOnly:
-                // Mouvement terrien : uniquement si la cible est au sol.
-                return target.IsGrounded;
+                // Attaque réservée aux unités terrestres posées sur un support.
+                return !target.IsAirUnit && target.IsGrounded;
             default:
                 // Aucune restriction : mouvement utilisable dans toutes les configurations.
                 return true;


### PR DESCRIPTION
## Résumé
- Ajout d'un indicateur `isAirUnit` pour différencier les unités terrestres et aériennes.
- Intégration d'un `CharacterController` dans `CharacterUnit` avec gestion de la chute via la gravité Unity.
- Adaptation du gestionnaire de combat pour tenir compte de l'altitude et du type d'unité.

## Tests
- `dotnet test` *(échoue : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68c52335f6d08325abc326c24138e568