### PR TITLE
Corrige la configuration TagManager et régénère les GUID corrompus

### DIFF
--- a/Assets/Scenes/GlowUpScene.unity.meta
+++ b/Assets/Scenes/GlowUpScene.unity.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: ef710165-cca4-4425-9822-9114cdcc722c
+guid: 87c41fa5ecf14743872bd44306c5b8fe
+# Nouveau GUID généré automatiquement pour rétablir un identifiant valide le 2025-09-16T15:56:36.899682Z.
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/GlowUpSceneSetup.cs.meta
@@ -1,5 +1,6 @@
 fileFormatVersion: 2
-guid: 27602f5b-c024-4e10-8fca-28477b1488e2
+guid: efe0da78c75746e6ab871779b3a9b5ff
+# Nouveau GUID généré automatiquement pour rétablir un identifiant valide le 2025-09-16T15:56:36.900194Z.
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -88,8 +88,8 @@ TagManager:
   - Light Layer 5 - Light Layer 5 - Light Layer 5 - Light Layer 5 - Light Layer 5
   - Light Layer 6 - Light Layer 6 - Light Layer 6 - Light Layer 6 - Light Layer 6
   - Light Layer 7 - Light Layer 7 - Light Layer 7 - Light Layer 7 - Light Layer 7
-  - Decal Layer default - Decal Layer default - Decal Layer default - Decal Layer
-    default - Decal Layer default
+  # Chaîne longue encapsulée pour garantir une définition YAML valide et éviter les retours à la ligne automatiques.
+  - "Decal Layer default - Decal Layer default - Decal Layer default - Decal Layer default - Decal Layer default"
   - Decal Layer 1 - Decal Layer 1 - Decal Layer 1 - Decal Layer 1 - Decal Layer 1
   - Decal Layer 2 - Decal Layer 2 - Decal Layer 2 - Decal Layer 2 - Decal Layer 2
   - Decal Layer 3 - Decal Layer 3 - Decal Layer 3 - Decal Layer 3 - Decal Layer 3


### PR DESCRIPTION
## Résumé
- corrige le YAML du TagManager en encapsulant la chaîne longue qui provoquait l'erreur de parsing
- régénère des GUID valides pour la scène GlowUp et le script GlowUpSceneSetup, avec une trace commentée pour le suivi

## Tests
- non exécutés (environnement de conteneur sans Unity)


------
https://chatgpt.com/codex/tasks/task_e_68c98797fb288325b1c33a249b391243