### PR TITLE
Corrige le filtre noir persistant lors de la transition vers le combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -708,8 +708,13 @@ public class BattleTransitionManager : MonoBehaviour
             yield return null;
         }
 
-        // Restaure l'état d'origine de l'overlay
-        worldFadeOverlay.color = originalColor;
+        // Restaure l'overlay en forçant sa transparence.
+        //
+        // Sans cette étape, si un fondu noir précédent (par exemple issu d'une
+        // timeline passée) a laissé l'overlay actif et opaque, le flash se
+        // terminerait sur un écran noir persistant. En imposant un alpha nul,
+        // on garantit que l'effet visuel est toujours correctement réinitialisé.
+        worldFadeOverlay.color = new Color(originalColor.r, originalColor.g, originalColor.b, 0f);
         worldFadeOverlay.gameObject.SetActive(wasActive);
     }
 


### PR DESCRIPTION
## Résumé
- Force la transparence de l'overlay après le flash de transition afin d’éviter un écran noir suite à une timeline.

## Tests
- `dotnet test` *(commande introuvable)*
- `apt-get install -y dotnet-sdk-7.0` *(package introuvable et dépôts non signés)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d426dd2c832593b92624e06a0a16