### PR TITLE
Gère les signaux pour la timeline du lanceur

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/Timeline_PontHarmonique_Performing.playable
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/Timeline_PontHarmonique_Performing.playable
@@ -132,22 +132,6 @@ MonoBehaviour:
   m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
   m_Rotation: {x: 0, y: 0, z: 0, w: 1}
   m_ApplyOffsets: 0
---- !u!114 &-2162983033640524082
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
-  m_Name: Signal Emitter
-  m_EditorClassIdentifier: 
-  m_Time: 1
-  m_Retroactive: 0
-  m_EmitOnce: 0
-  m_Asset: {fileID: 11400000, guid: 4fe02b1c980fde04e875a745c5df5743, type: 2}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -170,13 +171,36 @@ public class BattleTimelineManager : MonoBehaviour
 
         directorCaster.playableAsset = timeline;
 
-        // Binding explicite des pistes vers l'Animator ou le GameObject du lanceur.
+        // Binding explicite des pistes vers l'Animator, le GameObject du lanceur
+        // ou encore le SignalReceiver associé au PlayableDirector.
         foreach (var output in timeline.outputs)
         {
+            // 🔍 Type attendu par la piste (Animator, SignalReceiver, etc.)
+            Type type = output.outputTargetType;
             string lower = output.streamName.ToLower();
-            if (lower.Contains("camera"))
-                continue; // Les pistes caméra sont ignorées ici.
 
+            // Les pistes caméra sont ignorées dans ce director spécialisé.
+            if (lower.Contains("camera"))
+                continue;
+
+            // ✅ Gestion spécifique des pistes de Signaux : on les relie au
+            // SignalReceiver présent sur le PlayableDirector pour que les
+            // événements de la timeline soient correctement reçus.
+            if (type != null && typeof(Component).IsAssignableFrom(type) && type.Name.Contains("SignalReceiver"))
+            {
+                Component receiver = directorCaster.GetComponent(type);
+                if (receiver != null)
+                {
+                    directorCaster.SetGenericBinding(output.sourceObject, receiver);
+                }
+                else
+                {
+                    Debug.LogWarning($"[BattleTimelineManager] {type.Name} manquant sur {directorCaster.gameObject.name} pour la timeline.");
+                }
+                continue; // Rien d'autre à faire pour cette piste
+            }
+
+            // 🎭 Pistes d'animation : on tente de lier un Animator du lanceur
             if (lower.Contains("caster") || lower.Contains("pnj"))
             {
                 if (caster == null)
@@ -190,6 +214,7 @@ public class BattleTimelineManager : MonoBehaviour
             }
             else
             {
+                // 🧍 Autres pistes : on relie simplement le GameObject du lanceur
                 if (caster != null)
                     directorCaster.SetGenericBinding(output.sourceObject, caster);
             }


### PR DESCRIPTION
## Summary
- Ajout d'un binding automatique des SignalReceiver dans `BattleTimelineManager`
- Nettoyage de la timeline `Timeline_PontHarmonique_Performing` pour ne garder que le bon signal

## Testing
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68c53e0ea9088325ac8ec45bd622ea72