### PR TITLE
Séparation des caméras par phase pour moves et items

### DIFF
--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
@@ -56,4 +56,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 11400000, guid: 923281249d69c464c96295029f742965, type: 2}
   performingTimeline: {fileID: 11400000, guid: b86e10946b4e6fb4d975fd2aee69fae3, type: 2}
   retreatTimeline: {fileID: 11400000, guid: 57375bf4baa7d8e4d9e3f34c0e6b607f, type: 2}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
@@ -56,4 +56,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 7116d965a53bbee449dc994ffb5382ce, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
@@ -56,4 +56,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 7116d965a53bbee449dc994ffb5382ce, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
+++ b/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
@@ -53,6 +53,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_BombeSonique/Item_BombeSonique.asset
+++ b/Assets/Items/Item_BombeSonique/Item_BombeSonique.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_ClefDuCourage/Item_ClefDuCourage.asset
+++ b/Assets/Items/Item_ClefDuCourage/Item_ClefDuCourage.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_ElixirRevitalisant/Item_ElixirRevitalisant.asset
+++ b/Assets/Items/Item_ElixirRevitalisant/Item_ElixirRevitalisant.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_Endormissement/Item_Endormissement.asset
+++ b/Assets/Items/Item_Endormissement/Item_Endormissement.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
+++ b/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -52,7 +52,8 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
-  cameraName: CinemachineCamera_1_Corner_SU_R
+  preparingCameraName: CinemachineCamera_1_Corner_SU_R
+  performingCameraName: CinemachineCamera_1_Corner_SU_R
+  retreatCameraName:
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
+++ b/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
+++ b/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_Reveil/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil/Item_Reveil.asset
@@ -52,6 +52,5 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 0}
   beatPattern: []
   notes: []

--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
+++ b/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
@@ -56,4 +56,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
+++ b/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
+++ b/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
@@ -56,4 +56,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 11400000, guid: 8b121268222063b4989da9ded3770c89, type: 2}
   performingTimeline: {fileID: 11400000, guid: b83f5d61e438b814f9280da6cf30b677, type: 2}
   retreatTimeline: {fileID: 11400000, guid: 6437c7bb2b604fa4988c0e1be04bf1a1, type: 2}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
+++ b/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -55,5 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 332f64de2f14fea46b6df0d3bc73ee75, type: 2}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}
-  cameraName: CinemachineCamera_4_Corner_SU_L
+  preparingCameraName: CinemachineCamera_4_Corner_SU_L
+  performingCameraName: CinemachineCamera_4_Corner_SU_L
+  retreatCameraName:

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -55,4 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 361e91e8ca92edc459ed5ed247a853bd, type: 2}
   retreatTimeline: {fileID: 0}
-  cameraName: CinemachineCamera_5_Caster_Near
+  preparingCameraName: CinemachineCamera_5_Caster_Near
+  performingCameraName: CinemachineCamera_5_Caster_Near
+  retreatCameraName:

--- a/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
+++ b/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -55,4 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
   retreatTimeline: {fileID: 0}
-  cameraName: CinemachineCamera_5_Caster_Near
+  preparingCameraName: CinemachineCamera_5_Caster_Near
+  performingCameraName: CinemachineCamera_5_Caster_Near
+  retreatCameraName:

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -55,4 +55,3 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
-  fullTimeline: {fileID: 11400000, guid: 9749fda41aa1d3f489ae1280dda9b32b, type: 2}

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -88,15 +88,17 @@ public class ItemData : ScriptableObject
     public TimelineAsset performingTimeline;
     [Tooltip("Timeline jouée lors du repli après utilisation")]
     public TimelineAsset retreatTimeline;
-    [Tooltip("Timeline de caméra couvrant toute l'action de l'item.\n" +
-             "Elle suit l'utilisateur durant la préparation, l'exécution\n" +
-             "et le repli pour offrir un mouvement continu.")]
-    public TimelineAsset fullTimeline;
 
-    [Header("Caméra")]
-    // Nom de la CinemachineCamera à activer lors de l'utilisation de l'objet
-    [Tooltip("Nom de la CinemachineCamera utilisée pour cet objet.\nLaisser vide pour utiliser la caméra de combat par défaut.")]
-    public string cameraName;
+    [Header("Caméras par phase")]
+    // Nom de la caméra pendant la préparation de l'objet.
+    [Tooltip("CinemachineCamera active lors de la préparation.\nLaisser vide pour conserver la caméra en cours.")]
+    public string preparingCameraName;
+    // Nom de la caméra pendant l'utilisation de l'objet.
+    [Tooltip("CinemachineCamera active pendant l'utilisation.\nLaisser vide pour garder la caméra précédente.")]
+    public string performingCameraName;
+    // Nom de la caméra pendant la phase de repli.
+    [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
+    public string retreatCameraName;
 
     [Header("QTE Pattern")]
     public List<float> beatPattern;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -136,10 +136,16 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Timeline jouée lors du repli après l'exécution du move")]
     public TimelineAsset retreatTimeline;
 
-    [Header("Caméra")]
-    // Référence à la nouvelle CinemachineCamera à activer pour ce move
-    [Tooltip("Nom de la CinemachineCamera utilisée pour ce move.\nLaisser vide pour garder la caméra de combat par défaut.")]
-    public string cameraName;
+    [Header("Caméras par phase")]
+    // Nom de la caméra utilisée pendant la phase de préparation.
+    [Tooltip("CinemachineCamera active lors de la préparation.\nLaisser vide pour conserver la caméra actuelle.")]
+    public string preparingCameraName;
+    // Nom de la caméra utilisée pendant la phase d'exécution.
+    [Tooltip("CinemachineCamera active pendant l'exécution.\nLaisser vide pour garder la caméra précédente.")]
+    public string performingCameraName;
+    // Nom de la caméra utilisée pendant la phase de repli.
+    [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
+    public string retreatCameraName;
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -194,10 +194,14 @@ public class RhythmQTEManager : MonoBehaviour
     /// <param name="cameraTarget">Objet servant d'ancre pour la caméra.</param>
     /// <param name="autoRestore">Indique si la caméra doit être restaurée automatiquement.</param>
     /// <param name="initialRotation">Rotation de référence à conserver.</param>
-    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation)
+    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation, string cameraName = null)
     {
         if (timeline == null || BattleTimelineManager.Instance == null || animatorGO == null)
             return;
+
+        // 🎥 Active la caméra dédiée à cette phase si elle est renseignée.
+        if (!string.IsNullOrWhiteSpace(cameraName))
+            BattleCameraManager.Instance?.SwitchToCamera(cameraName);
 
         // 📽️ La caméra n'étant plus pilotée par les timelines des moves/items,
         // nous ré-alignons simplement l'origine avant de lancer la timeline du lanceur.
@@ -246,9 +250,6 @@ public class RhythmQTEManager : MonoBehaviour
         Debug.Log("Début de la séquence du MusicalMove: " + move + " de " + casterName);
         isActive = true;
         successResults = new List<bool>();
-
-        // Active la caméra spécifique au move si définie.
-        BattleCameraManager.Instance?.SwitchToCamera(move.cameraName);
 
         // Position et rotation initiales du lanceur avant tout déplacement.
         // La rotation capturée ici (début de la phase de préparation) servira de
@@ -314,7 +315,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             casterCameraTarget,
             move.performingTimeline == null && move.retreatTimeline == null,
-            initialRotation);
+            initialRotation,
+            move.preparingCameraName);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay);
 
         // Déplacement ou téléportation vers la cible si nécessaire.
@@ -335,7 +337,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             performingCameraTarget,
             move.retreatTimeline == null,
-            initialRotation);
+            initialRotation,
+            move.performingCameraName);
 
         if (pendingNotes == 0)
         {
@@ -373,7 +376,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             casterCameraTarget,
             true,
-            initialRotation);
+            initialRotation,
+            move.retreatCameraName);
         yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay);
 
         // Attente finale de la timeline caméra complète (désactivée).
@@ -412,9 +416,6 @@ public class RhythmQTEManager : MonoBehaviour
         string itemCasterName = caster != null ? caster.name : "(caster nul)";
         Debug.Log($"Début de la séquence d'utilisation de l'objet: {item.itemName} par {itemCasterName}");
         isActive = true;
-
-        // Active la caméra spécifique à l'objet si renseignée.
-        BattleCameraManager.Instance?.SwitchToCamera(item.cameraName);
 
         // Position et rotation de départ du lanceur avant toute animation.
         // La rotation enregistrée ici au tout début de la phase de préparation
@@ -458,7 +459,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             casterCameraTarget,
             item.performingTimeline == null && item.retreatTimeline == null,
-            initialRotation);
+            initialRotation,
+            item.preparingCameraName);
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay);
 
         // Déplacement ou téléportation éventuel vers la cible.
@@ -479,7 +481,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             performingCameraTarget,
             item.retreatTimeline == null,
-            initialRotation);
+            initialRotation,
+            item.performingCameraName);
 
         // QTE associé à l'objet durant l'utilisation.
         LastItemSuccess = true;
@@ -508,7 +511,8 @@ public class RhythmQTEManager : MonoBehaviour
             casterAnimatorGO,
             casterCameraTarget,
             true,
-            initialRotation);
+            initialRotation,
+            item.retreatCameraName);
         yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay);
 
         isActive = false;

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -22,21 +22,16 @@ sans infliger directement un bonus ou un malus classique. Elles ouvrent des
 opportunités tactiques que les novices peuvent appréhender facilement tout en
 permettant aux vétérans de créer des enchaînements complexes.
 
-## Timeline caméra continue
-Un champ `fullTimeline` est disponible dans chaque **MusicalMove** et désormais dans chaque **Item**. Il définit un
-mouvement de caméra couvrant l'ensemble de l'action (préparation, utilisation/exécution et repli) pour assurer un
-suivi sans coupure. La rotation du lanceur est enregistrée dès la première frame de la phase de préparation puis
-conservée jusqu'à la fin du move ou de l'objet, même si plusieurs timelines s'enchaînent, afin de garantir une
-orientation cohérente de la caméra.
+## Caméras par phase
+Chaque **MusicalMove** et chaque **Item** peut désormais définir trois noms de
+caméras Cinemachine :
+`preparingCameraName`, `performingCameraName` et `retreatCameraName`.
+Ces champs autorisent l'utilisation d'une caméra différente pour chaque
+phase sans obligation. Laisser un champ vide conserve la caméra active, ce
+qui garantit une transition fluide.
 
-Les phases classiques restent gérées par le code du jeu afin de déclencher les téléportations nécessaires entre chaque
-étape. Les timelines `preparingTimeline`, `performingTimeline` et `retreatTimeline` peuvent être lues en
-**superposition** pour animer le lanceur ou ses effets pendant que la caméra suit la timeline principale.
-
-Lorsqu'un **MusicalMove** ou un **Item** est utilisé, la `fullTimeline` démarre en premier puis les timelines de
-préparation, d'exécution et de repli se succèdent automatiquement en parallèle. Le lanceur peut être téléporté entre la
-fin de la préparation et le début de l'exécution ainsi qu'entre l'exécution et le repli afin d'assurer un enchaînement
-fluide de l'action.
+Ce nouveau système remplace l'ancien champ `cameraName` unique ainsi que
+la notion de `fullTimeline` qui contrôlait auparavant la caméra.
 
 ## Déplacement optionnel
 Un booléen `requiresMovement` est présent dans chaque **MusicalMove** et **Item**.


### PR DESCRIPTION
## Résumé
- Ajout de champs `preparingCameraName`, `performingCameraName` et `retreatCameraName` aux MusicalMoves et Items
- Adaptation du `RhythmQTEManager` pour commuter la caméra à chaque phase
- Suppression des anciennes références `fullTimeline` et du champ `cameraName` unique

## Tests
- `dotnet test` *(échoué: command not found)*
- `apt-get update` *(échoué: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a15b753c8325a89c21a45ad7bfa1