### PR TITLE
Évite les téléportations inutiles et bloque la rotation en Y

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1644,11 +1644,16 @@ public class NewBattleManager : MonoBehaviour
             anim.Play("Turn_90");
         }
 
-        // Tant que l’angle entre la rotation actuelle et la target est > 0.5f
+        // Verrouille la rotation initiale sur l'axe Y pour éviter tout tilt.
+        unit.transform.rotation = Quaternion.Euler(0f, unit.transform.eulerAngles.y, 0f);
+
+        // Tant que l’angle entre la rotation actuelle et la cible reste significatif
         while (Quaternion.Angle(unit.transform.rotation, targetRotation) > 0.5f)
         {
+            // Applique une rotation progressive uniquement sur l'axe Y
+            Quaternion current = Quaternion.Euler(0f, unit.transform.eulerAngles.y, 0f);
             unit.transform.rotation = Quaternion.RotateTowards(
-                unit.transform.rotation,
+                current,
                 targetRotation,
                 rotationSpeed * Time.deltaTime
             );

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -538,9 +538,11 @@ public class RhythmQTEManager : MonoBehaviour
         // Récupère le GameObject qui porte l'Animator pour pouvoir le masquer
         GameObject visualRoot = animator != null ? animator.gameObject : null;
 
-        bool isTeleport = item.moveSpeed <= 0f;
+        bool isTeleport = item.moveSpeed <= 0f; // Téléportation si vitesse nulle ou négative
+        float distanceToDestination = Vector3.Distance(caster.transform.position, destination); // Distance à parcourir
 
-        if (isTeleport)
+        // Téléportation uniquement si la destination est différente de la position actuelle
+        if (isTeleport && distanceToDestination > 0.01f)
         {
             // Lecture des effets de départ
             if (item.tpSFx_Start != null)
@@ -572,7 +574,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (item.tpSFx_End != null)
                 PlaySfx(item.tpSFx_End);
         }
-        else
+        else if (!isTeleport)
         {
             // Animation du dash
             if (!caster.IsDead)
@@ -591,6 +593,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
             caster.transform.position = destination;
         }
+        // Si isTeleport mais distance nulle, on ne fait rien : aucune téléportation nécessaire
 
         // Orientation vers la cible
         Vector3 dir = (target.transform.position - caster.transform.position).normalized;
@@ -610,9 +613,11 @@ public class RhythmQTEManager : MonoBehaviour
         Animator animator = caster.GetComponentInChildren<Animator>();
         // GameObject contenant l'Animator à masquer pendant la téléportation
         GameObject visualRoot = animator != null ? animator.gameObject : null;
-        bool isTeleport = item.moveSpeed <= 0f;
+        bool isTeleport = item.moveSpeed <= 0f; // Téléportation si vitesse nulle
+        float distanceToOrigin = Vector3.Distance(caster.transform.position, origin); // Distance de retour
 
-        if (isTeleport)
+        // Téléportation uniquement si le retour nécessite un déplacement
+        if (isTeleport && distanceToOrigin > 0.01f)
         {
             if (item.tpSFx_Start != null)
                 PlaySfx(item.tpSFx_Start);
@@ -641,7 +646,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (item.tpSFx_End != null)
                 PlaySfx(item.tpSFx_End);
         }
-        else
+        else if (!isTeleport)
         {
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
@@ -658,6 +663,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
             caster.transform.position = origin;
         }
+        // Si isTeleport mais distance nulle, aucune action n'est nécessaire
 
         // Orientation optionnelle vers la cible
         if (target != null)
@@ -703,9 +709,11 @@ public class RhythmQTEManager : MonoBehaviour
         Animator animator = caster.GetComponentInChildren<Animator>();
         // Stocke le GameObject visuel pour pouvoir le désactiver durant la téléportation
         GameObject visualRoot = animator != null ? animator.gameObject : null;
-        bool isTeleport = move.moveSpeed <= 0f;
+        bool isTeleport = move.moveSpeed <= 0f; // Téléportation si vitesse nulle
+        float distanceToTarget = Vector3.Distance(caster.transform.position, targetPos); // Distance à la cible
 
-        if (isTeleport)
+        // Téléportation uniquement si la cible est différente de la position actuelle
+        if (isTeleport && distanceToTarget > 0.01f)
         {
             if (move.tpSFx_Start != null)
                 PlaySfx(move.tpSFx_Start);
@@ -734,7 +742,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (move.tpSFx_End != null)
                 PlaySfx(move.tpSFx_End);
         }
-        else
+        else if (!isTeleport)
         {
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
@@ -751,6 +759,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
             caster.transform.position = targetPos;
         }
+        // Si isTeleport mais aucune distance à parcourir, on ignore le déplacement
 
         Vector3 lookDir = Vector3.zero;
         if (target != null)
@@ -784,9 +793,11 @@ public class RhythmQTEManager : MonoBehaviour
         Animator animator = caster.GetComponentInChildren<Animator>();
         // GameObject contenant l'Animator à désactiver durant la téléportation
         GameObject visualRoot = animator != null ? animator.gameObject : null;
-        bool isTeleport = move.moveSpeed <= 0f;
+        bool isTeleport = move.moveSpeed <= 0f; // Téléportation si vitesse nulle
+        float distanceToInitial = Vector3.Distance(caster.transform.position, initialPosition); // Distance à parcourir
 
-        if (isTeleport)
+        // Téléportation uniquement si nécessaire
+        if (isTeleport && distanceToInitial > 0.01f)
         {
             if (move.tpSFx_Start != null)
                 PlaySfx(move.tpSFx_Start);
@@ -795,7 +806,6 @@ public class RhythmQTEManager : MonoBehaviour
 
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
-
 
             // Cache temporairement le GameObject visuel
             if (visualRoot != null)
@@ -822,7 +832,7 @@ public class RhythmQTEManager : MonoBehaviour
             if (move.tpSFx_End != null)
                 PlaySfx(move.tpSFx_End);
         }
-        else
+        else if (!isTeleport)
         {
             if (!caster.IsDead)
                 animator?.Play("Dash_Battle");
@@ -838,6 +848,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
             caster.transform.position = initialPosition;
         }
+        // Si isTeleport mais distance nulle, pas de retour nécessaire
 
         yield return null;
 


### PR DESCRIPTION
## Résumé
- Empêche les compétences et objets de téléporter le personnage si la destination est identique à sa position actuelle
- Fige la rotation pendant les changements de tour pour ne pivoter que sur l’axe Y

## Tests
- `dotnet test` *(échec : dotnet manquant)*
- `apt-get update` *(échec : dépôts non signés/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eaf755008325bc09b1f2b11b554a