### PR TITLE
feat: enrichir les plans de caméra

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_Sforzando/CS_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/CS_Sforzando.asset
@@ -11,7 +11,9 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 13146f43f779441a913b73121bab3032, type: 3}
   m_Name: CS_Sforzando
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
+  targetToFollow: 1
+  distance: 5
   fieldOfView: 60
-  offset: {x: 0, y: 3, z: -5}
+  offset: {x: 0, y: 3, z: 0}
   blendDuration: 1

--- a/Assets/Scripts/Classes/CameraShotSO.cs
+++ b/Assets/Scripts/Classes/CameraShotSO.cs
@@ -11,12 +11,30 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "NewCameraShot", menuName = "Symphonie/Camera Shot")]
 public class CameraShotSO : ScriptableObject
 {
+    /// <summary>
+    /// Permet de choisir quel Transform la caméra doit suivre.
+    /// </summary>
+    public enum ShotTarget
+    {
+        /// <summary>Le lanceur de l'action.</summary>
+        Caster,
+        /// <summary>La cible principale de l'action.</summary>
+        Target
+    }
+
     [Header("Paramètres de cadrage")]
+
+    [Tooltip("Cible suivie pendant ce plan : le lanceur (Caster) ou la cible (Target).")]
+    public ShotTarget targetToFollow = ShotTarget.Target;
+
+    [Tooltip("Distance à conserver par rapport à la cible suivie.")]
+    public float distance = 5f;
+
     [Tooltip("Champ de vision de la caméra pendant ce plan.")]
     public float fieldOfView = 60f;
 
-    [Tooltip("Décalage appliqué par rapport à la cible suivie.")]
-    public Vector3 offset = new Vector3(0f, 3f, -5f);
+    [Tooltip("Décalage local appliqué par rapport à la cible suivie.")]
+    public Vector3 offset = new Vector3(0f, 3f, 0f);
 
     [Tooltip("Durée du fondu lors de la transition vers ce plan.")]
     public float blendDuration = 1f;

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -53,26 +53,33 @@ public class BattleCameraManager : MonoBehaviour
         if (shot == null || mainVirtualCamera == null)
             return;
 
-        Transform target = focus != null ? focus : caster;
+        // Détermine la cible à suivre en fonction des paramètres du plan.
+        Transform target = shot.targetToFollow == CameraShotSO.ShotTarget.Caster ? caster : focus;
         if (target == null)
             return;
 
+        // Calcule la position finale de la caméra : on part de la cible, on recule selon son orientation
+        // pour respecter la distance demandée puis on applique l'offset local.
+        Vector3 finalPosition = target.position
+                                - target.forward * shot.distance
+                                + target.TransformDirection(shot.offset);
+
 #if CINEMACHINE
         // Utilisation complète de Cinemachine : suivi, orientation et FOV.
-        mainVirtualCamera.Follow = target;
-        mainVirtualCamera.LookAt = target;
+        mainVirtualCamera.Follow = target;            // La caméra suit la cible choisie.
+        mainVirtualCamera.LookAt = target;            // Et la regarde.
         mainVirtualCamera.m_Lens.FieldOfView = shot.fieldOfView;
 
-        // Positionne la caméra en appliquant l'offset dans l'espace local de la cible
-        mainVirtualCamera.transform.position = target.position + target.TransformDirection(shot.offset);
+        // Positionne la caméra à la position calculée.
+        mainVirtualCamera.transform.position = finalPosition;
 
-        // Configure la durée de transition entre les plans
+        // Configure la durée de transition entre les plans.
         if (brain != null)
             brain.m_DefaultBlend.m_Time = shot.blendDuration;
 #else
         // Version de secours : déplace et oriente simplement la caméra standard.
-        mainVirtualCamera.transform.position = target.position + target.TransformDirection(shot.offset);
-        mainVirtualCamera.transform.LookAt(target);
+        mainVirtualCamera.transform.position = finalPosition;
+        mainVirtualCamera.transform.LookAt(target); // Conserve le regard sur la cible.
         mainVirtualCamera.fieldOfView = shot.fieldOfView;
 #endif
     }

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -24,8 +24,8 @@ permettant aux vétérans de créer des enchaînements complexes.
 
 ## Plan de caméra réutilisable
 Chaque **MusicalMove** et chaque **Item** dispose désormais d'un champ `cameraShot` faisant référence à un
-**CameraShotSO**. Ce ScriptableObject décrit un plan de caméra (champ de vision, décalage, durée de transition) qui
-accompagne l'action du début à la fin. La rotation du lanceur est enregistrée dès la première frame de la phase de
+**CameraShotSO**. Ce ScriptableObject décrit un plan de caméra (cible à suivre, distance, champ de vision, décalage,
+durée de transition) qui accompagne l'action du début à la fin. La rotation du lanceur est enregistrée dès la première frame de la phase de
 préparation puis conservée jusqu'au repli pour maintenir une orientation cohérente.
 
 Les phases classiques restent gérées par le code du jeu afin de déclencher les téléportations nécessaires entre chaque


### PR DESCRIPTION
## Résumé
- ajouter la sélection de cible et la distance dans CameraShotSO
- calculer la position finale de la caméra dans BattleCameraManager
- documenter les nouveaux champs et mettre à jour un exemple de plan

## Tests
- `dotnet test` *(échoué : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c587ec18488325a674fbf28405dbed