### PR TITLE
Gestion dynamique des caméras de combat

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -3,20 +3,23 @@ using System.Linq;
 using UnityEngine;
 using Unity.Cinemachine;
 
+/// <summary>
+/// Permet de changer de CinemachineCamera en ajustant les priorites.
+/// </summary>
 [DisallowMultipleComponent]
 public class CinemachineBlendSwitcher : MonoBehaviour
 {
     [Header("Brain (auto si vide)")]
     [SerializeField] private CinemachineBrain brain;
 
-    [Header("Caméras (auto-scan si vide)")]
+    [Header("Cameras (auto-scan si vide)")]
     [SerializeField] private List<CinemachineCamera> cameras = new();
 
-    [Header("Priorités")]
+    [Header("Priorites")]
     [SerializeField] private int activePriority = 100;
     [SerializeField] private int inactivePriority = 10;
 
-    [Header("Style de blend par défaut")]
+    [Header("Style de blend par defaut")]
     [SerializeField]
     private CinemachineBlendDefinition.Styles blendStyle =
         CinemachineBlendDefinition.Styles.EaseInOut;
@@ -26,16 +29,17 @@ public class CinemachineBlendSwitcher : MonoBehaviour
 
     void Awake()
     {
-        // Brain
+        // Recuperation du CinemachineBrain sur la camera de rendu.
         if (!brain && Camera.main) brain = Camera.main.GetComponent<CinemachineBrain>();
-        if (!brain) Debug.LogWarning("[BlendSwitcher] Aucun CinemachineBrain trouvé sur la caméra de rendu.");
+        if (!brain) Debug.LogWarning("[BlendSwitcher] Aucun CinemachineBrain trouve sur la camera de rendu.");
 
-        // Collecte des CmCameras
+        // Collecte automatique des CinemachineCamera si la liste est vide.
         if (cameras == null || cameras.Count == 0)
             cameras = FindObjectsByType<CinemachineCamera>(FindObjectsSortMode.None).ToList();
 
         cameras = cameras.Where(c => c != null).Distinct().ToList();
 
+        // Construction du dictionnaire d'acces rapide par nom.
         _byName.Clear();
         foreach (var c in cameras)
         {
@@ -43,43 +47,55 @@ public class CinemachineBlendSwitcher : MonoBehaviour
             if (!_byName.ContainsKey(key)) _byName.Add(key, c);
         }
 
+        // Toutes les cameras commencent avec une priorite inactive.
         foreach (var c in cameras) c.Priority = inactivePriority;
     }
 
     /// <summary>
-    /// Active la CinemachineCamera nommée "cameraName" avec une durée de blend "blendDuration".
+    /// Active la CinemachineCamera nommee <paramref name="cameraName"/>.
+    /// Si <paramref name="cameraName"/> est null ou vide,
+    /// toutes les CinemachineCamera sont desactivees pour revenir
+    /// a la camera classique taggee "BattleCamera".
     /// </summary>
     public void DisplayCamera(string cameraName, float blendDuration)
     {
+        // Cas : aucune camera Cinemachine active souhaitee.
         if (string.IsNullOrEmpty(cameraName))
         {
-            Debug.LogWarning("[BlendSwitcher] cameraName vide.");
+            foreach (var c in cameras)
+                c.Priority = inactivePriority; // toutes perdent la main
+
+            _current = null;
             return;
         }
 
+        // Recherche de la camera a activer.
         if (!_byName.TryGetValue(cameraName, out var next))
         {
             RebuildMap();
             if (!_byName.TryGetValue(cameraName, out next))
             {
-                Debug.LogWarning($"[BlendSwitcher] Aucune CinemachineCamera trouvée: {cameraName}");
+                Debug.LogWarning($"[BlendSwitcher] Aucune CinemachineCamera trouvee: {cameraName}");
                 return;
             }
         }
 
         if (_current == next) return;
 
-        // Définir le blend par défaut juste avant le switch
+        // Definition du blend par defaut juste avant le switch.
         if (brain)
             brain.DefaultBlend = new CinemachineBlendDefinition(blendStyle, Mathf.Max(0f, blendDuration));
 
-        // Priorités : la plus haute sera prise par le Brain et blended depuis l’actuelle
+        // Gestion des priorites : seule la camera cible obtient la priorite active.
         foreach (var c in cameras)
             c.Priority = (c == next) ? activePriority : inactivePriority;
 
         _current = next;
     }
 
+    /// <summary>
+    /// Reconstruit la liste et le dictionnaire des cameras disponibles.
+    /// </summary>
     public void RebuildMap()
     {
         cameras = FindObjectsByType<CinemachineCamera>(FindObjectsSortMode.None)

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -3,31 +3,26 @@ using UnityEngine;
 using Unity.Cinemachine;
 
 /// <summary>
-/// Gère l'activation des différentes <see cref="CinemachineCamera"/> en combat.
-/// Utilise <see cref="CinemachineBlendSwitcher"/> pour assurer des transitions fluides
-/// entre les angles de caméra.
-/// Chaque <c>MusicalMove</c> ou <c>Item</c> peut spécifier le nom d'une caméra à activer.
+/// Gere l'activation des CinemachineCamera durant les combats.
+/// Les transitions s'effectuent via <see cref="CinemachineBlendSwitcher"/>.
 /// </summary>
 public class BattleCameraManager : MonoBehaviour
 {
-    /// <summary>Accès global au gestionnaire de caméra de combat.</summary>
+    /// <summary>Acces global au gestionnaire de camera de combat.</summary>
     public static BattleCameraManager Instance { get; private set; }
 
-    [Tooltip("Durée du blend entre deux caméras.")]
+    [Tooltip("Duree du blend entre deux cameras.")]
     [SerializeField] private float blendDuration = 0.5f;
 
-    // Composant responsable des priorités et du blend entre caméras
+    // Composant responsable du changement de camera via les priorites.
     private CinemachineBlendSwitcher blendSwitcher;
 
-    // Caméra principale de combat (CinemachineCamera_0_BattleCamera)
-    private CinemachineCamera battleCamera;
-
-    // Collection de toutes les autres caméras disponibles pour le choix aléatoire
-    private readonly List<CinemachineCamera> otherCameras = new();
+    // Ensemble des cameras Cinemachine disponibles pour les moves.
+    private readonly List<CinemachineCamera> availableCameras = new();
 
     void Awake()
     {
-        // Mise en place du singleton
+        // Mise en place du singleton classique.
         if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
@@ -35,67 +30,58 @@ public class BattleCameraManager : MonoBehaviour
         }
         Instance = this;
 
-        // Recherche du CinemachineBlendSwitcher présent dans la scène
+        // Recherche du CinemachineBlendSwitcher present dans la scene.
         blendSwitcher = FindObjectOfType<CinemachineBlendSwitcher>();
         if (!blendSwitcher)
-            Debug.LogWarning("[BattleCameraManager] Aucun CinemachineBlendSwitcher trouvé dans la scène.");
+            Debug.LogWarning("[BattleCameraManager] Aucun CinemachineBlendSwitcher trouve dans la scene.");
 
-        // Récupération de la caméra principale explicitement par son nom
-        // On évite ainsi de se baser sur un éventuel tag "BattleCamera" qui
-        // pourrait pointer vers une autre caméra.
-        battleCamera = GameObject.Find("CinemachineCamera_0_BattleCamera")
-            ?.GetComponent<CinemachineCamera>();
-        if (!battleCamera)
-            Debug.LogWarning("[BattleCameraManager] Caméra principale introuvable (CinemachineCamera_0_BattleCamera).");
-
-        // Constitution de la liste des autres caméras pour les sélections aléatoires
+        // Recense toutes les CinemachineCamera presentes (angles speciaux).
         foreach (var cam in FindObjectsOfType<CinemachineCamera>())
         {
-            if (cam != null && cam != battleCamera)
-                otherCameras.Add(cam);
+            if (cam != null)
+                availableCameras.Add(cam);
         }
 
-        // S'assure que la caméra principale est affichée au démarrage
-        if (blendSwitcher && battleCamera)
-            blendSwitcher.DisplayCamera(battleCamera.gameObject.name, 0f);
+        // Au demarrage du combat on revient sur la camera principale taggee "BattleCamera".
+        if (blendSwitcher)
+            blendSwitcher.DisplayCamera(null, 0f);
     }
 
     /// <summary>
-    /// Active la caméra correspondant au nom fourni.
-    /// - <c>null</c>  : retour à la caméra de combat principale.
-    /// - chaîne vide : sélection d'une caméra aléatoire.
+    /// Active la camera correspondant au nom fourni.
+    /// - <c>null</c>  : retour a la camera de combat par defaut (tag "BattleCamera").
+    /// - chaine vide : selection d'une camera aleatoire.
     /// </summary>
-    /// <param name="cameraName">Nom de la caméra souhaitée.</param>
+    /// <param name="cameraName">Nom de la camera souhaitee.</param>
     public void SwitchToCamera(string cameraName)
     {
         if (!blendSwitcher)
             return; // Impossible de switcher sans blendSwitcher
 
-        // Cas 1 : aucun move/item en cours ➜ on revient à la BattleCamera
-        // DisplayCamera lui attribuera la priorité active (100)
+        // Cas 1 : aucun move/item en cours -> on revient sur la camera par defaut.
         if (cameraName == null)
         {
-            if (battleCamera)
-                blendSwitcher.DisplayCamera(battleCamera.gameObject.name, blendDuration);
+            blendSwitcher.DisplayCamera(null, blendDuration);
             return;
         }
 
-        // Cas 2 : nom vide ➜ choix d'une caméra aléatoire
+        // Cas 2 : nom vide -> choix d'une camera aleatoire.
         if (string.IsNullOrWhiteSpace(cameraName))
         {
-            if (otherCameras.Count > 0)
+            if (availableCameras.Count > 0)
             {
-                var randomCam = otherCameras[Random.Range(0, otherCameras.Count)];
+                var randomCam = availableCameras[Random.Range(0, availableCameras.Count)];
                 cameraName = randomCam.gameObject.name;
             }
-            else if (battleCamera)
+            else
             {
-                // Aucun autre angle disponible, on retombe sur la caméra principale
-                cameraName = battleCamera.gameObject.name;
+                // Aucune camera disponible, on retombe sur la camera principale.
+                blendSwitcher.DisplayCamera(null, blendDuration);
+                return;
             }
         }
 
-        // Affiche la caméra demandée (ou la BattleCamera si tout a échoué)
+        // Affiche la camera demandee (transition assuree par le blend switcher).
         blendSwitcher.DisplayCamera(cameraName, blendDuration);
     }
 }


### PR DESCRIPTION
## Résumé
- Centralisation de la logique de bascule des caméras de combat.
- Possibilité de désactiver toutes les CinemachineCamera pour revenir sur la caméra taggée "BattleCamera".

## Tests
- `dotnet test` *(absence de l'outil, installation impossible : réf. 403 lors de `apt-get update`)*


------
https://chatgpt.com/codex/tasks/task_e_68c66feba78c8325a45e1fa3c8779268