### PR TITLE
Système de battlecaméra modulable via CameraShotSO

### DIFF
--- a/Assets/Scripts/Classes/CameraShotSO.cs
+++ b/Assets/Scripts/Classes/CameraShotSO.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using Cinemachine;
+
+/// <summary>
+/// ScriptableObject décrivant un plan de caméra réutilisable.
+/// Permet aux game designers de configurer l'angle de vue
+/// indépendamment des timelines d'animations.
+/// </summary>
+[CreateAssetMenu(fileName = "NewCameraShot", menuName = "Symphonie/Camera Shot")]
+public class CameraShotSO : ScriptableObject
+{
+    [Header("Paramètres de cadrage")]
+    [Tooltip("Champ de vision de la caméra pendant ce plan.")]
+    public float fieldOfView = 40f;
+
+    [Tooltip("Décalage appliqué par rapport à la cible suivie.")]
+    public Vector3 offset = new Vector3(0f, 3f, -5f);
+
+    [Tooltip("Durée du fondu lors de la transition vers ce plan.")]
+    public float blendDuration = 1f;
+}

--- a/Assets/Scripts/Classes/CameraShotSO.cs.meta
+++ b/Assets/Scripts/Classes/CameraShotSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13146f43f779441a913b73121bab3032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -88,10 +88,11 @@ public class ItemData : ScriptableObject
     public TimelineAsset performingTimeline;
     [Tooltip("Timeline jouée lors du repli après utilisation")]
     public TimelineAsset retreatTimeline;
-    [Tooltip("Timeline de caméra couvrant toute l'action de l'item.\n" +
-             "Elle suit l'utilisateur durant la préparation, l'exécution\n" +
-             "et le repli pour offrir un mouvement continu.")]
-    public TimelineAsset fullTimeline;
+    // Le suivi caméra complet est maintenant défini par un CameraShotSO,
+    // permettant d'utiliser des plans standardisés sans créer une timeline
+    // dédiée à la caméra pour chaque objet.
+    [Tooltip("Plan de caméra couvrant l'utilisation complète de l'objet.")]
+    public CameraShotSO cameraShot;
 
     [Header("QTE Pattern")]
     public List<float> beatPattern;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -135,10 +135,11 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset performingTimeline;
     [Tooltip("Timeline jouée lors du repli après l'exécution du move")]
     public TimelineAsset retreatTimeline;
-    [Tooltip("Timeline de caméra couvrant toute l'action. La caméra suit le move\n" +
-             "durant la préparation, l'exécution et le repli afin d'offrir un suivi\n" +
-             "continu, tandis que le code se charge des téléportations entre chaque phase." )]
-    public TimelineAsset fullTimeline;
+    // Le mouvement de caméra global est désormais décrit par un CameraShotSO
+    // afin de s'affranchir des timelines spécifiques et de favoriser la
+    // réutilisation de plans préconfigurés.
+    [Tooltip("Plan de caméra réutilisable couvrant l'action du move.")]
+    public CameraShotSO cameraShot;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+using Cinemachine;
+
+/// <summary>
+/// Gère les plans de caméra durant les combats en utilisant Cinemachine.
+/// Ce gestionnaire centralise l'activation des CameraShotSO afin de
+/// respecter le point de vue de Munin tout en offrant des transitions
+/// souples entre les actions.
+/// </summary>
+public class BattleCameraManager : MonoBehaviour
+{
+    public static BattleCameraManager Instance { get; private set; }
+
+    [Header("Référence de caméra")]
+    [Tooltip("Virtual Camera principale utilisée pour les plans de combat.")]
+    public CinemachineVirtualCamera mainVirtualCamera;
+
+    private CinemachineBrain brain;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        brain = Camera.main != null ? Camera.main.GetComponent<CinemachineBrain>() : null;
+    }
+
+    /// <summary>
+    /// Applique un plan défini par un CameraShotSO.
+    /// </summary>
+    /// <param name="shot">Plan de caméra à jouer.</param>
+    /// <param name="caster">Transform du lanceur, utilisé comme repli si aucune cible.</param>
+    /// <param name="focus">Transform principal suivi pendant l'action.</param>
+    public void PlayShot(CameraShotSO shot, Transform caster, Transform focus)
+    {
+        if (shot == null || mainVirtualCamera == null)
+            return;
+
+        Transform target = focus != null ? focus : caster;
+        if (target == null)
+            return;
+
+        mainVirtualCamera.Follow = target;
+        mainVirtualCamera.LookAt = target;
+        mainVirtualCamera.m_Lens.FieldOfView = shot.fieldOfView;
+
+        // Positionne la caméra en appliquant l'offset dans l'espace local de la cible
+        mainVirtualCamera.transform.position = target.position + target.TransformDirection(shot.offset);
+
+        // Configure la durée de transition entre les plans
+        if (brain != null)
+            brain.m_DefaultBlend.m_Time = shot.blendDuration;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f60ca5c7fc8474b8c43ca235b471bdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -320,10 +320,9 @@ public class RhythmQTEManager : MonoBehaviour
             ? target.gameObject         // 🎯 Caméra sur la CharacterUnit ciblée pendant l'exécution
             : casterAnimatorGO;         // 🔁 Retombe sur le lanceur si aucune cible
         GameObject casterCameraTarget = casterAnimatorGO; // 📌 Ancre sur le lanceur pour préparation et repli
-        // Détermine si une timeline caméra couvrant toute l'action est disponible.
-        bool useOverlay = move.fullTimeline != null &&
-                          BattleTimelineManager.Instance != null &&
-                          TimelineManager.Instance != null &&
+        // Détermine si un plan de caméra dédié doit être utilisé.
+        bool useOverlay = move.cameraShot != null &&
+                          BattleCameraManager.Instance != null &&
                           casterAnimatorGO != null;
 
         // Éventuel délai de pré-animation.
@@ -334,15 +333,12 @@ public class RhythmQTEManager : MonoBehaviour
         if (move.startDelay > 0f)
             yield return new WaitForSeconds(move.startDelay);
 
-        // Lance la timeline globale de caméra si présente, une fois le délai écoulé.
+        // Active le plan de caméra global si défini.
         if (useOverlay)
-            BattleTimelineManager.Instance.PlayTimeline(
-                move.fullTimeline,
-                casterAnimatorGO,
-                performingCameraTarget,
-                battleCameraTag,
-                true,
-                initialRotation);
+            BattleCameraManager.Instance.PlayShot(
+                move.cameraShot,
+                casterAnimatorGO.transform,
+                performingCameraTarget != null ? performingCameraTarget.transform : null);
 
         // --- Phase de préparation ---
         StartTimelinePhase(
@@ -413,9 +409,8 @@ public class RhythmQTEManager : MonoBehaviour
             initialRotation);
         yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay);
 
-        // Attente finale de la timeline caméra complète.
-        if (useOverlay)
-            yield return WaitForTimelinePhase(move.fullTimeline, false);
+        // Aucun suivi supplémentaire n'est requis : le plan Cinemachine gère
+        // automatiquement sa propre transition de sortie.
 
         isActive = false;
         bool critical = successResults != null && successResults.Count > 0 && successResults.All(s => s);
@@ -481,20 +476,16 @@ public class RhythmQTEManager : MonoBehaviour
         GameObject casterCameraTarget = casterAnimatorGO; // 📌 Référence fixe sur le lanceur
 
         // Détermine si une timeline caméra complète est disponible pour l'objet.
-        bool useOverlay = item.fullTimeline != null &&
-                          BattleTimelineManager.Instance != null &&
-                          TimelineManager.Instance != null &&
+        bool useOverlay = item.cameraShot != null &&
+                          BattleCameraManager.Instance != null &&
                           casterAnimatorGO != null;
 
-        // Lance la timeline globale si présente.
+        // Active le plan de caméra global de l'objet.
         if (useOverlay)
-            BattleTimelineManager.Instance.PlayTimeline(
-                item.fullTimeline,
-                casterAnimatorGO,
-                performingCameraTarget,
-                battleCameraTag,
-                true,
-                initialRotation);
+            BattleCameraManager.Instance.PlayShot(
+                item.cameraShot,
+                casterAnimatorGO.transform,
+                performingCameraTarget != null ? performingCameraTarget.transform : null);
 
         // --- Phase de préparation ---
         StartTimelinePhase(
@@ -556,9 +547,8 @@ public class RhythmQTEManager : MonoBehaviour
             initialRotation);
         yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay);
 
-        // Attente finale de la timeline caméra complète.
-        if (useOverlay)
-            yield return WaitForTimelinePhase(item.fullTimeline, false);
+        // Le plan Cinemachine assure sa propre sortie sans synchronisation
+        // supplémentaire côté code.
 
         isActive = false;
         // Protection en cas de destruction du lanceur avant la fin de la séquence

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -22,21 +22,20 @@ sans infliger directement un bonus ou un malus classique. Elles ouvrent des
 opportunités tactiques que les novices peuvent appréhender facilement tout en
 permettant aux vétérans de créer des enchaînements complexes.
 
-## Timeline caméra continue
-Un champ `fullTimeline` est disponible dans chaque **MusicalMove** et désormais dans chaque **Item**. Il définit un
-mouvement de caméra couvrant l'ensemble de l'action (préparation, utilisation/exécution et repli) pour assurer un
-suivi sans coupure. La rotation du lanceur est enregistrée dès la première frame de la phase de préparation puis
-conservée jusqu'à la fin du move ou de l'objet, même si plusieurs timelines s'enchaînent, afin de garantir une
-orientation cohérente de la caméra.
+## Plan de caméra réutilisable
+Chaque **MusicalMove** et chaque **Item** dispose désormais d'un champ `cameraShot` faisant référence à un
+**CameraShotSO**. Ce ScriptableObject décrit un plan de caméra (champ de vision, décalage, durée de transition) qui
+accompagne l'action du début à la fin. La rotation du lanceur est enregistrée dès la première frame de la phase de
+préparation puis conservée jusqu'au repli pour maintenir une orientation cohérente.
 
 Les phases classiques restent gérées par le code du jeu afin de déclencher les téléportations nécessaires entre chaque
 étape. Les timelines `preparingTimeline`, `performingTimeline` et `retreatTimeline` peuvent être lues en
-**superposition** pour animer le lanceur ou ses effets pendant que la caméra suit la timeline principale.
+**superposition** pour animer le lanceur ou ses effets pendant que la caméra suit le plan défini par le `CameraShotSO`.
 
-Lorsqu'un **MusicalMove** ou un **Item** est utilisé, la `fullTimeline` démarre en premier puis les timelines de
-préparation, d'exécution et de repli se succèdent automatiquement en parallèle. Le lanceur peut être téléporté entre la
-fin de la préparation et le début de l'exécution ainsi qu'entre l'exécution et le repli afin d'assurer un enchaînement
-fluide de l'action.
+Lorsqu'un **MusicalMove** ou un **Item** est utilisé, le `cameraShot` est activé en premier afin de cadrer l'action puis
+les timelines de préparation, d'exécution et de repli se succèdent automatiquement en parallèle. Le lanceur peut être
+téléporté entre la fin de la préparation et le début de l'exécution ainsi qu'entre l'exécution et le repli afin d'assurer
+un enchaînement fluide de l'action.
 
 ## Déplacement optionnel
 Un booléen `requiresMovement` est présent dans chaque **MusicalMove** et **Item**.


### PR DESCRIPTION
## Résumé
- Ajout d'un `CameraShotSO` permettant de définir des plans de caméra réutilisables
- Introduction de `BattleCameraManager` pour piloter Cinemachine durant les combats
- Remplacement du champ `fullTimeline` par `cameraShot` dans `MusicalMoveSO` et `ItemData`
- Mise à jour du `RhythmQTEManager` et de la documentation pour ce nouveau système

## Test
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c57a714108832582f95bb6b4ac7ec6