### PR TITLE
feat: choisir l'instanciation sur caster ou target

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
@@ -22,26 +22,87 @@ public class InstantiateGameObject : MonoBehaviour
     }
 
     /// <summary>
-    /// Instancie un GameObject depuis une timeline ou un autre système externe.
+    /// Instancie un <see cref="GameObject"/> depuis une Timeline. La position
+    /// d'apparition est déterminée par un éventuel composant
+    /// <see cref="TimelineInstantiationParameters"/> présent sur le prefab
+    /// (voir la classe correspondante), permettant de choisir entre le lanceur
+    /// de l'action (caster) et la cible actuelle (target).
     /// </summary>
     /// <param name="gameObjectToInstantiate">Prefab à instancier.</param>
     public void InstantiateFromTimeline(GameObject gameObjectToInstantiate)
     {
-        // Vérifie les références avant d'instancier pour éviter les NullReferenceException
-        Vector3 spawnPosition; // Position d'apparition du VFX
+        // Par défaut, on instancie sur le lanceur. Ce comportement peut être
+        // redéfini par la présence d'un composant TimelineInstantiationParameters
+        // sur le prefab fourni.
+        bool spawnOnTarget = false;
 
-        if (NewBattleManager.Instance != null && NewBattleManager.Instance.currentCharacterUnit != null)
+        if (gameObjectToInstantiate != null)
         {
-            // Positionne le VFX sur l'unité actuellement active
-            spawnPosition = NewBattleManager.Instance.currentCharacterUnit.transform.position;
+            // Tentative de récupération des paramètres d'instanciation sur le prefab.
+            var parameters = gameObjectToInstantiate.GetComponent<TimelineInstantiationParameters>();
+            if (parameters != null)
+            {
+                spawnOnTarget = parameters.spawnOnTarget;
+            }
+        }
+
+        // Appel à la variante détaillée permettant d'instancier en tenant compte
+        // de la cible désirée.
+        InstantiateFromTimeline(gameObjectToInstantiate, spawnOnTarget);
+    }
+
+    /// <summary>
+    /// Variante permettant d'instancier un prefab en choisissant explicitement
+    /// s'il doit apparaître sur le lanceur (caster) ou sur la cible actuelle
+    /// (target). Utile en dehors des Timelines lorsque l'on souhaite forcer une
+    /// position spécifique sans passer par le composant
+    /// <see cref="TimelineInstantiationParameters"/>.
+    /// </summary>
+    /// <param name="gameObjectToInstantiate">Prefab à instancier.</param>
+    /// <param name="spawnOnTarget">
+    ///     Si <c>true</c>, l'objet est instancié sur la cible actuelle.
+    ///     Sinon, il apparaît sur le lanceur de l'action.
+    /// </param>
+    public void InstantiateFromTimeline(GameObject gameObjectToInstantiate, bool spawnOnTarget)
+    {
+        // Détermination de la position d'apparition en fonction du paramètre
+        // "spawnOnTarget". On tente d'abord de récupérer les unités impliquées
+        // via le NewBattleManager ; si elles sont absentes (par exemple en dehors
+        // d'un combat), on se rabat sur le GameObject porteur du script.
+
+        Vector3 spawnPosition = transform.position; // Position par défaut : objet porteur
+
+        if (NewBattleManager.Instance != null)
+        {
+            // Référence vers le lanceur (caster) et la cible
+            var caster = NewBattleManager.Instance.currentCharacterUnit;
+            var target = NewBattleManager.Instance.currentTargetCharacter;
+
+            if (spawnOnTarget && target != null)
+            {
+                // Instanciation au niveau de la cible actuelle
+                spawnPosition = target.transform.position;
+            }
+            else if (!spawnOnTarget && caster != null)
+            {
+                // Instanciation au niveau du lanceur (par défaut)
+                spawnPosition = caster.transform.position;
+            }
+            else
+            {
+                // Cas où les références sont manquantes : on utilise le
+                // GameObject courant et on log un avertissement pour faciliter
+                // le débogage.
+                Debug.LogWarning("[InstantiateGameObject] Références 'caster' ou 'target' introuvables. Instanciation sur le porteur de script.");
+            }
         }
         else
         {
-            // En cas d'absence du gestionnaire ou de l'unité, on le place sur le lanceur de timeline
-            spawnPosition = transform.position;
-            Debug.LogWarning("[InstantiateGameObject] NewBattleManager ou currentCharacterUnit introuvable, instanciation au niveau du TimelineManager.");
+            // Pas de gestionnaire de combat : contexte non prévu (ex. cinématique).
+            Debug.LogWarning("[InstantiateGameObject] NewBattleManager introuvable, instanciation sur le porteur de script.");
         }
 
+        // Instancie finalement le prefab si fourni.
         if (gameObjectToInstantiate != null)
         {
             Instantiate(gameObjectToInstantiate, spawnPosition, Quaternion.identity);

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Paramètres utilisés lors de l'instanciation d'un prefab depuis une Timeline.
+/// Ce composant doit être placé sur les prefabs qui seront instanciés afin de
+/// préciser s'ils doivent apparaître sur le lanceur (caster) ou sur la cible
+/// actuelle (target).
+/// </summary>
+public class TimelineInstantiationParameters : MonoBehaviour
+{
+    [Tooltip("Si vrai, le prefab sera instancié sur la cible (target) actuelle. Sinon il apparaîtra sur le lanceur (caster).")]
+    public bool spawnOnTarget = false;
+}

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a30a20661737496da060243229926737


### PR DESCRIPTION
## Résumé
- permettre à une Timeline d'instancier un objet sur le lanceur ou sur la cible via un composant dédié
- conserver une méthode d'instanciation explicite pour les cas spéciaux

## Test
- `npm test` (échoué : package.json manquant)
- `dotnet test` (échoué : commande introuvable)

------
https://chatgpt.com/codex/tasks/task_e_68c5419673b88325bc5c663c5e71cba1