### PR TITLE
Corrige l'accès aux composants Cinemachine

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
@@ -25,10 +25,12 @@ public class FollowBattleCaster : MonoBehaviour
         var caster = NewBattleManager.Instance?.currentCharacterUnit;
         if (caster == null) return;
 
-        // Suit le lanceur tout en appliquant un décalage personnalisé
+        // Suit le lanceur
         cmCamera.Follow = caster.transform;
-        var transposer = cmCamera.GetCinemachineComponent<CinemachineTransposer>();
+        // Récupère le composant du corps via l'étape correspondante dans Cinemachine 3
+        var transposer = cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Body) as CinemachineTransposer;
+        // Applique le décalage si le composant existe
         if (transposer != null)
-            transposer.m_FollowOffset = offset;
+            transposer.FollowOffset = offset;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
@@ -25,10 +25,12 @@ public class FollowBattleTarget : MonoBehaviour
         var target = NewBattleManager.Instance?.currentTargetCharacter;
         if (target == null) return;
 
-        // Assigne la cible à suivre et ajuste le décalage
+        // Assigne la cible à suivre
         cmCamera.Follow = target.transform;
-        var transposer = cmCamera.GetCinemachineComponent<CinemachineTransposer>();
+        // Dans Cinemachine 3, les composants sont obtenus par étape plutôt que par générique
+        var transposer = cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Body) as CinemachineTransposer;
+        // Si un transposer est trouvé, on applique le décalage voulu via la propriété publique
         if (transposer != null)
-            transposer.m_FollowOffset = offset;
+            transposer.FollowOffset = offset;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
@@ -27,9 +27,10 @@ public class LookAtBattleCaster : MonoBehaviour
 
         // Affecte le Transform du lanceur comme cible à regarder
         cmCamera.LookAt = caster.transform;
-        // Récupère le composant Composer pour appliquer le décalage configuré
-        var composer = cmCamera.GetCinemachineComponent<CinemachineComposer>();
+        // Dans Cinemachine 3, on récupère le composer via l'étape "Aim"
+        var composer = cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Aim) as CinemachineComposer;
+        // Si présent, on modifie l'offset de suivi pour ajuster le point visé
         if (composer != null)
-            composer.m_TrackedObjectOffset = offset;
+            composer.TrackedObjectOffset = offset;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
@@ -27,8 +27,9 @@ public class LookAtBattleTarget : MonoBehaviour
 
         // Oriente la caméra vers la cible actuelle
         cmCamera.LookAt = target.transform;
-        var composer = cmCamera.GetCinemachineComponent<CinemachineComposer>();
+        // Accède au composer via l'étape de visée pour ajuster l'offset
+        var composer = cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Aim) as CinemachineComposer;
         if (composer != null)
-            composer.m_TrackedObjectOffset = offset;
+            composer.TrackedObjectOffset = offset;
     }
 }


### PR DESCRIPTION
## Résumé
- Met à jour les scripts de suivi et de visée pour utiliser `GetCinemachineComponent` avec `CinemachineCore.Stage`.
- Remplace les anciens champs internes par les nouvelles propriétés `FollowOffset` et `TrackedObjectOffset`.

## Tests
- `dotnet build` *(échec : dotnet absent)*
- `apt-get update` *(échec : dépôts inaccessibles)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b1bb667c832599cc9a768e3715e6