### PR TITLE
Utilisation du transform pour le suivi et la visée en combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleCaster.cs
@@ -1,25 +1,18 @@
 using UnityEngine;
-using Unity.Cinemachine;
 
-/// Suit le lanceur actuel (caster) avec un décalage (Body = CinemachineFollow).
-[RequireComponent(typeof(CinemachineCamera))]
+/// Suit le lanceur actuel (caster) avec un décalage.
 public class FollowBattleCaster : MonoBehaviour
 {
     [Tooltip("Décalage appliqué par rapport à la position du lanceur.")]
     public Vector3 offset = new(0, 2, -3);
 
-    private CinemachineCamera cmCamera;
-
-    void Awake() => cmCamera = GetComponent<CinemachineCamera>();
-
     void LateUpdate()
     {
+        // Récupère le lanceur actuellement actif dans le combat.
         var caster = NewBattleManager.Instance?.currentCharacterUnit;
         if (!caster) return;
 
-        cmCamera.Follow = caster.transform;
-
-        if (cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Body) is CinemachineFollow follow)
-            follow.FollowOffset = offset;
+        // Place la caméra directement par rapport au lanceur, en tenant compte de l'offset.
+        transform.position = caster.transform.position + offset;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FollowBattleTarget.cs
@@ -1,26 +1,19 @@
 using UnityEngine;
-using Unity.Cinemachine;
 
-/// Suit la cible actuelle du combat avec un décalage personnalisé (Body = CinemachineFollow).
-[RequireComponent(typeof(CinemachineCamera))]
+/// Suit la cible actuelle du combat avec un décalage personnalisé.
 public class FollowBattleTarget : MonoBehaviour
 {
     [Tooltip("Décalage appliqué par rapport à la position de la cible.")]
     public Vector3 offset = new(0, 2, -3);
 
-    private CinemachineCamera cmCamera;
-
-    void Awake() => cmCamera = GetComponent<CinemachineCamera>();
-
     void LateUpdate()
     {
+        // Récupère la cible actuellement suivie dans le gestionnaire de combat.
         var target = NewBattleManager.Instance?.currentTargetCharacter;
         if (!target) return;
 
-        cmCamera.Follow = target.transform;
-
-        // Cinemachine 3 : Body = CinemachineFollow
-        if (cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Body) is CinemachineFollow follow)
-            follow.FollowOffset = offset;
+        // Déplace directement la caméra en appliquant l'offset au transform.
+        // On n'utilise plus CinemachineCamera afin de rester indépendant de ce composant.
+        transform.position = target.transform.position + offset;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleCaster.cs
@@ -1,26 +1,19 @@
 using UnityEngine;
-using Unity.Cinemachine;
 
-/// Oriente la caméra vers le lanceur avec un offset de visée (Aim = CinemachineComposer).
-[RequireComponent(typeof(CinemachineCamera))]
+/// Oriente la caméra vers le lanceur avec un offset de visée.
 public class LookAtBattleCaster : MonoBehaviour
 {
     [Tooltip("Décalage appliqué lors du ciblage du lanceur.")]
     public Vector3 offset;
 
-    private CinemachineCamera cmCamera;
-
-    void Awake() => cmCamera = GetComponent<CinemachineCamera>();
-
     void LateUpdate()
     {
+        // Récupère le lanceur actuel pour orienter la caméra.
         var caster = NewBattleManager.Instance?.currentCharacterUnit;
         if (!caster) return;
 
-        cmCamera.LookAt = caster.transform;
-
-        // Cinemachine 3 : Composer → offset = m_TrackedObjectOffset
-        if (cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Aim) is CinemachineComposer composer)
-            composer.m_TrackedObjectOffset = offset;
+        // Oriente le transform vers le lanceur en prenant en compte l'offset.
+        Vector3 lookPosition = caster.transform.position + offset;
+        transform.LookAt(lookPosition);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LookAtBattleTarget.cs
@@ -1,25 +1,19 @@
 using UnityEngine;
-using Unity.Cinemachine;
 
-/// Oriente la caméra vers la cible actuelle avec un offset de visée (Aim = CinemachineComposer).
-[RequireComponent(typeof(CinemachineCamera))]
+/// Oriente la caméra vers la cible actuelle avec un offset de visée.
 public class LookAtBattleTarget : MonoBehaviour
 {
     [Tooltip("Décalage appliqué lors du ciblage de la cible.")]
     public Vector3 offset;
 
-    private CinemachineCamera cmCamera;
-
-    void Awake() => cmCamera = GetComponent<CinemachineCamera>();
-
     void LateUpdate()
     {
+        // Récupère la cible actuelle pour orienter la caméra.
         var target = NewBattleManager.Instance?.currentTargetCharacter;
         if (!target) return;
 
-        cmCamera.LookAt = target.transform;
-
-        if (cmCamera.GetCinemachineComponent(CinemachineCore.Stage.Aim) is CinemachineComposer composer)
-            composer.m_TrackedObjectOffset = offset;
+        // Calcule la position visée en ajoutant l'offset puis oriente le transform vers cette position.
+        Vector3 lookPosition = target.transform.position + offset;
+        transform.LookAt(lookPosition);
     }
 }


### PR DESCRIPTION
## Résumé
- Remplace les réglages Cinemachine des scripts de suivi/visée par des manipulations directes du transform.
- Ajout de commentaires détaillés pour clarifier la logique appliquée aux cibles et aux lanceurs.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts inaccessibles)*
- `apt-get install -y dotnet-sdk-7.0` *(échec : paquet introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a7ab08b883258e1ee54898be1b69