### PR TITLE
feat: choisir l'instanciation sur caster ou target

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
@@ -22,26 +22,65 @@ public class InstantiateGameObject : MonoBehaviour
     }
 
     /// <summary>
-    /// Instancie un GameObject depuis une timeline ou un autre système externe.
+    /// Surcharge conservée pour compatibilité : instancie par défaut sur le
+    /// lanceur de l'action (caster) si aucun paramètre de cible n'est fourni.
     /// </summary>
     /// <param name="gameObjectToInstantiate">Prefab à instancier.</param>
     public void InstantiateFromTimeline(GameObject gameObjectToInstantiate)
     {
-        // Vérifie les références avant d'instancier pour éviter les NullReferenceException
-        Vector3 spawnPosition; // Position d'apparition du VFX
+        InstantiateFromTimeline(gameObjectToInstantiate, false);
+    }
 
-        if (NewBattleManager.Instance != null && NewBattleManager.Instance.currentCharacterUnit != null)
+    /// <summary>
+    /// Instancie un <see cref="GameObject"/> depuis une Timeline, en choisissant
+    /// s'il doit apparaître sur le lanceur de l'action (caster) ou sur la cible
+    /// actuellement sélectionnée.
+    /// </summary>
+    /// <param name="gameObjectToInstantiate">Prefab à instancier.</param>
+    /// <param name="spawnOnTarget">
+    ///     Si <c>true</c>, l'objet est instancié sur la cible actuelle.
+    ///     Sinon, il apparaît sur le lanceur de l'action.
+    /// </param>
+    public void InstantiateFromTimeline(GameObject gameObjectToInstantiate, bool spawnOnTarget)
+    {
+        // Détermination de la position d'apparition en fonction du paramètre
+        // "spawnOnTarget". On tente d'abord de récupérer les unités impliquées
+        // via le NewBattleManager ; si elles sont absentes (par exemple en dehors
+        // d'un combat), on se rabat sur le GameObject porteur du script.
+
+        Vector3 spawnPosition = transform.position; // Position par défaut : objet porteur
+
+        if (NewBattleManager.Instance != null)
         {
-            // Positionne le VFX sur l'unité actuellement active
-            spawnPosition = NewBattleManager.Instance.currentCharacterUnit.transform.position;
+            // Référence vers le lanceur (caster) et la cible
+            var caster = NewBattleManager.Instance.currentCharacterUnit;
+            var target = NewBattleManager.Instance.currentTargetCharacter;
+
+            if (spawnOnTarget && target != null)
+            {
+                // Instanciation au niveau de la cible actuelle
+                spawnPosition = target.transform.position;
+            }
+            else if (!spawnOnTarget && caster != null)
+            {
+                // Instanciation au niveau du lanceur (par défaut)
+                spawnPosition = caster.transform.position;
+            }
+            else
+            {
+                // Cas où les références sont manquantes : on utilise le
+                // GameObject courant et on log un avertissement pour faciliter
+                // le débogage.
+                Debug.LogWarning("[InstantiateGameObject] Références 'caster' ou 'target' introuvables. Instanciation sur le porteur de script.");
+            }
         }
         else
         {
-            // En cas d'absence du gestionnaire ou de l'unité, on le place sur le lanceur de timeline
-            spawnPosition = transform.position;
-            Debug.LogWarning("[InstantiateGameObject] NewBattleManager ou currentCharacterUnit introuvable, instanciation au niveau du TimelineManager.");
+            // Pas de gestionnaire de combat : contexte non prévu (ex. cinématique).
+            Debug.LogWarning("[InstantiateGameObject] NewBattleManager introuvable, instanciation sur le porteur de script.");
         }
 
+        // Instancie finalement le prefab si fourni.
         if (gameObjectToInstantiate != null)
         {
             Instantiate(gameObjectToInstantiate, spawnPosition, Quaternion.identity);


### PR DESCRIPTION
## Résumé
- permettre à une Timeline d'instancier un objet sur le lanceur ou sur la cible
- conserver une méthode d'instanciation par défaut pour compatibilité

## Test
- `npm test` (échoué : package.json manquant)
- `dotnet test` (échoué : commande introuvable)


------
https://chatgpt.com/codex/tasks/task_e_68c5419673b88325bc5c663c5e71cba1