### PR TITLE
Remplacer CinemachineVirtualCamera par CinemachineCamera

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -94,7 +94,8 @@ public class ItemData : ScriptableObject
     public TimelineAsset fullTimeline;
 
     [Header("Caméra")]
-    [Tooltip("Nom de la CinemachineVirtualCamera utilisée pour cet objet.\nLaisser vide pour utiliser la caméra de combat par défaut.")]
+    // Nom de la CinemachineCamera à activer lors de l'utilisation de l'objet
+    [Tooltip("Nom de la CinemachineCamera utilisée pour cet objet.\nLaisser vide pour utiliser la caméra de combat par défaut.")]
     public string cameraName;
 
     [Header("QTE Pattern")]

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -141,7 +141,8 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset fullTimeline;
 
     [Header("Caméra")]
-    [Tooltip("Nom de la CinemachineVirtualCamera utilisée pour ce move.\nLaisser vide pour garder la caméra de combat par défaut.")]
+    // Référence à la nouvelle CinemachineCamera à activer pour ce move
+    [Tooltip("Nom de la CinemachineCamera utilisée pour ce move.\nLaisser vide pour garder la caméra de combat par défaut.")]
     public string cameraName;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using Cinemachine;
 
 /// <summary>
-/// Gère l'activation des différentes CinemachineVirtualCameras en combat.
+/// Gère l'activation des différentes <see cref="CinemachineCamera"/> en combat.
 /// Chaque move ou item peut spécifier le nom d'une caméra à activer.
 /// </summary>
 public class BattleCameraManager : MonoBehaviour
@@ -13,8 +13,10 @@ public class BattleCameraManager : MonoBehaviour
     [Tooltip("Nom de la caméra utilisée par défaut lorsque aucun nom n'est fourni.")]
     public string defaultCameraName = "BattleCam_Default";
 
-    private readonly Dictionary<string, CinemachineVirtualCamera> cameras = new();
-    private CinemachineVirtualCamera activeCamera;
+    // Liste des caméras Cinemachine disponibles, indexées par leur nom de GameObject
+    private readonly Dictionary<string, CinemachineCamera> cameras = new();
+    // Caméra actuellement active dans la scène de combat
+    private CinemachineCamera activeCamera;
 
     void Awake()
     {
@@ -25,11 +27,12 @@ public class BattleCameraManager : MonoBehaviour
         }
         Instance = this;
 
-        // Recherche toutes les caméras virtuelles enfants et les enregistre.
-        foreach (var vcam in GetComponentsInChildren<CinemachineVirtualCamera>(true))
+        // Recherche toutes les caméras Cinemachine enfants et les enregistre.
+        foreach (var vcam in GetComponentsInChildren<CinemachineCamera>(true))
         {
             cameras[vcam.gameObject.name] = vcam;
-            vcam.gameObject.SetActive(false); // Désactive toutes les caméras au départ
+            // Désactive toutes les caméras au départ afin de garder la scène propre
+            vcam.gameObject.SetActive(false);
         }
 
         // Active la caméra par défaut si définie
@@ -40,10 +43,11 @@ public class BattleCameraManager : MonoBehaviour
     /// Active la caméra correspondant au nom fourni. Si aucun nom n'est trouvé,
     /// la caméra par défaut est réactivée.
     /// </summary>
-    /// <param name="cameraName">Nom de la CinemachineVirtualCamera à afficher.</param>
+    /// <param name="cameraName">Nom de la <see cref="CinemachineCamera"/> à afficher.</param>
     public void SwitchToCamera(string cameraName)
     {
-        CinemachineVirtualCamera newCam = null;
+        // Récupère la caméra correspondant au nom demandé
+        CinemachineCamera newCam = null;
         if (!string.IsNullOrEmpty(cameraName))
             cameras.TryGetValue(cameraName, out newCam);
 
@@ -53,9 +57,11 @@ public class BattleCameraManager : MonoBehaviour
         if (newCam == activeCamera)
             return;
 
+        // Désactivation de l'ancienne caméra si elle existe
         if (activeCamera != null)
             activeCamera.gameObject.SetActive(false);
 
+        // Activation de la nouvelle caméra
         if (newCam != null)
         {
             newCam.gameObject.SetActive(true);

--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
@@ -2,19 +2,22 @@ using UnityEngine;
 using Cinemachine;
 
 /// <summary>
-/// Assigne dynamiquement le lanceur actuel comme cible de suivi pour une CinemachineVirtualCamera.
+/// Assigne dynamiquement le lanceur actuel comme cible de suivi pour une caméra Cinemachine.
 /// </summary>
-[RequireComponent(typeof(CinemachineVirtualCamera))]
+// Utilise CinemachineCamera (Cinemachine 3) à la place de CinemachineVirtualCamera
+[RequireComponent(typeof(CinemachineCamera))]
 public class FollowBattleCaster : MonoBehaviour
 {
     [Tooltip("Décalage appliqué par rapport à la position du lanceur.")]
     public Vector3 offset = new(0, 2, -3);
 
-    private CinemachineVirtualCamera vcam;
+    // Caméra responsable du suivi du lanceur
+    private CinemachineCamera cmCamera;
 
     void Awake()
     {
-        vcam = GetComponent<CinemachineVirtualCamera>();
+        // Obtention de la nouvelle CinemachineCamera
+        cmCamera = GetComponent<CinemachineCamera>();
     }
 
     void LateUpdate()
@@ -22,8 +25,9 @@ public class FollowBattleCaster : MonoBehaviour
         var caster = NewBattleManager.Instance?.currentCharacterUnit;
         if (caster == null) return;
 
-        vcam.Follow = caster.transform;
-        var transposer = vcam.GetCinemachineComponent<CinemachineTransposer>();
+        // Suit le lanceur tout en appliquant un décalage personnalisé
+        cmCamera.Follow = caster.transform;
+        var transposer = cmCamera.GetCinemachineComponent<CinemachineTransposer>();
         if (transposer != null)
             transposer.m_FollowOffset = offset;
     }

--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
@@ -4,17 +4,20 @@ using Cinemachine;
 /// <summary>
 /// Suit la cible actuelle du combat avec un décalage personnalisé.
 /// </summary>
-[RequireComponent(typeof(CinemachineVirtualCamera))]
+// Désormais basé sur CinemachineCamera pour la compatibilité avec Cinemachine 3
+[RequireComponent(typeof(CinemachineCamera))]
 public class FollowBattleTarget : MonoBehaviour
 {
     [Tooltip("Décalage appliqué par rapport à la position de la cible.")]
     public Vector3 offset = new(0, 2, -3);
 
-    private CinemachineVirtualCamera vcam;
+    // Caméra Cinemachine utilisée pour suivre la cible
+    private CinemachineCamera cmCamera;
 
     void Awake()
     {
-        vcam = GetComponent<CinemachineVirtualCamera>();
+        // Remplace l'ancien appel vers CinemachineVirtualCamera
+        cmCamera = GetComponent<CinemachineCamera>();
     }
 
     void LateUpdate()
@@ -22,8 +25,9 @@ public class FollowBattleTarget : MonoBehaviour
         var target = NewBattleManager.Instance?.currentTargetCharacter;
         if (target == null) return;
 
-        vcam.Follow = target.transform;
-        var transposer = vcam.GetCinemachineComponent<CinemachineTransposer>();
+        // Assigne la cible à suivre et ajuste le décalage
+        cmCamera.Follow = target.transform;
+        var transposer = cmCamera.GetCinemachineComponent<CinemachineTransposer>();
         if (transposer != null)
             transposer.m_FollowOffset = offset;
     }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
@@ -4,17 +4,20 @@ using Cinemachine;
 /// <summary>
 /// Oriente la caméra vers le lanceur actuel avec un décalage optionnel.
 /// </summary>
-[RequireComponent(typeof(CinemachineVirtualCamera))]
+// Utilisation de CinemachineCamera (nouveau dans Cinemachine 3) à la place de l'ancienne CinemachineVirtualCamera
+[RequireComponent(typeof(CinemachineCamera))]
 public class LookAtBattleCaster : MonoBehaviour
 {
     [Tooltip("Décalage appliqué lors du ciblage du lanceur.")]
     public Vector3 offset;
 
-    private CinemachineVirtualCamera vcam;
+    // Référence vers la caméra Cinemachine qui suit et oriente l'action
+    private CinemachineCamera cmCamera;
 
     void Awake()
     {
-        vcam = GetComponent<CinemachineVirtualCamera>();
+        // Récupération de la nouvelle CinemachineCamera au lieu de CinemachineVirtualCamera
+        cmCamera = GetComponent<CinemachineCamera>();
     }
 
     void LateUpdate()
@@ -22,8 +25,10 @@ public class LookAtBattleCaster : MonoBehaviour
         var caster = NewBattleManager.Instance?.currentCharacterUnit;
         if (caster == null) return;
 
-        vcam.LookAt = caster.transform;
-        var composer = vcam.GetCinemachineComponent<CinemachineComposer>();
+        // Affecte le Transform du lanceur comme cible à regarder
+        cmCamera.LookAt = caster.transform;
+        // Récupère le composant Composer pour appliquer le décalage configuré
+        var composer = cmCamera.GetCinemachineComponent<CinemachineComposer>();
         if (composer != null)
             composer.m_TrackedObjectOffset = offset;
     }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
@@ -4,17 +4,20 @@ using Cinemachine;
 /// <summary>
 /// Oriente la caméra vers la cible actuelle avec un décalage optionnel.
 /// </summary>
-[RequireComponent(typeof(CinemachineVirtualCamera))]
+// Adoption de CinemachineCamera pour être compatible avec Cinemachine 3
+[RequireComponent(typeof(CinemachineCamera))]
 public class LookAtBattleTarget : MonoBehaviour
 {
     [Tooltip("Décalage appliqué lors du ciblage de la cible.")]
     public Vector3 offset;
 
-    private CinemachineVirtualCamera vcam;
+    // Caméra utilisée pour orienter le regard vers la cible
+    private CinemachineCamera cmCamera;
 
     void Awake()
     {
-        vcam = GetComponent<CinemachineVirtualCamera>();
+        // Récupère la CinemachineCamera associée à ce GameObject
+        cmCamera = GetComponent<CinemachineCamera>();
     }
 
     void LateUpdate()
@@ -22,8 +25,9 @@ public class LookAtBattleTarget : MonoBehaviour
         var target = NewBattleManager.Instance?.currentTargetCharacter;
         if (target == null) return;
 
-        vcam.LookAt = target.transform;
-        var composer = vcam.GetCinemachineComponent<CinemachineComposer>();
+        // Oriente la caméra vers la cible actuelle
+        cmCamera.LookAt = target.transform;
+        var composer = cmCamera.GetCinemachineComponent<CinemachineComposer>();
         if (composer != null)
             composer.m_TrackedObjectOffset = offset;
     }


### PR DESCRIPTION
## Résumé
- Met à jour la gestion de caméra pour utiliser CinemachineCamera (Cinemachine 3)
- Ajoute des commentaires pour faciliter la maintenance

## Test
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b07ccb3c8325877354755e14d294