### PR TITLE
Lecture des timelines depuis le PlayableDirector de chaque unité

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -1,19 +1,22 @@
 using UnityEngine;
-using UnityEngine.Playables;
 using UnityEngine.Timeline;
-using System;
 
 /// <summary>
 /// Gestionnaire centralisant les <see cref="TimelineAsset"/> jouées durant les combats.
-/// Désormais seule la timeline du lanceur est utilisée, la caméra étant gérée par ailleurs.
+/// Chaque CharacterUnit pilote désormais sa propre timeline via son PlayableDirector ;
+/// ce gestionnaire coordonne simplement les alignements caméra et les appels haut niveau.
 /// </summary>
 public class BattleTimelineManager : MonoBehaviour
 {
     /// <summary>Instance statique accessible depuis les autres scripts.</summary>
     public static BattleTimelineManager Instance { get; private set; }
 
-    /// <summary>Director chargé des animations du lanceur.</summary>
-    private PlayableDirector directorCaster;
+    /// <summary>
+    /// Mémorise l'unité ayant lancé la dernière timeline. Cette information
+    /// permet de fournir un arrêt ou un suivi de lecture par défaut lorsque
+    /// l'appelant n'en précise pas explicitement l'unité.
+    /// </summary>
+    private CharacterUnit lastUnitPlaying;
 
     private void Awake()
     {
@@ -24,18 +27,6 @@ public class BattleTimelineManager : MonoBehaviour
             return;
         }
         Instance = this;
-
-        FindCasterDirectorPlayer();
-    }
-
-    void FindCasterDirectorPlayer()
-    {
-        // Recherche du PlayableDirector dédié au caster.
-        Transform casterChild = transform.Find("PlayableDirector_Caster");
-        directorCaster = casterChild != null ? casterChild.GetComponent<PlayableDirector>() : null;
-
-        if (directorCaster == null)
-            Debug.LogError("[BattleTimelineManager] PlayableDirector_Caster introuvable.");
     }
 
     /// <summary>
@@ -61,74 +52,44 @@ public class BattleTimelineManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Joue uniquement la timeline du lanceur. Aucune piste caméra n'est prise en compte.
+    /// Joue uniquement la timeline du lanceur via son PlayableDirector local.
     /// </summary>
     /// <param name="timeline">Timeline à exécuter.</param>
-    /// <param name="caster">Objet servant de référence pour les bindings.</param>
-    public void PlayCasterTimeline(TimelineAsset timeline, GameObject caster)
+    /// <param name="unit">Unité dont le PlayableDirector doit être utilisé.</param>
+    /// <param name="casterBinding">Objet servant de référence pour les bindings (Animator, etc.).</param>
+    public void PlayCasterTimeline(TimelineAsset timeline, CharacterUnit unit, GameObject casterBinding)
     {
-        if (timeline == null || directorCaster == null)
+        if (timeline == null || unit == null)
             return;
 
-        directorCaster.playableAsset = timeline;
+        GameObject binding = casterBinding ?? unit.animator?.gameObject ?? unit.gameObject;
 
-        // Parcourt toutes les pistes pour relier dynamiquement les bons objets.
-        foreach (var output in timeline.outputs)
-        {
-            Type type = output.outputTargetType;
-            string lower = output.streamName.ToLower();
-
-            // Les pistes caméra sont ignorées : la caméra n'est plus contrôlée par timeline.
-            if (lower.Contains("camera"))
-                continue;
-
-            // Les pistes de signaux sont reliées au SignalReceiver du PlayableDirector.
-            if (type != null && typeof(Component).IsAssignableFrom(type) && type.Name.Contains("SignalReceiver"))
-            {
-                Component receiver = directorCaster.GetComponent(type);
-                if (receiver != null)
-                {
-                    directorCaster.SetGenericBinding(output.sourceObject, receiver);
-                }
-                else
-                {
-                    Debug.LogWarning($"[BattleTimelineManager] {type.Name} manquant sur {directorCaster.gameObject.name} pour la timeline.");
-                }
-                continue;
-            }
-
-            // Pistes d'animation : on tente de lier un Animator du lanceur.
-            if (lower.Contains("caster") || lower.Contains("pnj"))
-            {
-                if (caster == null)
-                    continue;
-
-                var animator = caster.GetComponentInChildren<Animator>();
-                if (animator != null)
-                    directorCaster.SetGenericBinding(output.sourceObject, animator);
-                else
-                    Debug.LogWarning("[BattleTimelineManager] Animator manquant sur le caster pour la timeline.");
-            }
-            else if (caster != null)
-            {
-                // Autres pistes : on relie simplement le GameObject du lanceur.
-                directorCaster.SetGenericBinding(output.sourceObject, caster);
-            }
-        }
-
-        directorCaster.time = 0;
-        directorCaster.Play();
+        unit.PlayBattleTimeline(timeline, binding);
+        lastUnitPlaying = unit;
     }
 
-    /// <summary>Arrête la timeline du lanceur si elle est en cours.</summary>
-    public void StopCasterTimeline()
+    /// <summary>Arrête la timeline en cours pour l'unité spécifiée.</summary>
+    /// <param name="unit">Unité ciblée, ou null pour cibler la dernière unité connue.</param>
+    public void StopCasterTimeline(CharacterUnit unit = null)
     {
-        if (directorCaster != null && directorCaster.state == PlayState.Playing)
-            directorCaster.Stop();
+        CharacterUnit target = unit ?? lastUnitPlaying;
+        if (target == null)
+            return;
+
+        target.StopBattleTimeline();
+
+        if (target == lastUnitPlaying)
+            lastUnitPlaying = null;
     }
 
-    /// <summary>Indique si le director du lanceur joue actuellement une timeline.</summary>
-    public bool IsCasterTimelinePlaying =>
-        directorCaster != null && directorCaster.state == PlayState.Playing;
+    /// <summary>
+    /// Indique si une timeline est actuellement jouée sur l'unité demandée.
+    /// </summary>
+    /// <param name="unit">Unité à interroger, ou null pour consulter la dernière unité utilisée.</param>
+    public bool IsCasterTimelinePlaying(CharacterUnit unit = null)
+    {
+        CharacterUnit target = unit ?? lastUnitPlaying;
+        return target != null && target.IsBattleTimelinePlaying;
+    }
 }
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using UnityEngine.Playables; // 📽️ Gestion des timelines propres à l'unité
+using UnityEngine.Timeline;  // 🎼 Lecture des TimelineAsset assignés au PlayableDirector local
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,8 +8,12 @@ using System.Linq;
 /// <summary>
 /// Représente une unité de combat. L'ajout d'un <see cref="CharacterController"/>
 /// permet de déléguer la gestion de la gravité à Unity pour plus de cohérence.
+/// Chaque unité embarque désormais son propre <see cref="PlayableDirector"/>
+/// afin de conserver l'ensemble des effets narratifs décrits dans l'Histoire de
+/// Symphonie tout en gagnant en modularité lors de la lecture des timelines.
 /// </summary>
 [RequireComponent(typeof(CharacterController))]
+[RequireComponent(typeof(PlayableDirector))]
 public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, IDebuffable
 {
     public CharacterData Data;
@@ -25,6 +31,19 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     private AudioSource audioSource;
     [HideInInspector] public Animator animator;
     private AwakeState awakeState;
+
+    /// <summary>
+    /// PlayableDirector individuel utilisé pour jouer les timelines de combat
+    /// propres à cette unité. Ce composant remplace l'ancien système centralisé
+    /// et garantit que les pistes "Caster" restent toujours correctement liées.
+    /// </summary>
+    private PlayableDirector battleDirector;
+
+    /// <summary>
+    /// Expose le PlayableDirector de combat à des fins de diagnostic tout en
+    /// conservant la protection d'accès pour éviter toute réaffectation externe.
+    /// </summary>
+    public PlayableDirector BattleDirector => battleDirector;
 
     /// <summary>
     /// Indique si l'unité est en état Awake (fusion avec l'ange gardien).
@@ -79,6 +98,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         controller = GetComponent<CharacterController>();
         if (controller == null)
             controller = gameObject.AddComponent<CharacterController>();
+
+        // Centralise la récupération (ou l'ajout) du PlayableDirector afin que
+        // chaque unité puisse lire ses propres timelines de MusicalMoves ou d'objets.
+        battleDirector = GetComponent<PlayableDirector>();
+        if (battleDirector == null)
+            battleDirector = gameObject.AddComponent<PlayableDirector>();
+
+        // Les timelines sont déclenchées manuellement, on désactive donc toute
+        // lecture automatique pour éviter une répétition non désirée en scène.
+        battleDirector.playOnAwake = false;
     }
 
     public CharacterType characterType => Data.characterType;
@@ -206,6 +235,162 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
                 customBar.SetValue(currentFatigue);
             }
         }
+    }
+
+    /// <summary>
+    /// Assure la cohérence des liens entre une timeline et le PlayableDirector
+    /// de l'unité avant de déclencher sa lecture. Les pistes portant la mention
+    /// "Caster" sont reliées en priorité à l'Animator du lanceur afin de
+    /// préserver l'intention chorégraphique des MusicalMoves.
+    /// </summary>
+    /// <param name="timeline">Timeline à jouer via le PlayableDirector local.</param>
+    /// <param name="casterBinding">
+    /// Objet de référence pour les pistes d'animation. S'il est omis, l'Animator
+    /// principal de l'unité est utilisé automatiquement.
+    /// </param>
+    public void PlayBattleTimeline(TimelineAsset timeline, GameObject casterBinding = null)
+    {
+        if (timeline == null)
+            return;
+
+        // Sécurise l'accès au PlayableDirector même si le composant a été ajouté
+        // dynamiquement après l'Awake (cas de duplication à l'éditeur par exemple).
+        if (battleDirector == null)
+            battleDirector = GetComponent<PlayableDirector>();
+
+        if (battleDirector == null)
+        {
+            Debug.LogError($"[CharacterUnit] Aucun PlayableDirector disponible sur {name}. La timeline '{timeline.name}' ne peut pas être jouée.");
+            return;
+        }
+
+        // Évite que plusieurs timelines se chevauchent sur la même unité.
+        battleDirector.Stop();
+
+        battleDirector.playableAsset = timeline;
+
+        // Détermine les cibles de binding prioritaires.
+        GameObject bindingRoot = casterBinding ?? animator?.gameObject ?? gameObject;
+        Animator bindingAnimator = casterBinding != null
+            ? casterBinding.GetComponent<Animator>() ?? casterBinding.GetComponentInChildren<Animator>()
+            : animator;
+
+        if (bindingAnimator == null && animator != null)
+            bindingAnimator = animator;
+
+        foreach (var output in timeline.outputs)
+        {
+            BindTimelineOutput(output, bindingRoot, bindingAnimator);
+        }
+
+        battleDirector.time = 0d;
+        battleDirector.Play();
+    }
+
+    /// <summary>
+    /// Arrête proprement la timeline de combat en cours sur cette unité. Cette
+    /// méthode est utilisée notamment lors de la fermeture des menus d'objets.
+    /// </summary>
+    public void StopBattleTimeline()
+    {
+        if (battleDirector != null && battleDirector.state == PlayState.Playing)
+            battleDirector.Stop();
+    }
+
+    /// <summary>
+    /// Indique si la timeline de combat locale est actuellement en cours
+    /// d'exécution. Utile pour synchroniser les différentes phases d'un move.
+    /// </summary>
+    public bool IsBattleTimelinePlaying => battleDirector != null && battleDirector.state == PlayState.Playing;
+
+    /// <summary>
+    /// Réalise le binding d'une piste individuelle d'une timeline vers les
+    /// cibles adéquates (Animator, GameObject ou composant spécialisé).
+    /// </summary>
+    private void BindTimelineOutput(PlayableBinding output, GameObject bindingRoot, Animator bindingAnimator)
+    {
+        // Les pistes caméra restent gérées par le BattleCameraManager pour
+        // conserver les transitions cinématographiques écrites dans la Bible du jeu.
+        string streamName = output.streamName ?? string.Empty;
+        if (streamName.IndexOf("camera", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            return;
+
+        System.Type targetType = output.outputTargetType;
+
+        // Les pistes de signaux doivent pointer vers les récepteurs attachés au director.
+        if (targetType != null && typeof(Component).IsAssignableFrom(targetType) && targetType.Name.Contains("SignalReceiver"))
+        {
+            Component receiver = battleDirector.GetComponent(targetType);
+            if (receiver != null)
+                battleDirector.SetGenericBinding(output.sourceObject, receiver);
+            else
+                Debug.LogWarning($"[CharacterUnit] SignalReceiver {targetType.Name} introuvable sur {battleDirector.gameObject.name} pour la timeline '{battleDirector.playableAsset.name}'.");
+            return;
+        }
+
+        // Priorité absolue : toute piste mentionnant explicitement le caster suit l'Animator principal.
+        if (streamName.IndexOf("caster", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+            streamName.IndexOf("pnj", System.StringComparison.OrdinalIgnoreCase) >= 0)
+        {
+            if (bindingAnimator != null)
+                battleDirector.SetGenericBinding(output.sourceObject, bindingAnimator);
+            else if (bindingRoot != null)
+                battleDirector.SetGenericBinding(output.sourceObject, bindingRoot);
+            else
+                battleDirector.SetGenericBinding(output.sourceObject, gameObject);
+            return;
+        }
+
+        // Les pistes "Model" visent généralement l'objet contenant l'Animator.
+        if (streamName.IndexOf("model", System.StringComparison.OrdinalIgnoreCase) >= 0 && bindingAnimator != null)
+        {
+            battleDirector.SetGenericBinding(output.sourceObject, bindingAnimator.gameObject);
+            return;
+        }
+
+        // Fallback : on s'appuie sur le type de sortie pour trouver un composant compatible.
+        if (targetType != null)
+        {
+            if (typeof(Animator).IsAssignableFrom(targetType))
+            {
+                if (bindingAnimator != null)
+                {
+                    battleDirector.SetGenericBinding(output.sourceObject, bindingAnimator);
+                    return;
+                }
+            }
+            else if (typeof(GameObject).IsAssignableFrom(targetType))
+            {
+                battleDirector.SetGenericBinding(output.sourceObject, bindingRoot ?? gameObject);
+                return;
+            }
+            else if (typeof(Component).IsAssignableFrom(targetType))
+            {
+                Component component = null;
+
+                if (bindingRoot != null)
+                {
+                    component = bindingRoot.GetComponent(targetType);
+                    if (component == null)
+                        component = bindingRoot.GetComponentInChildren(targetType);
+                }
+
+                if (component == null && bindingAnimator != null)
+                    component = bindingAnimator.GetComponent(targetType);
+
+                if (component == null)
+                    component = battleDirector.GetComponent(targetType);
+
+                if (component != null)
+                {
+                    battleDirector.SetGenericBinding(output.sourceObject, component);
+                    return;
+                }
+            }
+        }
+
+        // Dernier recours : on relie la piste à l'objet principal de l'unité.
+        battleDirector.SetGenericBinding(output.sourceObject, bindingRoot ?? gameObject);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/HPThresholdTimelineTrigger.cs
@@ -57,6 +57,7 @@ public class HPThresholdTimelineTrigger : MonoBehaviour
                     // aucune piste dédiée n'est recherchée.
                     NewBattleManager.Instance.QueueConditionalTimeline(
                         t.timeline,
+                        unitData.unit,
                         animatorGO);
                     break;
                 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -155,14 +155,17 @@ public class NewBattleManager : MonoBehaviour
     private struct PendingTimeline
     {
         public TimelineAsset asset;
-        public GameObject caster;
+        public CharacterUnit unit;
+        public GameObject casterBinding;
 
-        public PendingTimeline(TimelineAsset asset, GameObject caster)
+        public PendingTimeline(TimelineAsset asset, CharacterUnit unit, GameObject casterBinding)
         {
             // Référence vers l'asset de timeline à exécuter
             this.asset = asset;
+            // Unité propriétaire de la timeline (et donc du PlayableDirector utilisé)
+            this.unit = unit;
             // GameObject jouant la piste "Caster" de la timeline
-            this.caster = caster;
+            this.casterBinding = casterBinding;
         }
     }
 
@@ -636,15 +639,19 @@ public class NewBattleManager : MonoBehaviour
     /// Ajoute une timeline à jouer avant le prochain tour.
     /// </summary>
     /// <param name="asset">Timeline à exécuter.</param>
-    /// <param name="caster">Objet de référence pour les bindings (Animator par exemple).</param>
+    /// <param name="casterUnit">Unité propriétaire du PlayableDirector utilisé.</param>
+    /// <param name="casterBinding">Objet de référence pour les bindings (Animator par exemple).</param>
     /// La caméra n'est plus liée à la timeline : elle sera simplement repositionnée sur le lanceur.
-    public void QueueConditionalTimeline(TimelineAsset asset, GameObject caster)
+    public void QueueConditionalTimeline(TimelineAsset asset, CharacterUnit casterUnit, GameObject casterBinding = null)
     {
-        if (asset == null)
+        if (asset == null || casterUnit == null)
             return;
 
+        // Détermine automatiquement l'objet d'animation si aucun binding spécifique n'est fourni.
+        GameObject binding = casterBinding ?? casterUnit.animator?.gameObject ?? casterUnit.gameObject;
+
         // Stocke la timeline à jouer et le lanceur associé
-        pendingTimelines.Enqueue(new PendingTimeline(asset, caster));
+        pendingTimelines.Enqueue(new PendingTimeline(asset, casterUnit, binding));
     }
 
     /// <summary>
@@ -658,13 +665,25 @@ public class NewBattleManager : MonoBehaviour
             BattleTransitionManager.Instance?.HideBattleUI();
 
             // Aligne la caméra de combat sur l'unité concernée avant la cinématique
-            BattleTimelineManager.Instance?.AlignCameraToTarget(data.caster, "BattleCamera");
+            if (data.casterBinding != null)
+                BattleTimelineManager.Instance?.AlignCameraToTarget(data.casterBinding, "BattleCamera");
 
-            if (TimelineManager.Instance != null)
+            bool timelinePlayed = false;
+
+            if (BattleTimelineManager.Instance != null && data.unit != null)
             {
-                // Joue la timeline uniquement sur la piste "Caster".
-                TimelineManager.Instance.PlayTimeline(data.asset, data.caster, null);
+                BattleTimelineManager.Instance.PlayCasterTimeline(data.asset, data.unit, data.casterBinding);
+                timelinePlayed = true;
+
                 // Attente de la fin de la timeline avant de poursuivre
+                while (BattleTimelineManager.Instance.IsCasterTimelinePlaying(data.unit))
+                    yield return null;
+            }
+
+            // Fallback pour les situations de test où le BattleTimelineManager n'est pas présent
+            if (!timelinePlayed && TimelineManager.Instance != null)
+            {
+                TimelineManager.Instance.PlayTimeline(data.asset, data.casterBinding, null);
                 while (TimelineManager.Instance.IsTimelineActive)
                     yield return null;
             }
@@ -2220,7 +2239,7 @@ public class NewBattleManager : MonoBehaviour
 
             // La timeline reste utile pour jouer les éventuels signaux ou effets complémentaires.
             if (itemPreparingTimeline != null)
-                BattleTimelineManager.Instance.PlayCasterTimeline(itemPreparingTimeline, animGO);
+                BattleTimelineManager.Instance.PlayCasterTimeline(itemPreparingTimeline, currentCharacterUnit, animGO);
         }
 
         itemMenuTimelineActive = true;
@@ -2254,7 +2273,7 @@ public class NewBattleManager : MonoBehaviour
         }
 
         // Arrête la timeline d'attente lancée sur le caster si elle existe.
-        BattleTimelineManager.Instance?.StopCasterTimeline();
+        BattleTimelineManager.Instance?.StopCasterTimeline(currentCharacterUnit);
         itemMenuTimelineActive = false;
     }
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -190,13 +190,14 @@ public class RhythmQTEManager : MonoBehaviour
     /// </summary>
     /// <param name="timeline">Timeline à jouer.</param>
     /// <param name="overlay">Vrai pour une timeline en superposition.</param>
+    /// <param name="caster">Unité lançant la timeline.</param>
     /// <param name="animatorGO">Objet de référence pour le binding (caster).</param>
     /// <param name="cameraTarget">Objet servant d'ancre pour la caméra.</param>
     /// <param name="autoRestore">Indique si la caméra doit être restaurée automatiquement.</param>
     /// <param name="initialRotation">Rotation de référence à conserver.</param>
-    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation, string cameraName = null)
+    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, CharacterUnit caster, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation, string cameraName = null)
     {
-        if (timeline == null || BattleTimelineManager.Instance == null || animatorGO == null)
+        if (timeline == null || BattleTimelineManager.Instance == null || caster == null)
             return;
 
         // 🎥 Active la caméra dédiée à cette phase si elle est renseignée.
@@ -206,12 +207,13 @@ public class RhythmQTEManager : MonoBehaviour
         // 📽️ La caméra n'étant plus pilotée par les timelines des moves/items,
         // nous ré-alignons simplement l'origine avant de lancer la timeline du lanceur.
         BattleTimelineManager.Instance.AlignCameraToTarget(
-            cameraTarget ?? animatorGO, // Fallback sur le lanceur si la cible est absente
+            cameraTarget ?? animatorGO ?? caster.gameObject, // Fallback sur le lanceur si la cible est absente
             battleCameraTag,
             initialRotation);
 
-        // Lecture de la seule timeline du caster.
-        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, animatorGO);
+        // Lecture de la timeline via le PlayableDirector de l'unité concernée.
+        GameObject binding = animatorGO ?? caster.animator?.gameObject ?? caster.gameObject;
+        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, caster, binding);
     }
 
     /// <summary>
@@ -219,22 +221,22 @@ public class RhythmQTEManager : MonoBehaviour
     /// </summary>
     /// <param name="timeline">Timeline à surveiller.</param>
     /// <param name="overlay">Paramètre conservé pour compatibilité, sans effet.</param>
-    private IEnumerator WaitForTimelinePhase(TimelineAsset timeline, bool overlay)
+    private IEnumerator WaitForTimelinePhase(TimelineAsset timeline, bool overlay, CharacterUnit caster)
     {
-        if (timeline == null)
+        if (timeline == null || caster == null)
             yield break;
 
         float maxDuration = (float)timeline.duration;
         float timer = 0f;
         while (BattleTimelineManager.Instance != null &&
-               BattleTimelineManager.Instance.IsCasterTimelinePlaying &&
+               BattleTimelineManager.Instance.IsCasterTimelinePlaying(caster) &&
                timer < maxDuration)
         {
             timer += Time.deltaTime;
             yield return null;
         }
 
-        if (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePlaying)
+        if (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePlaying(caster))
             Debug.LogWarning($"[RhythmQTEManager] Timeline '{timeline.name}' encore active après {maxDuration}s. Suite forcée.");
     }
 
@@ -312,12 +314,13 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             move.preparingTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             casterCameraTarget,
             move.performingTimeline == null && move.retreatTimeline == null,
             initialRotation,
             move.preparingCameraName);
-        yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay);
+        yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay, caster);
 
         // Déplacement ou téléportation vers la cible si nécessaire.
         if (move.requiresMovement && caster != null && target != null)
@@ -337,6 +340,7 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             move.performingTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             performingCameraTarget,
             move.retreatTimeline == null,
@@ -366,7 +370,7 @@ public class RhythmQTEManager : MonoBehaviour
             }
         }
 
-        yield return WaitForTimelinePhase(move.performingTimeline, useOverlay);
+        yield return WaitForTimelinePhase(move.performingTimeline, useOverlay, caster);
 
         // --- Retour ou téléportation de repli ---
         if (move.requiresMovement && !move.stayInPlace && caster != null && target != null)
@@ -376,12 +380,13 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             move.retreatTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             casterCameraTarget,
             true,
             initialRotation,
             move.retreatCameraName);
-        yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay);
+        yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay, caster);
 
         // Attente finale de la timeline caméra complète (désactivée).
 
@@ -459,12 +464,13 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             item.preparingTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             casterCameraTarget,
             item.performingTimeline == null && item.retreatTimeline == null,
             initialRotation,
             item.preparingCameraName);
-        yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay);
+        yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay, caster);
 
         // Déplacement ou téléportation éventuel vers la cible.
         if (item.requiresMovement && caster != null && target != null)
@@ -484,6 +490,7 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             item.performingTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             performingCameraTarget,
             item.retreatTimeline == null,
@@ -504,7 +511,7 @@ public class RhythmQTEManager : MonoBehaviour
             LastItemSuccess = successResults.All(v => v);
         }
 
-        yield return WaitForTimelinePhase(item.performingTimeline, useOverlay);
+        yield return WaitForTimelinePhase(item.performingTimeline, useOverlay, caster);
 
         // --- Retour à la position d'origine ---
         if (item.requiresMovement && !item.stayInPlace && caster != null && target != null)
@@ -514,12 +521,13 @@ public class RhythmQTEManager : MonoBehaviour
         StartTimelinePhase(
             item.retreatTimeline,
             useOverlay,
+            caster,
             casterAnimatorGO,
             casterCameraTarget,
             true,
             initialRotation,
             item.retreatCameraName);
-        yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay);
+        yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay, caster);
 
         isActive = false;
         // Protection en cas de destruction du lanceur avant la fin de la séquence


### PR DESCRIPTION
## Résumé
- ajoute un PlayableDirector dédié à chaque `CharacterUnit` et garantit le binding automatique du caster sur les pistes concernées
- adapte le `BattleTimelineManager`, le `RhythmQTEManager` et la gestion du menu d’objets pour exploiter le PlayableDirector local de l’unité active
- fait transiter les timelines conditionnelles par l’unité concernée afin de conserver les effets narratifs et caméras alignées sur la bonne cible

## Tests
- non exécutés (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68c86cc25afc83258d811f49fbd5aabc