### PR TITLE
Lecture automatique des timelines d'introduction des unités

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -451,8 +451,23 @@ public class NewBattleManager : MonoBehaviour
             if (director == null)
                 director = unit.gameObject.AddComponent<PlayableDirector>();
 
-            // Associe la timeline et lance la lecture
+            // Associe la timeline au PlayableDirector
             director.playableAsset = timeline;
+
+            // Parcourt les pistes de sortie de la timeline pour leur affecter
+            // les bons GameObjects avant de jouer l'animation.
+            foreach (var track in timeline.GetOutputTracks())
+            {
+                // La piste "Root" contrôle le GameObject principal portant le CharacterUnit.
+                if (track.name == "Root")
+                    director.SetGenericBinding(track, unit.gameObject);
+
+                // La piste "Model" anime l'enfant qui possède l'Animator.
+                else if (track.name == "Model" && unit.animator != null)
+                    director.SetGenericBinding(track, unit.animator.gameObject);
+            }
+
+            // Lance la lecture de la timeline correctement configurée
             director.Play();
             activeDirectors.Add(director);
         }


### PR DESCRIPTION
## Résumé
- Affectation automatique des GameObjects aux pistes "Root" et "Model" des timelines d'intro.
- Lecture de la timeline via le PlayableDirector présent sur le CharacterUnit.

## Tests
- `dotnet test` *(échec : commande introuvable)*
- `npm test` *(échec : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68c7207101a883259121c2c61768ed47