### PR TITLE
Retarde l'apparition du menu principal après l'intro caméra

### DIFF
--- a/Assets/Scenes/MainMenu/MainMenu.prefab
+++ b/Assets/Scenes/MainMenu/MainMenu.prefab
@@ -85,6 +85,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6048776095960774139}
   - component: {fileID: 3399561089178856574}
+  - component: {fileID: 3188643251887260983}
   m_Layer: 0
   m_Name: MainMenu
   m_TagString: Untagged
@@ -129,7 +130,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cbd45d5b19ee4d16b4fa08ad897b1270, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   pressA: {fileID: 1278535571591470836}
   menuContainer: {fileID: 7645946083320227689}
   loadMenu: {fileID: 238922239257272416}
@@ -138,6 +139,21 @@ MonoBehaviour:
   cursorOffset: {x: -150, y: 0, z: 0}
   navigationCooldown: 0.25
   cursorLerpSpeed: 50
+--- !u!114 &3188643251887260983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 897300643701155760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ddb27e07b63445eaeb05741dcee3185, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  introDirector: {fileID: 0}
+  menuManager: {fileID: 3399561089178856574}
+  introDuration: 3
 --- !u!1 &2251524437557201998
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Playables;
+
+/// <summary>
+/// Gère l'introduction de la caméra sur l'écran titre puis
+/// informe le <see cref="MainMenuManager"/> lorsque celle-ci est terminée.
+/// </summary>
+public class MainMenuIntro : MonoBehaviour
+{
+    [Header("Références")]
+    [Tooltip("PlayableDirector jouant l'introduction de caméra. Laisser vide pour utiliser uniquement la durée.")]
+    public PlayableDirector introDirector; // Timeline optionnelle de l'intro
+    [Tooltip("Gestionnaire du menu principal à activer à la fin de l'intro.")]
+    public MainMenuManager menuManager;
+
+    [Header("Paramètres")]
+    [Tooltip("Durée de l'introduction si aucun PlayableDirector n'est fourni.")]
+    public float introDuration = 3f;
+
+    private void Start()
+    {
+        // Si un PlayableDirector est disponible, on attend sa fin
+        if (introDirector != null)
+        {
+            introDirector.stopped += OnIntroStopped;
+        }
+        else
+        {
+            // Sinon, on utilise un simple délai correspondant à la durée de l'intro
+            StartCoroutine(WaitAndActivate());
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (introDirector != null)
+        {
+            introDirector.stopped -= OnIntroStopped;
+        }
+    }
+
+    // Coroutine déclenchée lorsque l'on ne dispose pas d'un PlayableDirector
+    private IEnumerator WaitAndActivate()
+    {
+        yield return new WaitForSeconds(introDuration);
+        NotifyEnd();
+    }
+
+    // Appelée lorsque le PlayableDirector termine la lecture de la timeline
+    private void OnIntroStopped(PlayableDirector _)
+    {
+        NotifyEnd();
+    }
+
+    // Active l'affichage du menu en fin d'intro
+    private void NotifyEnd()
+    {
+        if (menuManager != null)
+        {
+            menuManager.OnIntroFinished();
+        }
+        else
+        {
+            Debug.LogWarning("[MainMenuIntro] MainMenuManager introuvable, impossible d'activer le menu.");
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ddb27e07b63445eaeb05741dcee3185
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
@@ -25,10 +25,13 @@ public class MainMenuManager : MonoBehaviour
     private int currentIndex = 0;
     private float lastNavTime = 0f;
 
-    private bool waitingForInput = true;
+    private bool waitingForInput = false; // Attente active seulement après l'intro
     private float timer = 0f;
     private PlayerInputs playerInputs;
     private Canvas parentCanvas;
+
+    // Indique si l'on doit demander le nom du joueur après l'intro
+    private bool askNameAfterIntro = false;
 
     [Header("Nom de Munin")]
     public GameObject namePanel; // Panneau UI demandant le nom du joueur
@@ -42,8 +45,12 @@ public class MainMenuManager : MonoBehaviour
 
     private void Start()
     {
+        // Au lancement de la scène, on masque toutes les interactions
         if (pressA != null)
-            pressA.alpha = 0.5f; // Pré-affiche le message "Press A"
+        {
+            pressA.alpha = 0.5f; // Valeur par défaut du fade
+            pressA.gameObject.SetActive(false); // Caché tant que l'intro n'est pas terminée
+        }
         if (menuContainer != null)
             menuContainer.SetActive(false);
         if (loadMenu != null)
@@ -76,8 +83,29 @@ public class MainMenuManager : MonoBehaviour
         }
         else
         {
-            // Aucun nom enregistré : on affiche le panneau de saisie
+            // Aucun nom enregistré : on affichera le panneau après l'intro
+            askNameAfterIntro = true;
+        }
+    }
+
+    /// <summary>
+    /// Méthode appelée à la fin de l'introduction de caméra pour
+    /// afficher l'indication "Press A" ou le panneau de saisie du nom.
+    /// </summary>
+    public void OnIntroFinished()
+    {
+        if (askNameAfterIntro)
+        {
+            // Le joueur doit d'abord choisir son nom
             ShowNamePanel();
+            return;
+        }
+
+        waitingForInput = true;
+        if (pressA != null)
+        {
+            pressA.gameObject.SetActive(true);
+            pressA.alpha = 0.5f; // Valeur initiale du clignotement
         }
     }
 
@@ -97,13 +125,15 @@ public class MainMenuManager : MonoBehaviour
     {
         if (waitingForInput)
         {
+            // Animation de l'indication "Press A"
             timer += Time.deltaTime * fadeSpeed;
             float alpha = 0.25f + 0.25f * (1 + Mathf.Sin(timer));
             if (pressA != null)
                 pressA.alpha = alpha;
         }
-        else
+        else if (menuContainer != null && menuContainer.activeSelf)
         {
+            // Navigation uniquement lorsque le menu est ouvert
             HandleNavigation();
         }
 
@@ -119,6 +149,10 @@ public class MainMenuManager : MonoBehaviour
 
     private void OnConfirm(InputAction.CallbackContext ctx)
     {
+        // Empêche toute interaction tant que l'intro n'est pas terminée
+        if (!waitingForInput && (menuContainer == null || !menuContainer.activeSelf))
+            return;
+
         // Si le panneau de saisie du nom est actif, le bouton de confirmation validera le nom
         if (namePanel != null && namePanel.activeSelf)
         {


### PR DESCRIPTION
## Résumé
- Cache le menu principal et l'indication "Press A" jusqu'à la fin de l'introduction de caméra.
- Ajoute un script `MainMenuIntro` pour notifier le `MainMenuManager` une fois l'intro terminée (timeline ou délai fixe).
- Met à jour le prefab du menu pour intégrer ce nouveau comportement.

## Tests
- `dotnet test` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be8c77808325a3124aaf5be03be4