### PR TITLE
Corrige l'utilisation de CinemachineCamera avec Unity 6

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -609,8 +609,10 @@ public class BattleTransitionManager : MonoBehaviour
         // Utilise la nouvelle méthode FindObjectsByType afin d'éviter l'appel obsolète
         var battleUICanvas = FindObjectsByType<Canvas>(FindObjectsSortMode.None)
             .FirstOrDefault(c => c.renderMode == RenderMode.ScreenSpaceCamera);
-        if (battleUICanvas != null)
-            battleUICanvas.worldCamera = battleCamera;
+        if (battleUICanvas != null && battleCamera != null)
+            // CinemachineCamera ne peut pas être directement assignée : on récupère la
+            // caméra Unity pilotée par Cinemachine pour l'utiliser dans l'UI.
+            battleUICanvas.worldCamera = battleCamera.OutputCamera;
 
         GameObject.Find("BattleScene_TransitionCanvas")?.transform.GetChild(0).gameObject.SetActive(true);
     }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1699,8 +1699,10 @@ public class NewBattleManager : MonoBehaviour
 
         // Utilise la caméra mémorisée ; la recherche est effectuée ponctuellement si nécessaire
         EnsureBattleCamera();
-        // Récupère désormais le composant CinemachineCamera sur l'objet tagué
-        CinemachineCamera screenshotCamera = battleCamera?.GetComponent<CinemachineCamera>();
+        // Récupère le composant CinemachineCamera sur l'objet tagué
+        CinemachineCamera screenshotCinemachine = battleCamera?.GetComponent<CinemachineCamera>();
+        // La capture se fait via la caméra Unity contrôlée par Cinemachine
+        Camera screenshotCamera = screenshotCinemachine != null ? screenshotCinemachine.OutputCamera : null;
         if (screenshotCamera == null)
         {
             Debug.LogError("Aucune caméra trouvée pour la capture !");
@@ -1710,8 +1712,8 @@ public class NewBattleManager : MonoBehaviour
         // Assure-toi que la caméra utilise la render texture pour la capture
         RenderTexture prevRT = screenshotCamera.targetTexture;
         screenshotCamera.targetTexture = VictoryScreenImage;
-        screenshotCamera.Render();
-        screenshotCamera.targetTexture = prevRT;
+        screenshotCamera.Render(); // Rend explicitement la scène dans la texture
+        screenshotCamera.targetTexture = prevRT; // Restaure l'ancienne configuration
 
         Debug.Log("Screenshot de victoire capturé !");
     }

--- a/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
@@ -39,8 +39,12 @@ public class StartManager : MonoBehaviour
     {
         Debug.Log("Resetting Camera Depths");
         // Le tag "BattleCamera" cible désormais un CinemachineCamera
-        CinemachineCamera battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponentInChildren<CinemachineCamera>();
-        battleCamera.depth = 0;
+        CinemachineCamera battleCamera = GameObject.FindGameObjectWithTag("BattleCamera")
+            .GetComponentInChildren<CinemachineCamera>();
+        // La profondeur doit être appliquée à la caméra Unity contrôlée par Cinemachine
+        Camera realCamera = battleCamera != null ? battleCamera.OutputCamera : null;
+        if (realCamera != null)
+            realCamera.depth = 0; // Replace la caméra de bataille au-dessus des autres
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- Utilisation de `OutputCamera` pour relier l'UI à la caméra de combat.
- Ajustement de la profondeur des caméras via la caméra Unity pilotée par Cinemachine.
- Capture de l'écran de victoire mise à jour pour utiliser la caméra réelle et la RenderTexture.

## Test
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bfcc61bc8325b33d668c6031ec5a