### PR TITLE
Définir caméras par défaut pour nouveaux contenus

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -1,6 +1,9 @@
 ﻿using UnityEngine;
 using UnityEngine.Timeline;
 using System.Collections.Generic;
+#if UNITY_EDITOR
+using UnityEditor; // Nécessaire uniquement dans l'éditeur pour charger l'item de référence.
+#endif
 
 [CreateAssetMenu(fileName = "New Item", menuName = "Symphonie/Item")]
 public class ItemData : ScriptableObject
@@ -99,6 +102,34 @@ public class ItemData : ScriptableObject
     // Nom de la caméra pendant la phase de repli.
     [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
     public string retreatCameraName;
+
+#if UNITY_EDITOR
+    // ------------------------------------------------------------------
+    // Références par défaut
+    // ------------------------------------------------------------------
+    // Les nouveaux Items doivent initialiser leurs caméras en se basant sur
+    // l'objet d'exemple "Item_LonguePortee". Cela évite de créer des
+    // variations involontaires et facilite le travail des game designers.
+    private const string LONGUE_PORTEE_PATH =
+        "Assets/Items/Item_LonguePortee/Item_LonguePortee.asset";
+
+    private void OnValidate()
+    {
+        // Récupère l'Item de référence. Si introuvable, on ne fait rien pour
+        // éviter les messages d'erreur intempestifs.
+        var reference = AssetDatabase.LoadAssetAtPath<ItemData>(LONGUE_PORTEE_PATH);
+        if (reference == null)
+            return;
+
+        // Applique les valeurs par défaut uniquement si les champs sont vides.
+        if (string.IsNullOrEmpty(preparingCameraName))
+            preparingCameraName = reference.preparingCameraName;
+        if (string.IsNullOrEmpty(performingCameraName))
+            performingCameraName = reference.performingCameraName;
+        if (string.IsNullOrEmpty(retreatCameraName))
+            retreatCameraName = reference.retreatCameraName;
+    }
+#endif
 
     [Header("QTE Pattern")]
     public List<float> beatPattern;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 // Les directives UnityEditor sont réservées à l'éditeur et ne doivent pas
 // être incluses dans le build du joueur. Elles ont été retirées pour éviter
 // les erreurs de compilation lors de l'export.
+#if UNITY_EDITOR
+using UnityEditor; // Utilisé uniquement pour charger les assets de référence.
+#endif
 
 [CreateAssetMenu(fileName = "NewMusicalMove", menuName = "Symphonie/Musical Move")]
 public class MusicalMoveSO : ScriptableObject
@@ -146,6 +149,40 @@ public class MusicalMoveSO : ScriptableObject
     // Nom de la caméra utilisée pendant la phase de repli.
     [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
     public string retreatCameraName;
+
+#if UNITY_EDITOR
+    // ------------------------------------------------------------------
+    // Références par défaut
+    // ------------------------------------------------------------------
+    // Lorsque l'on crée un nouveau MusicalMove, les trois champs de caméra
+    // doivent automatiquement reprendre les valeurs de l'exemple
+    // "MusicalMove_Rhapsodie" afin d'assurer une cohérence visuelle dans
+    // tout le projet. Cette méthode est uniquement exécutée dans l'éditeur
+    // afin d'éviter toute dépendance aux fichiers lors du build final.
+    private const string RHAPSODIE_PATH =
+        "Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset";
+
+    private void OnValidate()
+    {
+        // Charge le ScriptableObject de référence. Si le fichier est déplacé
+        // ou supprimé, aucune action n'est effectuée pour ne pas provoquer
+        // d'erreur dans l'éditeur.
+        var reference = AssetDatabase.LoadAssetAtPath<MusicalMoveSO>(RHAPSODIE_PATH);
+        if (reference == null)
+            return;
+
+        // Pour chaque champ, si aucune valeur n'est renseignée, on copie
+        // celle de "MusicalMove_Rhapsodie". Les concepteurs peuvent ensuite
+        // remplacer ces valeurs manuellement selon les besoins spécifiques
+        // du nouveau move.
+        if (string.IsNullOrEmpty(preparingCameraName))
+            preparingCameraName = reference.preparingCameraName;
+        if (string.IsNullOrEmpty(performingCameraName))
+            performingCameraName = reference.performingCameraName;
+        if (string.IsNullOrEmpty(retreatCameraName))
+            retreatCameraName = reference.retreatCameraName;
+    }
+#endif
 
     public void ApplyEffect(CharacterUnit caster, CharacterUnit target)
     {

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -30,6 +30,14 @@ Ces champs autorisent l'utilisation d'une caméra différente pour chaque
 phase sans obligation. Laisser un champ vide conserve la caméra active, ce
 qui garantit une transition fluide.
 
+### Valeurs par défaut recommandées
+Pour assurer une expérience cohérente, tout **nouveau MusicalMove** doit
+initialiser ces trois champs avec les valeurs définies dans
+**MusicalMove_Rhapsodie**. De même, les **nouveaux Items** doivent se baser
+sur les valeurs utilisées par **Item_LonguePortee**. Les concepteurs
+peuvent ensuite adapter ces paramètres selon les besoins spécifiques du
+contenu ajouté.
+
 Ce nouveau système remplace l'ancien champ `cameraName` unique ainsi que
 la notion de `fullTimeline` qui contrôlait auparavant la caméra.
 


### PR DESCRIPTION
## Résumé
- Initialise automatiquement les caméras par défaut des nouveaux MusicalMoves à partir de Rhapsodie
- Copie les valeurs de caméra de l'Item LonguePortée lors de la création de nouveaux Items
- Documente les références par défaut pour guider l'ajout de futurs contenus

## Test
- `npm test` *(échoue : package.json introuvable)*
- `dotnet test` *(échoue : dotnet non installé)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e8f50e7c83258e41d0276ae34cfe