### PR TITLE
Ajout d'une durée de blend par défaut pour Cinemachine

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -24,6 +24,9 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     private CinemachineBlendDefinition.Styles blendStyle =
         CinemachineBlendDefinition.Styles.EaseInOut;
 
+    [Tooltip("Duree par defaut du blend entre deux cameras (en secondes).")]
+    [SerializeField] private float defaultBlendDuration = 1f;
+
     private readonly Dictionary<string, CinemachineCamera> _byName = new();
     private CinemachineCamera _current; // camera actuellement active
 
@@ -62,6 +65,18 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// <para>Si une chaine vide est passee, toutes les cameras sont desactivees
     /// pour revenir a la camera classique.</para>
     /// </summary>
+    public void DisplayCamera(string cameraName)
+    {
+        // Redirige vers la surcharge avec duree explicite en utilisant
+        // la duree de blend par defaut.
+        DisplayCamera(cameraName, defaultBlendDuration);
+    }
+
+    /// <summary>
+    /// Active la <see cref="CinemachineCamera"/> nommee <paramref name="cameraName"/>.
+    /// </summary>
+    /// <param name="cameraName">Nom de la camera a activer.</param>
+    /// <param name="blendDuration">Duree du blend en secondes.</param>
     public void DisplayCamera(string cameraName, float blendDuration)
     {
         // Cas : retour a la camera par defaut (indice 0).

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -11,9 +11,6 @@ public class BattleCameraManager : MonoBehaviour
     /// <summary>Acces global au gestionnaire de camera de combat.</summary>
     public static BattleCameraManager Instance { get; private set; }
 
-    [Tooltip("Duree du blend entre deux cameras.")]
-    [SerializeField] private float blendDuration = 0.5f;
-
     // Composant responsable du changement de camera via les priorites.
     private CinemachineBlendSwitcher blendSwitcher;
 
@@ -43,6 +40,7 @@ public class BattleCameraManager : MonoBehaviour
         }
 
         // Au demarrage du combat on revient sur la camera principale taggee "BattleCamera".
+        // On force une transition immediate (duree 0) pour eviter un fondu au lancement.
         if (blendSwitcher)
             blendSwitcher.DisplayCamera(null, 0f);
     }
@@ -61,7 +59,8 @@ public class BattleCameraManager : MonoBehaviour
         // Cas 1 : aucun move/item en cours -> on revient sur la camera par defaut.
         if (cameraName == null)
         {
-            blendSwitcher.DisplayCamera(null, blendDuration);
+            // Blend avec la duree par defaut du switcher (1 seconde).
+            blendSwitcher.DisplayCamera(null);
             return;
         }
 
@@ -75,13 +74,14 @@ public class BattleCameraManager : MonoBehaviour
             }
             else
             {
-                // Aucune camera disponible, on retombe sur la camera principale.
-                blendSwitcher.DisplayCamera(null, blendDuration);
+                // Si aucune camera speciale n'est disponible, on retourne sur la camera
+                // principale avec la duree de blend standard.
+                blendSwitcher.DisplayCamera(null);
                 return;
             }
         }
 
-        // Affiche la camera demandee (transition assuree par le blend switcher).
-        blendSwitcher.DisplayCamera(cameraName, blendDuration);
+        // Affiche la camera demandee avec la duree de blend geree par le switcher.
+        blendSwitcher.DisplayCamera(cameraName);
     }
 }


### PR DESCRIPTION
## Résumé
- ajoute une durée de blend par défaut (1s) dans `CinemachineBlendSwitcher`
- expose une surcharge de `DisplayCamera` sans paramètre de durée
- simplifie `BattleCameraManager` pour utiliser la durée intégrée

## Tests
- `dotnet test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6afa03e388325b33a47156a70c80f