### PR TITLE
Cadrage automatique de la caméra sans fullTimeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -94,6 +94,52 @@ public class BattleTimelineManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Crée dynamiquement une cible de caméra placée entre deux unités
+    /// afin de cadrer simultanément le lanceur et sa cible lorsque
+    /// aucune timeline de caméra complète n'est définie.
+    /// </summary>
+    /// <param name="caster">Unité à l'origine de l'action.</param>
+    /// <param name="target">Unité visée par l'action.</param>
+    /// <param name="cameraTag">Tag de la caméra à orienter.</param>
+    /// <returns>GameObject temporaire servant d'ancre à la caméra.</returns>
+    public GameObject CreateMidpointCameraTarget(GameObject caster, GameObject target, string cameraTag)
+    {
+        if (caster == null || target == null || string.IsNullOrEmpty(cameraTag))
+            return null;
+
+        // Récupération de la caméra active pour connaître son FOV et sa position actuelle.
+        GameObject camGO = GameObject.FindGameObjectWithTag(cameraTag);
+        Camera cam = camGO != null ? camGO.GetComponent<Camera>() : null;
+        if (cam == null)
+            return null;
+
+        Vector3 casterPos = caster.transform.position;
+        Vector3 targetPos = target.transform.position;
+        // Milieu entre les deux unités.
+        Vector3 midpoint = (casterPos + targetPos) / 2f;
+
+        // Distance nécessaire pour englober les deux unités selon le FOV courant.
+        float distance = Vector3.Distance(casterPos, targetPos);
+        float fovRad = cam.fieldOfView * Mathf.Deg2Rad;
+        float requiredDist = (distance * 0.5f) / Mathf.Tan(fovRad / 2f);
+
+        // Direction conservant l'orientation actuelle de la caméra afin de limiter
+        // les changements brusques d'angle pour le joueur.
+        Vector3 direction = (cam.transform.position - midpoint).normalized;
+        if (direction == Vector3.zero)
+            direction = cam.transform.forward * -1f;
+
+        Vector3 cameraPosition = midpoint + direction * requiredDist;
+
+        // Création de l'ancre temporaire.
+        GameObject pivot = new GameObject("TempCameraTarget");
+        pivot.transform.position = cameraPosition;
+        pivot.transform.rotation = Quaternion.LookRotation(midpoint - cameraPosition);
+
+        return pivot;
+    }
+
+    /// <summary>
     /// Lance une timeline caméra via le PlayableDirector dédié et la file d'attente.
     /// </summary>
     public void PlayTimeline(

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -326,6 +326,26 @@ public class RhythmQTEManager : MonoBehaviour
                           TimelineManager.Instance != null &&
                           casterAnimatorGO != null;
 
+        // Lorsque la timeline complète est absente, on repositionne par défaut la caméra
+        // de manière à englober à la fois le lanceur et sa cible. Cela permet de
+        // conserver une visibilité correcte pour le joueur sans nécessiter de
+        // configuration spécifique dans chaque MusicalMove.
+        GameObject tempCameraTarget = null;
+        if (!useOverlay && BattleTimelineManager.Instance != null && caster != null && target != null)
+        {
+            tempCameraTarget = BattleTimelineManager.Instance.CreateMidpointCameraTarget(
+                caster.gameObject,
+                target.gameObject,
+                battleCameraTag);
+
+            if (tempCameraTarget != null)
+            {
+                performingCameraTarget = tempCameraTarget;
+                casterCameraTarget = tempCameraTarget;
+                initialRotation = tempCameraTarget.transform.rotation;
+            }
+        }
+
         // Éventuel délai de pré-animation.
         // 🔄 Cette attente se produit désormais AVANT toute timeline
         //     afin d'éviter un à-coup juste avant la téléportation.
@@ -417,6 +437,10 @@ public class RhythmQTEManager : MonoBehaviour
         if (useOverlay)
             yield return WaitForTimelinePhase(move.fullTimeline, false);
 
+        // Nettoyage de la cible de caméra temporaire si elle a été créée.
+        if (tempCameraTarget != null)
+            Destroy(tempCameraTarget);
+
         isActive = false;
         bool critical = successResults != null && successResults.Count > 0 && successResults.All(s => s);
         NewBattleManager.Instance.AfterMusicalMove(move, caster, critical);
@@ -485,6 +509,26 @@ public class RhythmQTEManager : MonoBehaviour
                           BattleTimelineManager.Instance != null &&
                           TimelineManager.Instance != null &&
                           casterAnimatorGO != null;
+
+        // Si aucune timeline caméra globale n'est fournie, on crée un pivot temporaire
+        // afin de centrer automatiquement la vue sur le lanceur et sa cible. Ceci
+        // garantit un cadrage correct même pour les objets simples dépourvus de
+        // configuration dédiée.
+        GameObject tempCameraTarget = null;
+        if (!useOverlay && BattleTimelineManager.Instance != null && caster != null && target != null)
+        {
+            tempCameraTarget = BattleTimelineManager.Instance.CreateMidpointCameraTarget(
+                caster.gameObject,
+                target.gameObject,
+                battleCameraTag);
+
+            if (tempCameraTarget != null)
+            {
+                performingCameraTarget = tempCameraTarget;
+                casterCameraTarget = tempCameraTarget;
+                initialRotation = tempCameraTarget.transform.rotation;
+            }
+        }
 
         // Lance la timeline globale si présente.
         if (useOverlay)
@@ -559,6 +603,10 @@ public class RhythmQTEManager : MonoBehaviour
         // Attente finale de la timeline caméra complète.
         if (useOverlay)
             yield return WaitForTimelinePhase(item.fullTimeline, false);
+
+        // Libère la cible temporaire créée pour cette utilisation d'objet.
+        if (tempCameraTarget != null)
+            Destroy(tempCameraTarget);
 
         isActive = false;
         // Protection en cas de destruction du lanceur avant la fin de la séquence

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -29,6 +29,10 @@ suivi sans coupure. La rotation du lanceur est enregistrée dès la première fr
 conservée jusqu'à la fin du move ou de l'objet, même si plusieurs timelines s'enchaînent, afin de garantir une
 orientation cohérente de la caméra.
 
+Si ce champ est laissé vide, le jeu place automatiquement la caméra de combat
+de façon à voir simultanément le lanceur et sa cible, garantissant ainsi une
+lisibilité optimale même sans configuration spécifique.
+
 Les phases classiques restent gérées par le code du jeu afin de déclencher les téléportations nécessaires entre chaque
 étape. Les timelines `preparingTimeline`, `performingTimeline` et `retreatTimeline` peuvent être lues en
 **superposition** pour animer le lanceur ou ses effets pendant que la caméra suit la timeline principale.


### PR DESCRIPTION
## Résumé
- crée un pivot de caméra entre lanceur et cible pour les mouvements ou objets sans `fullTimeline`
- repositionne la caméra sur ce pivot pendant les différentes phases
- documente le comportement par défaut de la caméra

## Tests
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c56549fe0c83258b8bd59ec2dc4016