### PR TITLE
feat: navigation des competences avec PlayerInputs

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -21,6 +21,7 @@ public class InputsManager : MonoBehaviour
 
     private InputActionMap[] allMaps;
 
+
     /// <summary>
     /// Indique si les validations doivent être temporairement ignorées.
     /// Cette variable passe à <c>true</c> lorsqu'une compétence ou un objet est
@@ -73,6 +74,9 @@ public class InputsManager : MonoBehaviour
             playerInputs.InfoBox.Get(),
             playerInputs.Menu.Get()
         };
+
+        // Les actions LeftShoulder et RightShoulder sont désormais définies dans
+        // l'asset PlayerInputs. Elles seront reliées aux callbacks dans SetInputs().
     }
 
     /// <summary>
@@ -105,6 +109,9 @@ public class InputsManager : MonoBehaviour
         battle.Confirm.canceled += OnConfirmCanceled;
         battle.EnemiesGroupSelection.performed += OnEnemiesGroupSelection;
         battle.SquadGroupSelection.performed += OnSquadGroupSelection;
+        // Naviguer entre les pages de compétences avec les boutons d'épaules
+        battle.LeftShoulder.performed += OnPreviousSkillPage;
+        battle.RightShoulder.performed += OnNextSkillPage;
 
         var world = playerInputs.World;
         world.ForceCam.performed += OnForceCamInput;
@@ -129,6 +136,8 @@ public class InputsManager : MonoBehaviour
         battle.Confirm.canceled -= OnConfirmCanceled;
         battle.EnemiesGroupSelection.performed -= OnEnemiesGroupSelection;
         battle.SquadGroupSelection.performed -= OnSquadGroupSelection;
+        battle.LeftShoulder.performed -= OnPreviousSkillPage;
+        battle.RightShoulder.performed -= OnNextSkillPage;
 
         var world = playerInputs.World;
         world.ForceCam.performed -= OnForceCamInput;
@@ -157,6 +166,13 @@ public class InputsManager : MonoBehaviour
     void OnDestroy()
     {
         InputSystem.onDeviceChange -= OnDeviceChange;
+        // Nettoyage des abonnements aux boutons d'épaules
+        if (playerInputs != null)
+        {
+            var battle = playerInputs.Battle;
+            battle.LeftShoulder.performed -= OnPreviousSkillPage;
+            battle.RightShoulder.performed -= OnNextSkillPage;
+        }
     }
 
     /// <summary>
@@ -290,9 +306,10 @@ public class InputsManager : MonoBehaviour
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            if (bm.skillChoices.Count > 0)
+            int baseIndex = bm.currentSkillPageIndex * bm.currentSkillsMenuSlots.Count;
+            if (bm.skillChoices.Count > baseIndex)
             {
-                bm.currentMove = bm.skillChoices[0];
+                bm.currentMove = bm.skillChoices[baseIndex];
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
@@ -347,9 +364,10 @@ public class InputsManager : MonoBehaviour
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            if (bm.skillChoices.Count > 1)
+            int baseIndex = bm.currentSkillPageIndex * bm.currentSkillsMenuSlots.Count;
+            if (bm.skillChoices.Count > baseIndex + 1)
             {
-                bm.currentMove = bm.skillChoices[1];
+                bm.currentMove = bm.skillChoices[baseIndex + 1];
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
@@ -398,9 +416,10 @@ public class InputsManager : MonoBehaviour
 
         if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            if (bm.skillChoices.Count > 2)
+            int baseIndex = bm.currentSkillPageIndex * bm.currentSkillsMenuSlots.Count;
+            if (bm.skillChoices.Count > baseIndex + 2)
             {
-                bm.currentMove = bm.skillChoices[2];
+                bm.currentMove = bm.skillChoices[baseIndex + 2];
                 if (bm.currentCharacterUnit.GetHarmonicCount(bm.currentCharacterUnit.Data.harmonicType) < bm.currentMove.harmonicCost)
                 {
                     ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
@@ -465,6 +484,26 @@ public class InputsManager : MonoBehaviour
         // Active l'état Awake et rafraîchit les compétences disponibles
         unit.EnterAwakeState();
         bm.OpenSkillsMenu();
+    }
+
+    /// <summary>
+    /// Appelé lorsque le joueur presse l'épaule droite pour afficher la page suivante de compétences.
+    /// </summary>
+    private void OnNextSkillPage(InputAction.CallbackContext ctx)
+    {
+        NewBattleManager bm = NewBattleManager.Instance;
+        if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
+            bm.NextSkillPage();
+    }
+
+    /// <summary>
+    /// Appelé lorsque le joueur presse l'épaule gauche pour afficher la page précédente de compétences.
+    /// </summary>
+    private void OnPreviousSkillPage(InputAction.CallbackContext ctx)
+    {
+        NewBattleManager bm = NewBattleManager.Instance;
+        if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
+            bm.PreviousSkillPage();
     }
 
     private void OnBackInput(InputAction.CallbackContext ctx)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -230,6 +230,9 @@ public class NewBattleManager : MonoBehaviour
     [HideInInspector] public ItemData currentItem;
     [HideInInspector] public TargetType currentItemTargetType;
     public int currentMenuIndex;
+    // Index de la page actuellement affichée dans le SkillsMenu.
+    // Chaque page contient autant de compétences que de slots disponibles.
+    [HideInInspector] public int currentSkillPageIndex = 0;
     // Sélection nulle pour remplir les emplacements vides
     public MusicalMoveSO emptyMove;
 
@@ -1906,41 +1909,85 @@ public class NewBattleManager : MonoBehaviour
         ToggleMenuContainers(false, true, false);
         currentMenuIndex = 0;
 
+        // Réinitialise la page affichée
+        currentSkillPageIndex = 0;
+
+        // Récupère toutes les compétences disponibles pour l'unité
         skillChoices = currentCharacterUnit.Data.musicalAttacks
             .Where(m => !m.onlyAwake || currentCharacterUnit.IsAwake)
             .Where(m => !m.enterAwake || !currentCharacterUnit.IsAwake)
             .Where(m => currentCharacterUnit.CanUseMove(m))
             .ToList();
 
-        // Ajoute le move spécial s'il existe et est autorisé
+        // Ajoute le mouvement spécial s'il existe et est autorisé
         if (currentCharacterUnit.Data.specialMusicalMove != null &&
             currentCharacterUnit.CanUseMove(currentCharacterUnit.Data.specialMusicalMove))
             skillChoices.Add(currentCharacterUnit.Data.specialMusicalMove);
 
-        // 7) Création des boutons de compétences
-        for (int i = 0; i < skillChoices.Count && i < currentSkillsMenuSlots.Count; i++)
-        {
-            var move = skillChoices[i];
-            UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
+        // Affiche la première page de compétences
+        RefreshSkillsMenuDisplay();
+    }
 
-            bool enoughHarmonic = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= move.harmonicCost;
-            bool resonanceOk = true;
-            if (move.enterAwake)
-                resonanceOk = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.resonancePoint;
-            bool usageOk = currentCharacterUnit.CanUseMove(move);
-            bool available = enoughHarmonic && resonanceOk && usageOk;
-            bool highlight = move == currentCharacterUnit.Data.specialMusicalMove && available;
-            SetButtonAvailability(currentSkillsMenuSlots[i], available, highlight);
-        }
-        // Indique les emplacements vides
-        for (int j = skillChoices.Count; j < currentSkillsMenuSlots.Count; j++)
+    /// <summary>
+    /// Rafraîchit l'affichage des compétences selon la page courante.
+    /// </summary>
+    public void RefreshSkillsMenuDisplay()
+    {
+        int pageSize = currentSkillsMenuSlots.Count;
+        int startIndex = currentSkillPageIndex * pageSize;
+
+        // Parcourt chaque slot disponible pour afficher la compétence correspondante
+        for (int i = 0; i < pageSize; i++)
         {
-            if (emptyMove != null)
-                UpdateButton(currentSkillsMenuSlots[j], emptyMove.moveName, emptyMove.moveIcon);
+            int globalIndex = startIndex + i;
+            if (globalIndex < skillChoices.Count)
+            {
+                var move = skillChoices[globalIndex];
+                UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
+
+                bool enoughHarmonic = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= move.harmonicCost;
+                bool resonanceOk = true;
+                if (move.enterAwake)
+                    resonanceOk = currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.resonancePoint;
+                bool usageOk = currentCharacterUnit.CanUseMove(move);
+                bool available = enoughHarmonic && resonanceOk && usageOk;
+                bool highlight = move == currentCharacterUnit.Data.specialMusicalMove && available;
+                SetButtonAvailability(currentSkillsMenuSlots[i], available, highlight);
+            }
             else
-                UpdateButton(currentSkillsMenuSlots[j], "Indisponible", null);
+            {
+                // Slot vide ou hors de portée : on affiche l'emplacement vide par défaut
+                if (emptyMove != null)
+                    UpdateButton(currentSkillsMenuSlots[i], emptyMove.moveName, emptyMove.moveIcon);
+                else
+                    UpdateButton(currentSkillsMenuSlots[i], "Indisponible", null);
+                SetButtonAvailability(currentSkillsMenuSlots[i], false, false);
+            }
+        }
+    }
 
-            SetButtonAvailability(currentSkillsMenuSlots[j], false, false);
+    /// <summary>
+    /// Passe à la page suivante des compétences si possible.
+    /// </summary>
+    public void NextSkillPage()
+    {
+        int maxPage = Mathf.Max(0, (skillChoices.Count - 1) / currentSkillsMenuSlots.Count);
+        if (currentSkillPageIndex < maxPage)
+        {
+            currentSkillPageIndex++;
+            RefreshSkillsMenuDisplay();
+        }
+    }
+
+    /// <summary>
+    /// Revient à la page précédente des compétences si possible.
+    /// </summary>
+    public void PreviousSkillPage()
+    {
+        if (currentSkillPageIndex > 0)
+        {
+            currentSkillPageIndex--;
+            RefreshSkillsMenuDisplay();
         }
     }
 

--- a/Assets/Scripts/PlayerInputs.cs
+++ b/Assets/Scripts/PlayerInputs.cs
@@ -1101,6 +1101,20 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         m_Battle_EnemiesGroupSelection = m_Battle.FindAction("EnemiesGroupSelection", throwIfNotFound: true);
         m_Battle_SquadGroupSelection = m_Battle.FindAction("SquadGroupSelection", throwIfNotFound: true);
         m_Battle_Awake = m_Battle.FindAction("Awake", throwIfNotFound: true);
+        m_Battle_LeftShoulder = m_Battle.FindAction("LeftShoulder", throwIfNotFound: false);
+        if (m_Battle_LeftShoulder == null)
+        {
+            m_Battle_LeftShoulder = m_Battle.AddAction("LeftShoulder", InputActionType.Button);
+            m_Battle_LeftShoulder.AddBinding("<Gamepad>/leftShoulder");
+            m_Battle_LeftShoulder.AddBinding("<Keyboard>/leftArrow");
+        }
+        m_Battle_RightShoulder = m_Battle.FindAction("RightShoulder", throwIfNotFound: false);
+        if (m_Battle_RightShoulder == null)
+        {
+            m_Battle_RightShoulder = m_Battle.AddAction("RightShoulder", InputActionType.Button);
+            m_Battle_RightShoulder.AddBinding("<Gamepad>/rightShoulder");
+            m_Battle_RightShoulder.AddBinding("<Keyboard>/rightArrow");
+        }
         // InfoBox
         m_InfoBox = asset.FindActionMap("InfoBox", throwIfNotFound: true);
         m_InfoBox_Cancel = m_InfoBox.FindAction("Cancel", throwIfNotFound: true);
@@ -1414,6 +1428,8 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
     private readonly InputAction m_Battle_EnemiesGroupSelection;
     private readonly InputAction m_Battle_SquadGroupSelection;
     private readonly InputAction m_Battle_Awake;
+    private readonly InputAction m_Battle_LeftShoulder;
+    private readonly InputAction m_Battle_RightShoulder;
     /// <summary>
     /// Provides access to input actions defined in input action map "Battle".
     /// </summary>
@@ -1469,6 +1485,14 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Battle/Awake".
         /// </summary>
         public InputAction @Awake => m_Wrapper.m_Battle_Awake;
+        /// <summary>
+        /// Provides access to the underlying input action "Battle/LeftShoulder".
+        /// </summary>
+        public InputAction @LeftShoulder => m_Wrapper.m_Battle_LeftShoulder;
+        /// <summary>
+        /// Provides access to the underlying input action "Battle/RightShoulder".
+        /// </summary>
+        public InputAction @RightShoulder => m_Wrapper.m_Battle_RightShoulder;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -1528,6 +1552,12 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
             @Awake.started += instance.OnAwake;
             @Awake.performed += instance.OnAwake;
             @Awake.canceled += instance.OnAwake;
+            @LeftShoulder.started += instance.OnLeftShoulder;
+            @LeftShoulder.performed += instance.OnLeftShoulder;
+            @LeftShoulder.canceled += instance.OnLeftShoulder;
+            @RightShoulder.started += instance.OnRightShoulder;
+            @RightShoulder.performed += instance.OnRightShoulder;
+            @RightShoulder.canceled += instance.OnRightShoulder;
         }
 
         /// <summary>
@@ -1572,6 +1602,12 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
             @Awake.started -= instance.OnAwake;
             @Awake.performed -= instance.OnAwake;
             @Awake.canceled -= instance.OnAwake;
+            @LeftShoulder.started -= instance.OnLeftShoulder;
+            @LeftShoulder.performed -= instance.OnLeftShoulder;
+            @LeftShoulder.canceled -= instance.OnLeftShoulder;
+            @RightShoulder.started -= instance.OnRightShoulder;
+            @RightShoulder.performed -= instance.OnRightShoulder;
+            @RightShoulder.canceled -= instance.OnRightShoulder;
         }
 
         /// <summary>
@@ -2095,6 +2131,20 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnAwake(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "LeftShoulder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnLeftShoulder(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "RightShoulder" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnRightShoulder(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "InfoBox" which allows adding and removing callbacks.

--- a/Assets/Scripts/PlayerInputs.inputactions
+++ b/Assets/Scripts/PlayerInputs.inputactions
@@ -463,6 +463,24 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "LeftShoulder",
+                    "type": "Button",
+                    "id": "acc57531-6104-40fa-9706-da7f533dd003",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RightShoulder",
+                    "type": "Button",
+                    "id": "7c4f6bed-28bd-49ae-807a-b838366b2308",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -793,6 +811,50 @@
                     "processors": "",
                     "groups": "",
                     "action": "Awake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fed2420f-015d-45ad-a0c8-46244b264249",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LeftShoulder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3e972452-1b57-4a4a-9511-d465cfc441e3",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LeftShoulder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "87967906-7038-42fc-a4c3-f24ef686c961",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RightShoulder",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e1aded40-fd53-435a-b081-65d7fe039567",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RightShoulder",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
## Résumé
- Ajout des actions LeftShoulder et RightShoulder dans l'asset `PlayerInputs`
- Utilisation de ces actions pour paginer les compétences depuis `InputsManager`
- Nettoyage automatique des abonnements aux boutons d'épaule

## Test
- `dotnet test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5580ad7dc8325a380b811ac1543a5