### PR TITLE
Retirer la gestion de caméra via Timeline pour les moves

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -2,49 +2,22 @@ using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 
 /// <summary>
-/// Gestionnaire dédié au lancement des <see cref="TimelineAsset"/> durant les combats.
-/// Toutes les timelines de <c>MusicalMove</c> et d'<c>Item</c> sont lues via deux
-/// <see cref="PlayableDirector"/> spécialisés :
-/// <list type="bullet">
-/// <item>PlayableDirector_Camera pour les mouvements de caméra globaux.</item>
-/// <item>PlayableDirector_Caster pour les animations du lanceur.</item>
-/// </list>
+/// Gestionnaire centralisant les <see cref="TimelineAsset"/> jouées durant les combats.
+/// Désormais seule la timeline du lanceur est utilisée, la caméra étant gérée par ailleurs.
 /// </summary>
 public class BattleTimelineManager : MonoBehaviour
 {
     /// <summary>Instance statique accessible depuis les autres scripts.</summary>
     public static BattleTimelineManager Instance { get; private set; }
 
-    /// <summary>Director dédié aux timelines de caméra globales.</summary>
-    private PlayableDirector directorCamera;
-
     /// <summary>Director chargé des animations du lanceur.</summary>
     private PlayableDirector directorCaster;
 
-    /// <summary>Structure interne représentant une demande de lecture de timeline caméra.</summary>
-    private class TimelineRequest
-    {
-        public TimelineAsset timeline;      // Timeline à jouer
-        public GameObject caster;           // Objet utilisé pour les bindings (animations, signaux...)
-        public GameObject cameraTarget;     // Nouvelle cible pour positionner et suivre la caméra
-        public string cameraTag;            // Tag de la caméra à animer
-        public bool autoRestore;            // Faut-il restaurer la caméra à la fin ?
-        public Quaternion? fixedRotation;   // Rotation imposée pour conserver l'orientation
-    }
-
-    /// <summary>File d'attente des timelines caméra à jouer séquentiellement.</summary>
-    private readonly Queue<TimelineRequest> timelineQueue = new Queue<TimelineRequest>();
-
-    /// <summary>Référence vers la coroutine de traitement de la file.</summary>
-    private Coroutine queueCoroutine;
-
     private void Awake()
     {
-        // Mise en place du singleton classique.
+        // Mise en place classique du singleton.
         if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
@@ -52,37 +25,26 @@ public class BattleTimelineManager : MonoBehaviour
         }
         Instance = this;
 
-        // Récupération des deux PlayableDirectors enfants.
-        Transform camChild = transform.Find("PlayableDirector_Camera");
+        // Recherche du PlayableDirector dédié au caster.
         Transform casterChild = transform.Find("PlayableDirector_Caster");
-        directorCamera = camChild != null ? camChild.GetComponent<PlayableDirector>() : null;
         directorCaster = casterChild != null ? casterChild.GetComponent<PlayableDirector>() : null;
 
-        if (directorCamera == null)
-            Debug.LogError("[BattleTimelineManager] PlayableDirector_Camera introuvable.");
         if (directorCaster == null)
             Debug.LogError("[BattleTimelineManager] PlayableDirector_Caster introuvable.");
-
-        // Le TimelineManager global utilise le director de caméra pour gérer les timelines principales.
-        if (TimelineManager.Instance != null && directorCamera != null)
-            TimelineManager.Instance.SetExternalDirector(directorCamera);
     }
 
     /// <summary>
-    /// Repositionne immédiatement l'origine de la caméra de combat sur une cible fournie.
-    /// Utilisé lorsque seule l'animation du lanceur est jouée (overlay) afin de
-    /// conserver une mise en scène cohérente malgré l'absence de timeline caméra
-    /// spécifique à la phase en cours.
+    /// Aligne l'origine de la caméra de combat sur la cible donnée.
     /// </summary>
-    /// <param name="cameraTarget">Objet servant de nouvelle ancre pour la caméra.</param>
-    /// <param name="cameraTag">Tag de la caméra à déplacer.</param>
+    /// <param name="cameraTarget">Nouvelle ancre pour la caméra.</param>
+    /// <param name="cameraTag">Tag de la caméra à repositionner.</param>
     /// <param name="fixedRotation">Rotation imposée, ou null pour reprendre celle de la cible.</param>
     public void AlignCameraToTarget(GameObject cameraTarget, string cameraTag, Quaternion? fixedRotation = null)
     {
         if (cameraTarget == null || string.IsNullOrEmpty(cameraTag))
             return;
 
-        // Recherche de la caméra puis de son parent direct (BattleCamera_Origin).
+        // On récupère le parent direct (BattleCamera_Origin) pour déplacer l'ensemble du rig.
         GameObject cameraGO = GameObject.FindGameObjectWithTag(cameraTag);
         Transform cameraParent = cameraGO != null ? cameraGO.transform.parent : null;
 
@@ -93,78 +55,11 @@ public class BattleTimelineManager : MonoBehaviour
         }
     }
 
-
     /// <summary>
-    /// Lance une timeline caméra via le PlayableDirector dédié et la file d'attente.
+    /// Joue uniquement la timeline du lanceur. Aucune piste caméra n'est prise en compte.
     /// </summary>
-    public void PlayTimeline(
-        TimelineAsset timeline,
-        GameObject caster,
-        GameObject cameraTarget,
-        string cameraTag,
-        bool autoRestore = true,
-        Quaternion? fixedRotation = null)
-    {
-        if (timeline == null || TimelineManager.Instance == null || directorCamera == null)
-        {
-            Debug.LogWarning("[BattleTimelineManager] Lecture annulée : gestionnaire ou timeline manquante.");
-            return;
-        }
-
-        timelineQueue.Enqueue(new TimelineRequest
-        {
-            timeline = timeline,
-            caster = caster,
-            cameraTarget = cameraTarget,
-            cameraTag = cameraTag,
-            autoRestore = autoRestore,
-            fixedRotation = fixedRotation
-        });
-
-        if (queueCoroutine == null)
-            queueCoroutine = StartCoroutine(ProcessQueue());
-    }
-
-    /// <summary>Traite séquentiellement toutes les timelines caméra en attente.</summary>
-    private IEnumerator ProcessQueue()
-    {
-        while (timelineQueue.Count > 0)
-        {
-            var request = timelineQueue.Dequeue();
-
-            // Assure l'utilisation du director caméra par le TimelineManager global.
-            TimelineManager.Instance.SetExternalDirector(directorCamera);
-
-            // Restaure la caméra uniquement à la fin de la dernière timeline de la file.
-            bool restore = request.autoRestore && timelineQueue.Count == 0;
-
-            TimelineManager.Instance.PlayTimeline(
-                request.timeline,
-                request.caster,
-                request.cameraTag,
-                false,
-                false,
-                true,
-                restore,
-                request.fixedRotation,
-                request.cameraTarget);
-
-            // Attente de la fin de la timeline en cours.
-            while (TimelineManager.Instance.IsTimelinePlaying)
-            {
-                if (timelineQueue.Count > 0)
-                    TimelineManager.Instance.SetAutoRestore(false);
-                yield return null;
-            }
-        }
-
-        // Toutes les timelines ont été jouées : on libère la coroutine.
-        queueCoroutine = null;
-    }
-
-    /// <summary>
-    /// Joue une timeline d'animation pour le lanceur en parallèle de la caméra.
-    /// </summary>
+    /// <param name="timeline">Timeline à exécuter.</param>
+    /// <param name="caster">Objet servant de référence pour les bindings.</param>
     public void PlayCasterTimeline(TimelineAsset timeline, GameObject caster)
     {
         if (timeline == null || directorCaster == null)
@@ -172,21 +67,17 @@ public class BattleTimelineManager : MonoBehaviour
 
         directorCaster.playableAsset = timeline;
 
-        // Binding explicite des pistes vers l'Animator, le GameObject du lanceur
-        // ou encore le SignalReceiver associé au PlayableDirector.
+        // Parcourt toutes les pistes pour relier dynamiquement les bons objets.
         foreach (var output in timeline.outputs)
         {
-            // 🔍 Type attendu par la piste (Animator, SignalReceiver, etc.)
             Type type = output.outputTargetType;
             string lower = output.streamName.ToLower();
 
-            // Les pistes caméra sont ignorées dans ce director spécialisé.
+            // Les pistes caméra sont ignorées : la caméra n'est plus contrôlée par timeline.
             if (lower.Contains("camera"))
                 continue;
 
-            // ✅ Gestion spécifique des pistes de Signaux : on les relie au
-            // SignalReceiver présent sur le PlayableDirector pour que les
-            // événements de la timeline soient correctement reçus.
+            // Les pistes de signaux sont reliées au SignalReceiver du PlayableDirector.
             if (type != null && typeof(Component).IsAssignableFrom(type) && type.Name.Contains("SignalReceiver"))
             {
                 Component receiver = directorCaster.GetComponent(type);
@@ -198,10 +89,10 @@ public class BattleTimelineManager : MonoBehaviour
                 {
                     Debug.LogWarning($"[BattleTimelineManager] {type.Name} manquant sur {directorCaster.gameObject.name} pour la timeline.");
                 }
-                continue; // Rien d'autre à faire pour cette piste
+                continue;
             }
 
-            // 🎭 Pistes d'animation : on tente de lier un Animator du lanceur
+            // Pistes d'animation : on tente de lier un Animator du lanceur.
             if (lower.Contains("caster") || lower.Contains("pnj"))
             {
                 if (caster == null)
@@ -213,16 +104,22 @@ public class BattleTimelineManager : MonoBehaviour
                 else
                     Debug.LogWarning("[BattleTimelineManager] Animator manquant sur le caster pour la timeline.");
             }
-            else
+            else if (caster != null)
             {
-                // 🧍 Autres pistes : on relie simplement le GameObject du lanceur
-                if (caster != null)
-                    directorCaster.SetGenericBinding(output.sourceObject, caster);
+                // Autres pistes : on relie simplement le GameObject du lanceur.
+                directorCaster.SetGenericBinding(output.sourceObject, caster);
             }
         }
 
         directorCaster.time = 0;
         directorCaster.Play();
+    }
+
+    /// <summary>Arrête la timeline du lanceur si elle est en cours.</summary>
+    public void StopCasterTimeline()
+    {
+        if (directorCaster != null && directorCaster.state == PlayState.Playing)
+            directorCaster.Stop();
     }
 
     /// <summary>Indique si le director du lanceur joue actuellement une timeline.</summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2113,16 +2113,14 @@ public class NewBattleManager : MonoBehaviour
     private void StartItemPreparingTimeline()
     {
         // S'assure qu'une Timeline et un gestionnaire existent avant de lancer quoi que ce soit
-        if (itemPreparingTimeline == null || BattleTimelineManager.Instance == null || TimelineManager.Instance == null || itemMenuTimelineActive)
+        if (itemPreparingTimeline == null || BattleTimelineManager.Instance == null || itemMenuTimelineActive)
             return;
 
         GameObject animGO = currentCharacterUnit.GetComponentInChildren<Animator>()?.gameObject;
-        // Démarre la Timeline qui boucle tant que le menu est ouvert
-        BattleTimelineManager.Instance.PlayTimeline(
-            itemPreparingTimeline,
-            animGO,
-            animGO,
-            "BattleCamera");
+        // La caméra n'étant plus contrôlée par timeline, on la repositionne puis
+        // on joue la boucle d'attente uniquement sur le lanceur.
+        BattleTimelineManager.Instance.AlignCameraToTarget(animGO, "BattleCamera");
+        BattleTimelineManager.Instance.PlayCasterTimeline(itemPreparingTimeline, animGO);
         itemMenuTimelineActive = true;
     }
 
@@ -2131,10 +2129,11 @@ public class NewBattleManager : MonoBehaviour
     /// </summary>
     private void StopItemPreparingTimeline()
     {
-        if (!itemMenuTimelineActive || TimelineManager.Instance == null)
+        if (!itemMenuTimelineActive || BattleTimelineManager.Instance == null)
             return;
 
-        TimelineManager.Instance.StopTimeline();
+        // Arrête la timeline d'attente lancée sur le caster.
+        BattleTimelineManager.Instance.StopCasterTimeline();
         itemMenuTimelineActive = false;
     }
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -199,69 +199,39 @@ public class RhythmQTEManager : MonoBehaviour
         if (timeline == null || BattleTimelineManager.Instance == null || animatorGO == null)
             return;
 
-        if (overlay)
-        {
-            // 🎥 Lorsque la caméra globale (overlay) est utilisée, la timeline du lanceur
-            // est lue via le PlayableDirector dédié. Cependant, l'origine de la caméra
-            // (BattleCamera_Origin) ne se repositionnait pas, ce qui provoquait un ancrage
-            // incorrect durant les phases de préparation et de repli. Nous ré-alignons donc
-            // explicitement l'origine avant de lancer l'animation du caster.
-            BattleTimelineManager.Instance.AlignCameraToTarget(
-                cameraTarget ?? animatorGO, // Fallback sur le lanceur si la cible est absente
-                battleCameraTag,
-                initialRotation);
+        // 📽️ La caméra n'étant plus pilotée par les timelines des moves/items,
+        // nous ré-alignons simplement l'origine avant de lancer la timeline du lanceur.
+        BattleTimelineManager.Instance.AlignCameraToTarget(
+            cameraTarget ?? animatorGO, // Fallback sur le lanceur si la cible est absente
+            battleCameraTag,
+            initialRotation);
 
-            // Lecture via le PlayableDirector du lanceur en parallèle de la timeline caméra complète.
-            BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
-        }
-        else
-        {
-            // Cas classique : la timeline contrôle également la caméra.
-            BattleTimelineManager.Instance.PlayTimeline(timeline, animatorGO, cameraTarget, battleCameraTag, autoRestore, initialRotation);
-        }
+        // Lecture de la seule timeline du caster.
+        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
     }
 
     /// <summary>
     /// Attend la fin d'une timeline précédemment lancée.
     /// </summary>
     /// <param name="timeline">Timeline à surveiller.</param>
-    /// <param name="overlay">Vrai si la timeline est jouée en superposition.</param>
+    /// <param name="overlay">Paramètre conservé pour compatibilité, sans effet.</param>
     private IEnumerator WaitForTimelinePhase(TimelineAsset timeline, bool overlay)
     {
         if (timeline == null)
             yield break;
 
-        if (overlay)
+        float maxDuration = (float)timeline.duration;
+        float timer = 0f;
+        while (BattleTimelineManager.Instance != null &&
+               BattleTimelineManager.Instance.IsCasterTimelinePlaying &&
+               timer < maxDuration)
         {
-            // Suivi de la timeline via le PlayableDirector du lanceur.
-            float maxDuration = (float)timeline.duration;
-            float timer = 0f;
-            while (BattleTimelineManager.Instance != null &&
-                   BattleTimelineManager.Instance.IsCasterTimelinePlaying &&
-                   timer < maxDuration)
-            {
-                timer += Time.deltaTime;
-                yield return null;
-            }
-
-            if (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePlaying)
-                Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
+            timer += Time.deltaTime;
+            yield return null;
         }
-        else
-        {
-            float maxDuration = (float)timeline.duration;
-            float timer = 0f;
-            while (TimelineManager.Instance != null &&
-                   TimelineManager.Instance.IsTimelineActive &&
-                   timer < maxDuration)
-            {
-                timer += Time.deltaTime;
-                yield return null;
-            }
 
-            if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelineActive)
-                Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
-        }
+        if (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePlaying)
+            Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
     }
 
     // Séquence du Musicalmove - Ajouter autant de méthodes que d'effets durant le move


### PR DESCRIPTION
## Résumé
- Centralisation des timelines de combat sur le seul lanceur et suppression des pistes caméra.
- Mise à jour du RhythmQTEManager pour aligner la caméra puis lire uniquement la timeline du caster.
- Adaptation du NewBattleManager pour l'animation d'attente d'item sans timeline caméra.

## Tests
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : dépôts 403 - impossible d’installer dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c672783be48325b416f7bbf798d415