### PR TITLE
Ajout du booléen de déplacement pour moves et items

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -17,6 +17,9 @@ public class ItemData : ScriptableObject
     public float moveSpeed;
     public float castDistance;
 
+    [Tooltip("Si vrai, l'utilisateur doit se déplacer ou se téléporter vers la cible pour l'utiliser")]
+    public bool requiresMovement = true;
+
     [Header("Effets spéciaux")]
     // Délai entre disparition et réapparition lors d'un téléport
     // Utile pour synchroniser les effets visuels/sonores

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -90,6 +90,9 @@ public class MusicalMoveSO : ScriptableObject
     public float moveSpeed = 20f;
     public float castDistance;
 
+    [Tooltip("Si vrai, le lanceur doit se déplacer ou se téléporter pour exécuter ce move")]
+    public bool requiresMovement = true;
+
     // Temps entre la disparition et la réapparition lors d'une téléportation
     // Permet de laisser les effets visuels/sonores se jouer avant le déplacement
     [Tooltip("Délai en secondes entre la disparition et la réapparition (0 = instantané)")]

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -354,9 +354,16 @@ public class RhythmQTEManager : MonoBehaviour
             initialRotation);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay);
 
-        // Déplacement ou téléportation vers la cible.
-        if (caster != null && target != null)
+        // Déplacement ou téléportation vers la cible si nécessaire.
+        if (move.requiresMovement && caster != null && target != null)
             yield return MoveTo(caster, target, move);
+        else if (caster != null && target != null)
+        {
+            // Sans déplacement, on oriente simplement le lanceur vers sa cible
+            Vector3 dir = (target.transform.position - caster.transform.position).normalized;
+            if (dir != Vector3.zero)
+                caster.transform.forward = dir;
+        }
 
         // --- Phase d'exécution ---
         StartTimelinePhase(
@@ -393,7 +400,7 @@ public class RhythmQTEManager : MonoBehaviour
         yield return WaitForTimelinePhase(move.performingTimeline, useOverlay);
 
         // --- Retour ou téléportation de repli ---
-        if (!move.stayInPlace && caster != null && target != null)
+        if (move.requiresMovement && !move.stayInPlace && caster != null && target != null)
             yield return ReturnToInitialPosition(move, caster, target, originPosition);
 
         // --- Phase de repli ---
@@ -500,8 +507,15 @@ public class RhythmQTEManager : MonoBehaviour
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay);
 
         // Déplacement ou téléportation éventuel vers la cible.
-        if (caster != null && target != null)
+        if (item.requiresMovement && caster != null && target != null)
             yield return SimpleMoveTo(caster, target, item);
+        else if (caster != null && target != null)
+        {
+            // Sans déplacement, on oriente simplement l'utilisateur vers sa cible
+            Vector3 dir = (target.transform.position - caster.transform.position).normalized;
+            if (dir != Vector3.zero)
+                caster.transform.forward = dir;
+        }
 
         // --- Phase d'utilisation ---
         StartTimelinePhase(
@@ -529,7 +543,7 @@ public class RhythmQTEManager : MonoBehaviour
         yield return WaitForTimelinePhase(item.performingTimeline, useOverlay);
 
         // --- Retour à la position d'origine ---
-        if (!item.stayInPlace && caster != null && target != null)
+        if (item.requiresMovement && !item.stayInPlace && caster != null && target != null)
             yield return SimpleReturnToInitialPosition(caster, target, item, originPosition);
 
         // --- Phase de repli ---

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -38,6 +38,14 @@ préparation, d'exécution et de repli se succèdent automatiquement en parallè
 fin de la préparation et le début de l'exécution ainsi qu'entre l'exécution et le repli afin d'assurer un enchaînement
 fluide de l'action.
 
+## Déplacement optionnel
+Un booléen `requiresMovement` est présent dans chaque **MusicalMove** et **Item**.
+- `true` : le lanceur se déplace ou se téléporte pour atteindre sa cible.
+- `false` : l'action se déclenche sans déplacement, évitant toute téléportation.
+
+Cette option rend le jeu plus accessible en autorisant des actions à distance simples tout en offrant aux joueurs avancés
+des possibilités de combinaisons qui n'imposent plus un repositionnement systématique.
+
 ## MusicalMove : Crescendo Fulgurant
 - **Type** : Attaque
 - **Effet** : inflige 30 points de dégâts à une cible unique.


### PR DESCRIPTION
## Résumé
- Ajout du champ `requiresMovement` aux ScriptableObjects `MusicalMoveSO` et `ItemData`
- Adaptation des routines d'exécution pour éviter les téléportations inutiles
- Documentation mise à jour sur l'option de déplacement

## Tests
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c52be9656c8325b8422a8f0be6cb44