### PR TITLE
Améliore la fluidité de la WorldCamera

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -149,7 +149,9 @@ public class CameraController : MonoBehaviour
 
     #region Boucle Principale
     /// <summary>
-    /// Gère l'état de la caméra à chaque frame. Peut entrer en conflit avec OrbitAround ou PathFollow actifs.
+    /// Gère l'état de la caméra. La logique de suivi a été déplacée en <c>LateUpdate</c>
+    /// afin de garantir que le joueur a terminé son déplacement avant d'ajuster la caméra,
+    /// ce qui évite les saccades lorsqu'il change brusquement de direction.
     /// </summary>
     void Update()
     {
@@ -171,41 +173,47 @@ public class CameraController : MonoBehaviour
         if (Camera.main != null && !Camera.main.enabled)
             return;
 
-        if (currentWorldCameraState == WorldCameraState.OrbitAround && orbitTarget != null && activeCamera != null)
-        {
-            UpdateOrbit();
-            return;
-        }
-
-        if (Application.isPlaying)
-        {
-            player ??= GameObject.FindGameObjectWithTag("Player")?.transform;
-            eventsManager ??= FindFirstObjectByType<EventsManager>();
-            HandleCameraBehaviour();
-        }
+        // Toute la logique de suivi (HandleCameraBehaviour, UpdateOrbit...) est
+        // désormais appliquée dans LateUpdate pour une meilleure fluidité.
     }
 
     /// <summary>
-    /// Effectue les ajustements de caméra en fin de frame pour éviter les conflits.
+    /// Effectue les ajustements de caméra en fin de frame pour éviter les conflits
+    /// et assurer un suivi plus smooth.
     /// </summary>
     void LateUpdate()
     {
-        if (Application.isPlaying)
-        {
-            // Les Timelines prennent le contrôle total de la caméra
-            if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)
-                return;
+        if (!Application.isPlaying)
+            return;
 
+        // Les Timelines prennent le contrôle total de la caméra
+        if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)
+            return;
+
+        // Mise à jour des références dynamiques (player, eventsManager)
+        player ??= GameObject.FindGameObjectWithTag("Player")?.transform;
+        eventsManager ??= FindFirstObjectByType<EventsManager>();
+
+        // 🔁 Mise à jour de l'orbite ou suivi classique selon l'état courant
+        if (currentWorldCameraState == WorldCameraState.OrbitAround && orbitTarget != null && activeCamera != null)
+        {
+            UpdateOrbit();
+        }
+        else
+        {
+            HandleCameraBehaviour();
+
+            // En mode forcé, l'application de l'offset doit être faite après la mise à jour
             if (currentWorldCameraState == WorldCameraState.Forced)
             {
                 FollowForcedCameraPoint();
             }
-
-            // Applique le léger mouvement de respiration directement sur les GameObjects caméra
-            // (leurs parents restent libres pour recevoir les déplacements forcés)
-            ApplyBreathing(worldCamera != null ? worldCamera.transform : null, ref worldBreathOffset);
-            ApplyBreathing(battleCamera != null ? battleCamera.transform : null, ref battleBreathOffset);
         }
+
+        // Applique le léger mouvement de respiration directement sur les GameObjects caméra
+        // (leurs parents restent libres pour recevoir les déplacements forcés)
+        ApplyBreathing(worldCamera != null ? worldCamera.transform : null, ref worldBreathOffset);
+        ApplyBreathing(battleCamera != null ? battleCamera.transform : null, ref battleBreathOffset);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CameraController.cs
@@ -69,6 +69,9 @@ public class CameraController : MonoBehaviour
     public float forcedCamMinPitch = -20f;
     public float forcedCamMaxPitch = 60f;
 
+    [Tooltip("Vitesse d'interpolation utilisée pour suivre le joueur en mode forcé.")]
+    [SerializeField] private float forcedCamFollowLerpSpeed = 10f;
+
     private float forcedCamYaw = 0f;
     private float forcedCamPitch = 20f;
     private float forcedCamDistance = 5f;
@@ -383,7 +386,7 @@ public class CameraController : MonoBehaviour
     }
 
     /// <summary>
-    /// Applique simplement la position forcée de la caméra sans gestion des collisions.
+    /// Suit le joueur en mode forcé en interpolant position et rotation pour un mouvement fluide.
     /// </summary>
     void FollowForcedCameraPoint()
     {
@@ -395,10 +398,20 @@ public class CameraController : MonoBehaviour
 
         // Position désirée calculée à partir du joueur et de l'offset courant
         Vector3 desiredPos = player.position + forcedCamOffset;
+        // Rotation désirée pour que la caméra regarde la cible adéquate
+        Quaternion desiredRot = Quaternion.LookRotation(look.position - desiredPos);
 
-        // Aucune gestion d'obstacle : la caméra est placée directement à la position désirée.
-        camOrigin.position = desiredPos;
-        camOrigin.rotation = Quaternion.LookRotation(look.position - camOrigin.position);
+        // Interpolation pour un mouvement et une rotation plus smooth
+        camOrigin.position = Vector3.Lerp(
+            camOrigin.position,
+            desiredPos,
+            forcedCamFollowLerpSpeed * Time.deltaTime
+        );
+        camOrigin.rotation = Quaternion.Slerp(
+            camOrigin.rotation,
+            desiredRot,
+            forcedCamFollowLerpSpeed * Time.deltaTime
+        );
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- Déplace la logique de suivi de la WorldCamera dans `LateUpdate` pour un mouvement plus fluide lorsque le joueur change brusquement de direction
- Ajoute des commentaires et nettoie `Update` pour éviter les saccades

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `apt-get update` *(échec : dépôts non signés / accès refusé)*

------
https://chatgpt.com/codex/tasks/task_e_68c7064143088325819b1c4a8a23439b