### PR TITLE
Prioriser la caméra orbitale au démarrage du combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -51,7 +51,11 @@ public class BattleCameraManager : MonoBehaviour
     /// - chaine vide : selection d'une camera aleatoire.
     /// </summary>
     /// <param name="cameraName">Nom de la camera souhaitee.</param>
-    public void SwitchToCamera(string cameraName)
+    /// <param name="blendTime">
+    /// Duree du fondu en secondes. Utiliser une valeur negative pour conserver
+    /// la duree definie dans le <see cref="CinemachineBlendSwitcher"/>.
+    /// </param>
+    public void SwitchToCamera(string cameraName, float blendTime = -1f)
     {
         if (!blendSwitcher)
             return; // Impossible de switcher sans blendSwitcher
@@ -59,8 +63,10 @@ public class BattleCameraManager : MonoBehaviour
         // Cas 1 : aucun move/item en cours -> on revient sur la camera par defaut.
         if (cameraName == null)
         {
-            // Blend avec la duree par defaut du switcher (1 seconde).
-            blendSwitcher.DisplayCamera(null);
+            if (blendTime >= 0f)
+                blendSwitcher.DisplayCamera(null, blendTime); // Transition forcee
+            else
+                blendSwitcher.DisplayCamera(null); // Duree par defaut
             return;
         }
 
@@ -75,13 +81,19 @@ public class BattleCameraManager : MonoBehaviour
             else
             {
                 // Si aucune camera speciale n'est disponible, on retourne sur la camera
-                // principale avec la duree de blend standard.
-                blendSwitcher.DisplayCamera(null);
+                // principale avec la duree de blend souhaitee ou celle par defaut.
+                if (blendTime >= 0f)
+                    blendSwitcher.DisplayCamera(null, blendTime);
+                else
+                    blendSwitcher.DisplayCamera(null);
                 return;
             }
         }
 
-        // Affiche la camera demandee avec la duree de blend geree par le switcher.
-        blendSwitcher.DisplayCamera(cameraName);
+        // Affiche la camera demandee avec la duree de blend appropriee.
+        if (blendTime >= 0f)
+            blendSwitcher.DisplayCamera(cameraName, blendTime);
+        else
+            blendSwitcher.DisplayCamera(cameraName);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.Playables;
 using UnityEngine.InputSystem; // Nécessaire pour utiliser les actions d'input
 using UnityEngine.Timeline; // Pour lancer les timelines post-combat
 using Unity.Cinemachine; // Pour gérer les caméras Cinemachine
@@ -440,32 +439,14 @@ public class BattleTransitionManager : MonoBehaviour
         CharacterUnit firstUnit = NewBattleManager.Instance.ReturnFirstStrikeCharacter();
         if (battleCamera != null)
         {
-            battleCamera.SetActive(true); // Active explicitement la caméra d'intro si elle était désactivée
+            battleCamera.SetActive(true); // S'assure que la camera de combat est active
 
             if (firstUnit != null)
                 battleCamera.transform.position = firstUnit.transform.position;
 
-            // Récupère le PlayableDirector directement sur le même objet que ce gestionnaire.
-            // Cela évite de chercher dans la hiérarchie de la battleCamera et clarifie la structure.
-            PlayableDirector introDirector = transform.GetComponent<PlayableDirector>();
-            if (introDirector != null)
-            {
-                // Signale au TimelineManager de jouer cette Timeline afin qu'il suive
-                // précisément son état (lecture/en pause/arrêt).
-                // Le troisième paramètre à "false" garantit que la musique en cours n'est
-                // pas atténuée ni interrompue lors de l'explosion de l'écran Versus.
-                // L'introduction de combat doit se dérouler entièrement sans possibilité de l'interrompre
-                TimelineManager.Instance.PlayTimeline(introDirector, false, false, false);
-
-                // Tant que la Timeline est en cours, on attend avant d'afficher l'UI
-                // pour ne pas interférer avec la cinématique d'introduction.
-                yield return new WaitUntil(() => !TimelineManager.Instance.IsTimelinePlaying);
-            }
-            else
-            {
-                // Avertissement explicite si aucun PlayableDirector n'est trouvé sur l'objet courant.
-                Debug.LogWarning("[BattleTransitionManager] Aucun PlayableDirector trouvé sur BattleTransitionManager.");
-            }
+            // Au lieu de jouer une timeline d'introduction, on affiche directement
+            // la camera orbitale autour du champ de bataille avec une transition instantanée.
+            BattleCameraManager.Instance?.SwitchToCamera("CinemachineCamera_10_OrbitAroundBattlefield", 0f);
         }
         else
         {


### PR DESCRIPTION
## Résumé
- Remplace la timeline d'intro de combat par l'activation immédiate de la caméra `CinemachineCamera_10_OrbitAroundBattlefield`.
- Ajoute un paramètre de durée de fondu à `BattleCameraManager.SwitchToCamera` pour permettre des transitions instantanées.

## Tests
- `dotnet test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : dépôts non signés/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b8e383b4832587a71b48527d2195