### PR TITLE
Gestion des références nulles pour PassTurnUI

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -594,8 +594,9 @@ public class InputsManager : MonoBehaviour
             StopCoroutine(passRoutine);
             passRoutine = null;
         }
-
-        PassTurnUI.Instance.ResetProgressSmooth();
+        // Vérifie que l'interface de passage de tour existe toujours
+        // avant de tenter de réinitialiser sa progression.
+        PassTurnUI.Instance?.ResetProgressSmooth();
     }
 
     private IEnumerator PassTurnRoutine()
@@ -606,12 +607,14 @@ public class InputsManager : MonoBehaviour
             if (!playerInputs.Battle.Back.IsPressed())
             {
                 passRoutine = null;
-                PassTurnUI.Instance.ResetProgressSmooth();
+                // L'UI peut avoir été détruite si le combat s'est terminé.
+                PassTurnUI.Instance?.ResetProgressSmooth();
                 yield break;
             }
 
             elapsed += Time.unscaledDeltaTime;
-            PassTurnUI.Instance.SetProgress(elapsed / passHoldDuration);
+            // Met à jour la jauge uniquement si elle est toujours présente.
+            PassTurnUI.Instance?.SetProgress(elapsed / passHoldDuration);
             yield return null;
         }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -729,7 +729,8 @@ public class NewBattleManager : MonoBehaviour
         InputsManager.Instance.playerInputs.Battle.Enable();
         OrientAllUnitsTowardClosestOpponent();
 
-        PassTurnUI.Instance.Show();
+        // Affiche l'interface de passage de tour si elle est disponible.
+        PassTurnUI.Instance?.Show();
     }
 
     private IEnumerator ExecuteTurn(CharacterUnit unit)
@@ -1282,7 +1283,8 @@ public class NewBattleManager : MonoBehaviour
         isTurnResolving = false;
         HandleEndOfBattle();
 
-        PassTurnUI.Instance.Hide(); // Bouclage
+        // Cache la jauge si elle existe pour éviter les références invalides.
+        PassTurnUI.Instance?.Hide(); // Bouclage
     }
 
     public void AfterMusicalMove(MusicalMoveSO move, CharacterUnit caster, bool wasCritical)
@@ -1878,7 +1880,8 @@ public class NewBattleManager : MonoBehaviour
 
     public void ShowMainMenu()
     {
-        PassTurnUI.Instance.Show();
+        // Réaffiche la jauge de passage de tour si elle existe.
+        PassTurnUI.Instance?.Show();
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectItemSkillOrPass();
         ChangeBattleState(BattleState.SquadUnit_MainMenu);
         ToggleMenuContainers(true, false, false);
@@ -1904,7 +1907,8 @@ public class NewBattleManager : MonoBehaviour
 
     public void OpenSkillsMenu()
     {
-        PassTurnUI.Instance.Hide();
+        // Masque la jauge lorsque l'on ouvre le menu des compétences.
+        PassTurnUI.Instance?.Hide();
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectSkill();
         ChangeBattleState(BattleState.SquadUnit_SkillsMenu);
         // S'assure qu'aucun item n'est en cours de sélection

--- a/Assets/Scripts/MonoBehavioursUsed/PassTurnUI.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PassTurnUI.cs
@@ -32,6 +32,17 @@ public class PassTurnUI : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Réinitialise l'instance statique lorsque cet objet est détruit.
+    /// Cela évite de conserver une référence vers un objet Unity détruit
+    /// qui provoquerait ensuite des MissingReferenceException.
+    /// </summary>
+    private void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
+    }
+
     void Start()
     {
         Hide();


### PR DESCRIPTION
## Résumé
- Empêche la persistance de l'instance statique de PassTurnUI après destruction pour éviter les MissingReferenceException.
- Sécurise les appels à PassTurnUI dans InputsManager et NewBattleManager avec des vérifications nullables.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés / accès refusé)*

------
https://chatgpt.com/codex/tasks/task_e_68c56bd91d288325bfc67974103d04ea