### PR TITLE
Adapter les scripts à la BattleCamera Cinemachine

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using TMPro;
+using Cinemachine; // Utilisation de CinemachineCamera pour la BattleCamera
 
 /// <summary>
 /// Popup visuel indiquant un gain d'harmonique au-dessus d'une unité.
@@ -17,7 +18,7 @@ public class AddHarmonicPopup : MonoBehaviour
 
     private float elapsed = 0f;        // Temps écoulé depuis l'apparition
     private float floatOffset = 0f;    // Décalage vertical progressif
-    private Camera battleCamera;            // Caméra utilisée pour la conversion Monde/Ecran
+    private CinemachineCamera battleCamera; // Caméra utilisée pour la conversion Monde/Ecran
     private CanvasGroup canvasGroup;   // Pour faire disparaître progressivement le popup
     private Transform target;          // Unité suivie
 
@@ -42,7 +43,8 @@ public class AddHarmonicPopup : MonoBehaviour
 
         textMesh.text = "+" + amount.ToString();
 
-        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponent<Camera>();
+        // Récupère désormais le composant CinemachineCamera, le tag restant inchangé
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponent<CinemachineCamera>();
 
         canvasGroup = GetComponent<CanvasGroup>();
         if (canvasGroup == null)

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 using UnityEngine.Playables;
 using UnityEngine.InputSystem; // Nécessaire pour utiliser les actions d'input
 using UnityEngine.Timeline; // Pour lancer les timelines post-combat
+using Cinemachine; // Accès au composant CinemachineCamera
 
 public class BattleTransitionManager : MonoBehaviour
 {
@@ -26,7 +27,7 @@ public class BattleTransitionManager : MonoBehaviour
     [Header("Music")]
     [SerializeField] private AudioSource musicSource;
 
-    private Camera battleCamera;
+    private CinemachineCamera battleCamera; // Référence à la nouvelle BattleCamera Cinemachine
 
     [Header("Scenes")]
     [SerializeField] private GameObject worldScene; // GameObject racine de la scène du monde à désactiver pendant les combats
@@ -183,7 +184,8 @@ public class BattleTransitionManager : MonoBehaviour
 
         worldFadeOverlay ??= GameObject.Find("WorldFadeOverlayPanel")?.GetComponent<Image>();
         playerDetection ??= FindFirstObjectByType<PlayerDetection>();
-        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
+        // Le tag reste "BattleCamera" mais on récupère désormais le composant CinemachineCamera
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<CinemachineCamera>();
 
         // Tente de récupérer automatiquement le GameObject "WorldScene" si l'on n'a rien assigné dans l'inspecteur
         worldScene ??= GameObject.Find("WorldScene");

--- a/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraActivationManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using Cinemachine; // Pour la gestion de la BattleCamera Cinemachine
 
 /// <summary>
 /// Gère l'activation des différentes caméras du jeu afin d'éviter qu'elles soient
@@ -10,7 +11,7 @@ public class CameraActivationManager : MonoBehaviour
     public static CameraActivationManager Instance { get; private set; }
 
     private Camera worldCamera;   // Référence à la WorldCam_Cam
-    private Camera battleCamera;  // Référence à la BattleCam_Cam
+    private CinemachineCamera battleCamera;  // Référence à la BattleCam_Cam
     private Camera versusCamera;  // Référence à la VersusCam_Cam
 
     /// <summary>
@@ -41,7 +42,8 @@ public class CameraActivationManager : MonoBehaviour
     {
         // Recherche des caméras par leurs tags respectifs
         worldCamera = GameObject.FindGameObjectWithTag("WorldCamera")?.GetComponent<Camera>();
-        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
+        // Le tag "BattleCamera" pointe désormais vers un CinemachineCamera
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<CinemachineCamera>();
         versusCamera = GameObject.FindGameObjectWithTag("VersusCamera")?.GetComponent<Camera>();
 
         ActivateWorldCamera(); // État par défaut : exploration
@@ -98,7 +100,8 @@ public class CameraActivationManager : MonoBehaviour
     /// ne puissent jamais être actives en même temps afin d'éviter des rendus
     /// multiples coûteux.
     /// </summary>
-    private void SetCameraState(Camera cam, bool state)
+    // Utilise Behaviour pour accepter aussi bien Camera que CinemachineCamera
+    private void SetCameraState(Behaviour cam, bool state)
     {
         if (cam == null)
             return;

--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using Cinemachine; // Permet de manipuler le composant CinemachineCamera
 
 public enum WorldCameraState
 {
@@ -39,7 +40,7 @@ public class CameraController : MonoBehaviour
     [Tooltip("Fréquence de l'oscillation de respiration.")]
     [SerializeField] private float breathingFrequency = 1f;
 
-    private Camera battleCamera;               // Référence directe à la BattleCamera
+    private CinemachineCamera battleCamera;    // Référence directe à la BattleCamera
     private Transform battleCameraParent;      // Parent direct de la BattleCamera (utilisé pour le forçage)
     private float worldBreathOffset;           // Dernier décalage appliqué à la WorldCamera elle-même
     private float battleBreathOffset;          // Dernier décalage appliqué à la BattleCamera elle-même
@@ -123,7 +124,7 @@ public class CameraController : MonoBehaviour
         }
 
         // Recherche de la BattleCamera et de son parent pour gérer séparément forçage et respiration
-        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<Camera>();
+        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")?.GetComponent<CinemachineCamera>();
         if (battleCamera == null) Debug.LogWarning("[CameraController] BattleCamera introuvable !");
         battleCameraParent = battleCamera != null && battleCamera.transform.parent != null
             ? battleCamera.transform.parent

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -8,6 +8,7 @@ using UnityEngine.InputSystem;
 using TMPro;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
+using Cinemachine; // Nécessaire pour récupérer la BattleCamera Cinemachine
 
 #region TargetType
 public enum TargetType
@@ -1698,7 +1699,8 @@ public class NewBattleManager : MonoBehaviour
 
         // Utilise la caméra mémorisée ; la recherche est effectuée ponctuellement si nécessaire
         EnsureBattleCamera();
-        Camera screenshotCamera = battleCamera?.GetComponent<Camera>();
+        // Récupère désormais le composant CinemachineCamera sur l'objet tagué
+        CinemachineCamera screenshotCamera = battleCamera?.GetComponent<CinemachineCamera>();
         if (screenshotCamera == null)
         {
             Debug.LogError("Aucune caméra trouvée pour la capture !");

--- a/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Cinemachine; // Utilisation de CinemachineCamera pour la BattleCamera
 
 /// <summary>
 /// Initialise différents paramètres dès le chargement de la scène Commencement.
@@ -37,7 +38,8 @@ public class StartManager : MonoBehaviour
     void ResetCamerasDepth()
     {
         Debug.Log("Resetting Camera Depths");
-        Camera battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponentInChildren<Camera>();
+        // Le tag "BattleCamera" cible désormais un CinemachineCamera
+        CinemachineCamera battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponentInChildren<CinemachineCamera>();
         battleCamera.depth = 0;
     }
 


### PR DESCRIPTION
## Résumé
- remplace la récupération de `Camera` par `CinemachineCamera` pour les objets tagués `BattleCamera`
- ajuste le gestionnaire d'activation pour accepter `CinemachineCamera` en plus des `Camera`
- met à jour les scripts dépendants (popup, transitions, manager de combat, etc.)

## Tests
- `dotnet test` *(commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba5adb9083258c6108f0e6bb4a21