### PR TITLE
Intégration des actions d'entrée globales

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InteractionManager.cs
@@ -85,16 +85,27 @@ public class InteractionManager : MonoBehaviour
         ResetBattleInputs();
     }
 
+    /// <summary>
+    /// Abonne l'action d'interaction du monde à la confirmation pour
+    /// permettre au joueur de déclencher les <see cref="PointOfInterest"/>.
+    /// </summary>
     public void SetInputs()
     {
-        var infoBox = InputsManager.Instance.playerInputs.InfoBox;
-        infoBox.Confirm.performed += OnConfirm;        
+        // L'action "Interact" fait partie du mapping d'entrée "World".
+        // En l'utilisant directement, on garantit une cohérence des contrôles
+        // sur l'ensemble des PointsOfInterest et dans tout le jeu.
+        var world = InputsManager.Instance.playerInputs.World;
+        world.Interact.performed += OnConfirm;
     }
 
+    /// <summary>
+    /// Retire l'abonnement à l'action d'interaction afin d'éviter
+    /// les appels lorsque l'objet est désactivé.
+    /// </summary>
     public void ResetBattleInputs()
     {
-        var infoBox = InputsManager.Instance.playerInputs.InfoBox;
-        infoBox.Confirm.performed -= OnConfirm;
+        var world = InputsManager.Instance.playerInputs.World;
+        world.Interact.performed -= OnConfirm;
     }
 
     void OnConfirm(InputAction.CallbackContext ctx)
@@ -201,10 +212,9 @@ public class InteractionManager : MonoBehaviour
                     // Affiche l'invite locale d'interaction.
                     localInfoBox.SetActive(true);
 
-                    // Active également la map d'inputs InfoBox pour capter la touche de validation.
+                    // Seule la map "World" est nécessaire pour récupérer l'action Interact.
                     InputsManager.Instance.ActivateOnly(
-                        InputsManager.Instance.playerInputs.World.Get(),
-                        InputsManager.Instance.playerInputs.InfoBox.Get());
+                        InputsManager.Instance.playerInputs.World.Get());
                 }
             }
         }

--- a/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PointOfInterest.cs
@@ -139,6 +139,11 @@ public class PointOfInterest : MonoBehaviour, IInteractable, ILocalInfoBoxTarget
 #endif
 
     // === Mode OnConfirm ===
+    /// <summary>
+    /// Appelé par l'Input System lorsque le joueur presse l'action
+    /// <c>Interact</c> de la map <c>World</c>. Cette méthode délègue ensuite
+    /// le déroulement de l'interaction au moteur interne.
+    /// </summary>
     public void Interact()
     {
         TryStartInteraction();

--- a/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ReveVisionController.cs
@@ -9,36 +9,46 @@ using UnityEngine.InputSystem;
 /// </summary>
 public class ReveVisionController : MonoBehaviour
 {
-    [Tooltip("Action Input System utilisée pour activer la vision révélée.")]
-    public string actionName = "ReveVisionToggle"; // Nom logique de l'action.
+    [Tooltip("Action d'entrée utilisée pour activer la vision révélée.")]
+    public InputAction toggleAction; // Référence vers l'action écoutée.
 
-    [Tooltip("Action d'entrée réellement écoutée. Si null, une action par défaut sera créée.")]
-    public InputAction toggleAction;
+    // Indique si nous avons créé l'action localement (pour éviter de désactiver l'action globale).
+    private bool ownsLocalAction = false;
 
     // État actuel de la vision révélée.
     private bool reveActive = false;
 
-    private void Awake()
+    private void OnEnable()
     {
-        // Crée une action par défaut si rien n'est assigné dans l'inspecteur.
-        if (toggleAction == null)
+        // Essaie d'utiliser le système d'inputs centralisé.
+        if (toggleAction == null && InputsManager.Instance != null)
         {
-            // Par défaut on associe la touche R du clavier.
-            toggleAction = new InputAction(actionName, binding: "<Keyboard>/r");
+            // Utilise l'action "World.Action" définie dans l'asset d'inputs.
+            toggleAction = InputsManager.Instance.playerInputs.World.Action;
+            ownsLocalAction = false;
         }
 
-        // Abonnement au déclenchement de l'action.
+        // Si aucune action n'a pu être récupérée (jeu lancé sans InputsManager), on crée un fallback local.
+        if (toggleAction == null)
+        {
+            toggleAction = new InputAction("ReveVisionToggle", binding: "<Keyboard>/r");
+            toggleAction.Enable();
+            ownsLocalAction = true;
+        }
+
+        // Abonnement au déclenchement.
         toggleAction.performed += OnTogglePerformed;
-        toggleAction.Enable();
     }
 
-    private void OnDestroy()
+    private void OnDisable()
     {
-        // Nettoie proprement l'action pour éviter les fuites mémoire.
         if (toggleAction != null)
         {
             toggleAction.performed -= OnTogglePerformed;
-            toggleAction.Disable();
+
+            // On ne désactive l'action que si elle a été créée localement.
+            if (ownsLocalAction)
+                toggleAction.Disable();
         }
     }
 
@@ -50,6 +60,7 @@ public class ReveVisionController : MonoBehaviour
 
     /// <summary>
     /// Bascule l'état de la vision révélée et met à jour le shader global.
+    /// Cette mécanique fait directement écho à l'Histoire de Symphonie en révélant les secrets cachés.
     /// </summary>
     private void ToggleVision()
     {

--- a/Assets/Scripts/MonoBehavioursUsed/VirtualKeyboard.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/VirtualKeyboard.cs
@@ -39,12 +39,25 @@ public class VirtualKeyboard : MonoBehaviour
     // Texte actuellement saisi via le clavier virtuel, accessible aux autres systèmes.
     public string currentVKWordText { get; private set; } = string.Empty;
 
-    // Référence vers le système d'inputs généré par l'Input System.
+    // Référence vers le système d'inputs. On privilégie l'instance centrale fournie par InputsManager
+    // afin de conserver une cohérence des contrôles dans tout le projet.
     private PlayerInputs playerInputs;
+    // Indique si nous avons dû créer une instance locale (cas rare lorsque InputsManager est absent).
+    private bool ownsLocalInputs = false;
 
     private void Awake()
     {
-        playerInputs = new PlayerInputs();
+        // Récupère l'instance globale d'inputs si disponible ; sinon, on en crée une localement.
+        if (InputsManager.Instance != null)
+        {
+            playerInputs = InputsManager.Instance.playerInputs;
+            ownsLocalInputs = false;
+        }
+        else
+        {
+            playerInputs = new PlayerInputs();
+            ownsLocalInputs = true;
+        }
 
         if (Instance == null)
         {
@@ -76,9 +89,9 @@ public class VirtualKeyboard : MonoBehaviour
         if (cursor != null)
             cursor.gameObject.SetActive(false);
 
-        // Recherche d'une instance de PlayerInputs dans la scène.
+        // Avertit si aucune instance d'inputs n'a pu être trouvée.
         if (playerInputs == null)
-            Debug.LogWarning("[VirtualKeyboard] Aucun PlayerInputs trouvé dans la scène.");
+            Debug.LogWarning("[VirtualKeyboard] Aucun PlayerInputs disponible. Les entrées ne fonctionneront pas.");
     }
 
     /// <summary>
@@ -95,9 +108,10 @@ public class VirtualKeyboard : MonoBehaviour
         _currentIndex = 0;
         UpdateCursor();
 
-        // Activation du mapping World afin de recevoir les entrées
-        // du joystick ou du clavier pendant l'utilisation du clavier virtuel.
-        playerInputs.World.Enable();
+        // On s'assure que le mapping World est actif pour recevoir les entrées.
+        // Si l'InputsManager gère déjà cette map, l'appel à Enable() est sans risque.
+        if (playerInputs != null)
+            playerInputs.World.Enable();
 
         // Abonnements aux différentes entrées du joueur.
         playerInputs.World.Move.performed += OnMove;
@@ -123,9 +137,9 @@ public class VirtualKeyboard : MonoBehaviour
             playerInputs.World.Interact.performed -= OnInteract;
             playerInputs.World.Cancel.performed -= OnCancel;
 
-            // Désactivation du mapping World pour éviter
-            // toute réception d'entrées lorsque le clavier est fermé.
-            playerInputs.World.Disable();
+            // On ne désactive le mapping que si nous avons créé les inputs localement.
+            if (ownsLocalInputs)
+                playerInputs.World.Disable();
         }
 
         if (cursor != null)
@@ -143,8 +157,8 @@ public class VirtualKeyboard : MonoBehaviour
         // On ferme proprement le clavier pour retirer les abonnements et désactiver la map.
         CloseVK();
 
-        // Libère les ressources de l'Input System.
-        if (playerInputs != null)
+        // Libère les ressources uniquement si l'on possède une instance locale.
+        if (ownsLocalInputs && playerInputs != null)
             playerInputs.Dispose();
     }
 

--- a/Docs/SystemeSuccesPointOfInterest.md
+++ b/Docs/SystemeSuccesPointOfInterest.md
@@ -12,5 +12,6 @@ Ce document décrit la procédure pour débloquer un succès lorsque le joueur i
 3. **Configurer le PointOfInterest**
    - Sur le composant `PointOfInterest`, renseignez le champ **Succès** avec l'`AchievementSO` à débloquer.
    - Lors de l'interaction, le succès sera automatiquement débloqué si un `AchievementManager` actif est trouvé.
+   - L'interaction se fait via l'action `Interact` de la map d'entrées **World**, offrant une cohérence de contrôle pour tous les joueurs.
 
 Grâce à cette fonctionnalité, chaque point d'intérêt peut récompenser le joueur par un succès, renforçant ainsi la progression narrative et ludique.


### PR DESCRIPTION
## Résumé
- Harmonise ReveVisionController avec l'InputsManager tout en prévoyant un fallback local
- Centralise le VirtualKeyboard sur l'instance globale de PlayerInputs pour des contrôles cohérents

## Tests
- `npm test` *(échoué : package.json introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_68c705c4d8508325aa02bff33971100e