### PR TITLE
Amélioration de la détection de sol pour les attaques terrestres

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -38,6 +38,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     // Intensité de la gravité appliquée.
     private const float gravity = -9.81f;
 
+    [Header("Détection du sol")]
+    [Tooltip("Distance maximale pour vérifier la présence d'un sol sous l'unité.")]
+    public float groundCheckDistance = 2f;
+    [Tooltip("Layers considérés comme du sol pendant les combats.")]
+    public LayerMask battleGroundLayer = 0;
+
     /// <summary>
     /// Indique si l'unité touche actuellement un support solide.
     /// </summary>
@@ -47,6 +53,25 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// Indique si l'unité est de type aérien.
     /// </summary>
     public bool IsAirUnit => Data != null && Data.isAirUnit;
+
+    /// <summary>
+    /// Détecte si un sol existe sous l'unité à portée de <see cref="groundCheckDistance"/>.
+    /// Cette information sert non seulement à permettre aux attaques terrestres
+    /// d'atteindre une cible en vol lorsqu'un support se trouve sous elle,
+    /// mais aussi à empêcher toute attaque aérienne lorsque la moindre surface
+    /// solide est détectée, fidèle au récit de l'Histoire de Symphonie où les
+    /// résonances du sol répondent aux cieux.
+    /// </summary>
+    public bool HasGroundBelow()
+    {
+        // Définit un masque par défaut si aucun n'est précisé dans l'éditeur.
+        if (battleGroundLayer == 0)
+            battleGroundLayer = LayerMask.GetMask("Battle_Ground");
+
+        // Lancement d'un rayon vers le bas pour vérifier la présence d'un sol.
+        Vector3 origin = transform.position;
+        return Physics.Raycast(origin, Vector3.down, groundCheckDistance, battleGroundLayer);
+    }
 
     private void Awake()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -215,8 +215,8 @@ public class InputsManager : MonoBehaviour
             {
                 if (bm.currentMove.altitudeCondition == AltitudeCondition.AirOnly)
                 {
-                    // Indique que la cible doit être aérienne.
-                    instructions.Add("La cible doit être en l'air");
+                    // Indique que la cible doit être en l'air sans aucun sol sous elle.
+                    instructions.Add("La cible doit être en l'air sans sol sous elle");
                 }
                 else if (bm.currentMove.altitudeCondition == AltitudeCondition.GroundOnly)
                 {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -919,7 +919,7 @@ public class NewBattleManager : MonoBehaviour
         {
             // Message spécifique selon la contrainte de hauteur définie sur le move.
             if (move.altitudeCondition == AltitudeCondition.AirOnly)
-                ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être en l'air");
+                ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être en l'air sans sol sous elle");
             else if (move.altitudeCondition == AltitudeCondition.GroundOnly)
                 ActionUIDisplayManager.Instance.DisplayInstruction("La cible doit être au sol");
             yield break;
@@ -1097,11 +1097,16 @@ public class NewBattleManager : MonoBehaviour
         switch (move.altitudeCondition)
         {
             case AltitudeCondition.AirOnly:
-                // Attaque réservée aux unités aériennes ou aux unités momentanément en l'air.
-                return target.IsAirUnit || !target.IsGrounded;
+                // Attaque réservée aux unités sans aucun sol sous elles.
+                // Qu'une unité soit terrestre ou aérienne, la présence d'un support
+                // en contrebas la protège de ce type d'assaut venu du ciel.
+                return !target.HasGroundBelow();
             case AltitudeCondition.GroundOnly:
                 // Attaque réservée aux unités terrestres posées sur un support.
-                return !target.IsAirUnit && target.IsGrounded;
+                // Cependant, si une unité survole un sol, elle peut aussi être touchée
+                // par les attaques terrestres qui résonnent à travers la scène,
+                // tandis qu'elle devient intouchable par les attaques aériennes.
+                return (!target.IsAirUnit && target.IsGrounded) || target.HasGroundBelow();
             default:
                 // Aucune restriction : mouvement utilisable dans toutes les configurations.
                 return true;


### PR DESCRIPTION
## Résumé
- empêche les attaques aériennes de toucher une cible ayant un sol sous elle
- ajuste la validation d'altitude et les messages d'erreur en conséquence

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68c527a1977483259cfba9def1e02585