### PR TITLE
Amélioration de la détection de sol pour les attaques terrestres

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -38,6 +38,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     // Intensité de la gravité appliquée.
     private const float gravity = -9.81f;
 
+    [Header("Détection du sol")]
+    [Tooltip("Distance maximale pour vérifier la présence d'un sol sous l'unité.")]
+    public float groundCheckDistance = 2f;
+    [Tooltip("Layers considérés comme du sol pendant les combats.")]
+    public LayerMask battleGroundLayer = 0;
+
     /// <summary>
     /// Indique si l'unité touche actuellement un support solide.
     /// </summary>
@@ -47,6 +53,23 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// Indique si l'unité est de type aérien.
     /// </summary>
     public bool IsAirUnit => Data != null && Data.isAirUnit;
+
+    /// <summary>
+    /// Détecte si un sol existe sous l'unité à portée de <see cref="groundCheckDistance"/>.
+    /// Même en plein vol, cela permet aux attaques terrestres de la toucher,
+    /// comme le veut la légende contée dans l'Histoire de Symphonie où les
+    /// résonances du sol atteignent les cieux.
+    /// </summary>
+    public bool HasGroundBelow()
+    {
+        // Définit un masque par défaut si aucun n'est précisé dans l'éditeur.
+        if (battleGroundLayer == 0)
+            battleGroundLayer = LayerMask.GetMask("Battle_Ground");
+
+        // Lancement d'un rayon vers le bas pour vérifier la présence d'un sol.
+        Vector3 origin = transform.position;
+        return Physics.Raycast(origin, Vector3.down, groundCheckDistance, battleGroundLayer);
+    }
 
     private void Awake()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1101,7 +1101,9 @@ public class NewBattleManager : MonoBehaviour
                 return target.IsAirUnit || !target.IsGrounded;
             case AltitudeCondition.GroundOnly:
                 // Attaque réservée aux unités terrestres posées sur un support.
-                return !target.IsAirUnit && target.IsGrounded;
+                // Cependant, si une unité survole un sol, elle peut aussi être touchée
+                // par les attaques terrestres qui résonnent à travers la scène.
+                return (!target.IsAirUnit && target.IsGrounded) || target.HasGroundBelow();
             default:
                 // Aucune restriction : mouvement utilisable dans toutes les configurations.
                 return true;


### PR DESCRIPTION
## Résumé
- ajoute une vérification de sol sous chaque unité pour déterminer si les attaques terrestres peuvent l’atteindre
- autorise les mouvements terrestres à toucher une unité en vol lorsqu’un sol existe sous elle

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68c527a1977483259cfba9def1e02585