### PR TITLE
Rend les filtres BlackScreen et WhiteScreen transparents au lancement des combats

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -340,6 +340,20 @@ public class BattleTransitionManager : MonoBehaviour
     /// </summary>
     private IEnumerator TransitionRoutine()
     {
+        // 🛡️ Assure que les filtres BlackScreen et WhiteScreen sont totalement
+        //    transparents avant même l'affichage de l'écran de Versus.
+        //    Cette précaution évite tout flash résiduel provenant d'une
+        //    transition précédente.
+        var fader = FadeChildrenOpacity.Instance;
+        if (fader != null)
+        {
+            // Indice 0 = BlackScreen, indice 1 = WhiteScreen.
+            // La durée est fixée à 0 pour appliquer instantanément la
+            // transparence complète.
+            fader.EnsureTransparency(0, 0f);
+            fader.EnsureTransparency(1, 0f);
+        }
+
         // Détermine quel champ de bataille doit être chargé en fonction de
         // l'ennemi détecté par le joueur.
         // 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -495,6 +495,17 @@ public class NewBattleManager : MonoBehaviour
     {
         Debug.Log("[BattleTurnManager] Démarrage du combat");
 
+        // 🛡️ Assure que les filtres d'écran sont totalement invisibles au lancement du combat.
+        //    Sans cette étape, un résidu de fondu noir ou blanc pourrait persister d'une timeline précédente.
+        var fader = FadeChildrenOpacity.Instance;
+        if (fader != null)
+        {
+            // Indice 0 = BlackScreen, indice 1 = WhiteScreen
+            // La durée est fixée à 0 pour appliquer la transparence immédiatement.
+            fader.EnsureTransparency(0, 0f);
+            fader.EnsureTransparency(1, 0f);
+        }
+
         GameManager.Instance?.ResetEnemiesDefeatedCount();
 
         battleStartTime = Time.time;


### PR DESCRIPTION
## Résumé
- Assure que les écrans noir et blanc sont immédiatement transparents en début de combat

## Test
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôt non signé)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e5ad15488325a125a19582c4b446