### PR TITLE
Retrait de effectPrefab et gestion des effets via la timeline

### DIFF
--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
@@ -39,7 +39,6 @@ MonoBehaviour:
   targetTypes: 
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 5
   teleportDelay: 1

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
@@ -39,7 +39,6 @@ MonoBehaviour:
   targetTypes: 
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
@@ -39,7 +39,6 @@ MonoBehaviour:
   targetTypes: 
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -36,9 +36,8 @@ MonoBehaviour:
   targetType: 1
   defaultTargetType: 1
   targetTypes: 01000000
-  effectType: 9
+  effectType: 0
   effectValue: 0
-  effectPrefab: {fileID: 100000, guid: 6e5de56a4c4f4adbb612238f8f4ad971, type: 3}
   moveSpeed: 20
   castDistance: 1.5
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
+++ b/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
@@ -39,7 +39,6 @@ MonoBehaviour:
   targetTypes: 03000000
   effectType: 1
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
+++ b/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 04000000
   effectType: 1
   effectValue: 20
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 50
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
+++ b/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
@@ -39,7 +39,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 30
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 2
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 1.5
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
+++ b/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 5
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 0100000003000000
   effectType: 0
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 1
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 7
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   harmonicCost: 1
   harmonicGeneration: 0
   power: 0
-  effectType: 8
+  effectType: 0
   effectValue: 0
   useCriticalVariant: 0
   criticalEffectType: 0
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetType: 1
   defaultTargetType: 1
   targetTypes: 01000000
-  effectPrefab: {fileID: 100000, guid: a9e8b7c3f95d4f278b1a412be0c8e3a1, type: 3}
   moveSpeed: 0
   castDistance: 0
   requiresMovement: 0

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 03000000
   effectType: 6
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 0
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 1.5
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
+++ b/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 10
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 1.5
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 0
   effectValue: 20
-  effectPrefab: {fileID: 0}
   moveSpeed: 0
   castDistance: 2
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 4
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 1.5
   teleportDelay: 0.2

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -38,7 +38,6 @@ MonoBehaviour:
   targetTypes: 01000000
   effectType: 4
   effectValue: 0
-  effectPrefab: {fileID: 0}
   moveSpeed: 20
   castDistance: 1
   teleportDelay: 0.2

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -81,9 +81,9 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Liste de tous les ciblages possibles pour ce move")]
     public List<TargetType> targetTypes = new List<TargetType>() { TargetType.SingleEnemy };
 
-    [Header("Effets spéciaux et déplacement")]
-    [Tooltip("Prefab instancié pour certains effets spéciaux comme la création ou la suppression de sol.")]
-    public GameObject effectPrefab;
+    [Header("Déplacement")]
+    // La gestion des effets visuels est désormais confiée à la timeline,
+    // seul le déplacement reste paramétrable dans ce ScriptableObject.
     [Tooltip("Vitesse de déplacement du lanceur lors de l'exécution du move")]
     public float moveSpeed = 20f;
     [Tooltip("Distance maximale de lancement lorsque le move le nécessite")]
@@ -208,27 +208,9 @@ public class MusicalMoveSO : ScriptableObject
             if (target.GetComponent<LinkMark>() == null)
                 target.gameObject.AddComponent<LinkMark>();
         }
-        else if (typeToUse == MusicalEffectType.SpawnGround)
-        {
-            // Crée un sol temporaire sous la cible afin de permettre l'utilisation de moves terrestres
-            // sur des unités normalement en vol.
-            if (effectPrefab != null && target != null)
-            {
-                GameObject ground = Instantiate(effectPrefab, target.transform.position, Quaternion.identity);
-                // Assure que l'objet utilise bien le layer Battle_Ground pour être reconnu comme sol.
-                ground.layer = LayerMask.NameToLayer("Battle_Ground");
-            }
-        }
-        else if (typeToUse == MusicalEffectType.RemoveGround)
-        {
-            // Supprime visuellement le sol sous la cible en instanciant un prefab dédié,
-            // la forçant ainsi à être considérée comme aérienne.
-            if (effectPrefab != null && target != null)
-            {
-                Instantiate(effectPrefab, target.transform.position, Quaternion.identity);
-            }
-        }
-
+        // Les effets visuels comme la création ou la suppression de sol sont
+        // désormais entièrement gérés par la timeline, aucune instanciation
+        // de prefab n'est nécessaire ici.
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
             caster.GetComponent<FatigueSystem>()?.OnActionPerformed(fatigueToApply);
@@ -249,7 +231,7 @@ public enum MoveType
     Alteration  // Modifie le terrain ou l'état d'une cible sans être purement offensif ou défensif.
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark, SpawnGround, RemoveGround }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
 
 public enum RelativePosition { Front, Back, Left, Right , NC}
 


### PR DESCRIPTION
## Résumé
- Supprime le champ `effectPrefab` de `MusicalMoveSO` et délègue les effets visuels à la timeline
- Nettoie tous les assets de `MusicalMove` pour enlever les références à `effectPrefab`
- Ajuste les moves PontHarmonique et AbimeHarmonique à un type d'effet neutre

## Tests
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : 403 Forbidden lors de l'accès aux dépôts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5358fce2c8325b9a198561dc670e4