### PR TITLE
Suppression de la dépendance obligatoire à Cinemachine

### DIFF
--- a/Assets/Scripts/Classes/CameraShotSO.cs
+++ b/Assets/Scripts/Classes/CameraShotSO.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
-using Cinemachine;
+
+// Ce ScriptableObject est volontairement indépendant de Cinemachine afin de
+// pouvoir être utilisé même si le package n'est pas présent dans le projet.
 
 /// <summary>
 /// ScriptableObject décrivant un plan de caméra réutilisable.

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -1,21 +1,32 @@
 using UnityEngine;
+
+#if CINEMACHINE
 using Cinemachine;
+#endif
 
 /// <summary>
-/// Gère les plans de caméra durant les combats en utilisant Cinemachine.
-/// Ce gestionnaire centralise l'activation des CameraShotSO afin de
-/// respecter le point de vue de Munin tout en offrant des transitions
-/// souples entre les actions.
+/// Gère les plans de caméra durant les combats. Lorsque Cinemachine est
+/// disponible, le script s'appuie sur ses composants avancés ; sinon il
+/// se replie sur la caméra standard de Unity pour assurer un minimum de
+/// fonctionnalité.
 /// </summary>
 public class BattleCameraManager : MonoBehaviour
 {
     public static BattleCameraManager Instance { get; private set; }
-
+#if CINEMACHINE
     [Header("Référence de caméra")]
     [Tooltip("Virtual Camera principale utilisée pour les plans de combat.")]
     public CinemachineVirtualCamera mainVirtualCamera;
 
     private CinemachineBrain brain;
+#else
+    [Header("Référence de caméra")]
+    [Tooltip("Caméra standard utilisée lorsque Cinemachine est absent.")]
+    public Camera mainVirtualCamera;
+
+    // Aucun CinemachineBrain n'est disponible ; variable conservée pour cohérence.
+    private Camera brain;
+#endif
 
     private void Awake()
     {
@@ -25,7 +36,10 @@ public class BattleCameraManager : MonoBehaviour
             return;
         }
         Instance = this;
+#if CINEMACHINE
+        // Récupère la référence au CinemachineBrain pour gérer les fondus entre plans.
         brain = Camera.main != null ? Camera.main.GetComponent<CinemachineBrain>() : null;
+#endif
     }
 
     /// <summary>
@@ -43,6 +57,8 @@ public class BattleCameraManager : MonoBehaviour
         if (target == null)
             return;
 
+#if CINEMACHINE
+        // Utilisation complète de Cinemachine : suivi, orientation et FOV.
         mainVirtualCamera.Follow = target;
         mainVirtualCamera.LookAt = target;
         mainVirtualCamera.m_Lens.FieldOfView = shot.fieldOfView;
@@ -53,5 +69,11 @@ public class BattleCameraManager : MonoBehaviour
         // Configure la durée de transition entre les plans
         if (brain != null)
             brain.m_DefaultBlend.m_Time = shot.blendDuration;
+#else
+        // Version de secours : déplace et oriente simplement la caméra standard.
+        mainVirtualCamera.transform.position = target.position + target.TransformDirection(shot.offset);
+        mainVirtualCamera.transform.LookAt(target);
+        mainVirtualCamera.fieldOfView = shot.fieldOfView;
+#endif
     }
 }


### PR DESCRIPTION
## Résumé
- Retrait de l'`using` Cinemachine dans `CameraShotSO` pour éviter la dépendance directe au package.
- Gestionnaire de caméra de combat compatible sans Cinemachine via compilation conditionnelle et caméra Unity classique.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c583ca3f8883259014c6d7c29f7291