### PR TITLE
Retarder l'affichage du menu principal jusqu'à la fin de l'intro caméra

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuIntro.cs
@@ -18,6 +18,16 @@ public class MainMenuIntro : MonoBehaviour
     [Tooltip("Durée de l'introduction si aucun PlayableDirector n'est fourni.")]
     public float introDuration = 3f;
 
+    private void Awake()
+    {
+        // Assure que le menu principal reste caché dès le chargement de la scène
+        // pour éviter qu'il n'apparaisse avant la fin de l'intro de caméra.
+        if (menuManager != null)
+        {
+            menuManager.HideAllUI();
+        }
+    }
+
     private void Start()
     {
         // Si un PlayableDirector est disponible, on attend sa fin

--- a/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/MainMenuManager.cs
@@ -43,20 +43,44 @@ public class MainMenuManager : MonoBehaviour
         playerInputs = new PlayerInputs();
     }
 
+    /// <summary>
+    /// Masque complètement l'interface du menu. Appelé au démarrage
+    /// et avant l'activation du menu pour éviter tout affichage prématuré
+    /// pendant l'introduction de la caméra.
+    /// </summary>
+    public void HideAllUI()
+    {
+        // Indication "Press A" cachée et alpha réinitialisé
+        if (pressA != null)
+        {
+            pressA.alpha = 0.5f;
+            pressA.gameObject.SetActive(false);
+        }
+
+        // Conteneur du menu principal désactivé
+        if (menuContainer != null)
+            menuContainer.SetActive(false);
+
+        // Sous-menu de chargement masqué
+        if (loadMenu != null)
+            loadMenu.gameObject.SetActive(false);
+
+        // Curseur de navigation hors champ
+        if (menuCursor != null)
+            menuCursor.SetActive(false);
+
+        // Panneau de saisie de nom désactivé par sécurité
+        if (namePanel != null)
+            namePanel.SetActive(false);
+
+        // Aucune interaction autorisée tant que l'intro n'est pas terminée
+        waitingForInput = false;
+    }
+
     private void Start()
     {
         // Au lancement de la scène, on masque toutes les interactions
-        if (pressA != null)
-        {
-            pressA.alpha = 0.5f; // Valeur par défaut du fade
-            pressA.gameObject.SetActive(false); // Caché tant que l'intro n'est pas terminée
-        }
-        if (menuContainer != null)
-            menuContainer.SetActive(false);
-        if (loadMenu != null)
-            loadMenu.gameObject.SetActive(false);
-        if (menuCursor != null)
-            menuCursor.SetActive(false);
+        HideAllUI();
 
         playerInputs.Menu.Enable();
         playerInputs.World.Enable();


### PR DESCRIPTION
## Résumé
- Ajout d'une méthode `HideAllUI` pour masquer tous les éléments du menu principal.
- Masquage systématique du menu au chargement via `MainMenuIntro`, évitant tout affichage avant la fin de l'intro caméra.

## Tests
- `dotnet test` *(échec : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68c6f04bc3fc8325ac8dd01923ad242c