### PR TITLE
✨ Correction des effets du move Sforzando

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_Sforzando/Effect_Sforzando_Hit.prefab
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/Effect_Sforzando_Hit.prefab
@@ -5041,6 +5041,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2304300485131842377}
+  - component: {fileID: 7645388365046011802}
   m_Layer: 19
   m_Name: Effect_Sforzando_Hit
   m_TagString: Untagged
@@ -5065,3 +5066,16 @@ Transform:
   - {fileID: 228924707543943129}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7645388365046011802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6080883197992003042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a30a20661737496da060243229926737, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  spawnOnTarget: 1

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Charge fulgurante qui téléporte Lucian devant sa cible avant de libérer une onde de choc sonore."
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/Timeline_Sforzando_Performing.playable
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/Timeline_Sforzando_Performing.playable
@@ -33,12 +33,12 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
   m_Name: Caster
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier:
   m_Version: 3
   m_AnimClip: {fileID: 0}
   m_Locked: 0
   m_Muted: 0
-  m_CustomPlayableFullTypename: 
+  m_CustomPlayableFullTypename:
   m_Curves: {fileID: 0}
   m_Parent: {fileID: 11400000}
   m_Children: []
@@ -132,6 +132,63 @@ MonoBehaviour:
   m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
   m_Rotation: {x: 0, y: 0, z: 0, w: 1}
   m_ApplyOffsets: 0
+--- !u!114 &-1807950700000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
+  m_Name: Signal Emitter
+  m_EditorClassIdentifier:
+  m_Time: 1
+  m_Retroactive: 0
+  m_EmitOnce: 0
+  m_Asset: {fileID: 11400000, guid: d08033fa8c2f6494c883a2e7a12961fb, type: 2}
+--- !u!114 &-1807950700000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
+  m_Name: Signal Emitter
+  m_EditorClassIdentifier:
+  m_Time: 1
+  m_Retroactive: 0
+  m_EmitOnce: 0
+  m_Asset: {fileID: 11400000, guid: b290b75cb93343e380e8347d6d46edb8, type: 2}
+--- !u!114 &-1807950700000000000
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b46e36075dd1c124a8422c228e75e1fb, type: 3}
+  m_Name: Signal Track
+  m_EditorClassIdentifier:
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename:
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects:
+    - {fileID: -1807950700000000002}
+    - {fileID: -1807950700000000001}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,6 +204,7 @@ MonoBehaviour:
   m_Version: 0
   m_Tracks:
   - {fileID: -2477970755808460308}
+  - {fileID: -1807950700000000000}
   m_FixedDuration: 0
   m_EditorSettings:
     m_Framerate: 60

--- a/Assets/Prefabs/TimelineManager.prefab
+++ b/Assets/Prefabs/TimelineManager.prefab
@@ -471,6 +471,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: d08033fa8c2f6494c883a2e7a12961fb, type: 2}
     - {fileID: 11400000, guid: 3189bc366e2f95147aa58e53b69660d4, type: 2}
     - {fileID: 11400000, guid: 4e760a2fbdb45824bb84319549a64af7, type: 2}
+    - {fileID: 11400000, guid: b290b75cb93343e380e8347d6d46edb8, type: 2}
     m_Events:
     - m_PersistentCalls:
         m_Calls:
@@ -553,7 +554,21 @@ MonoBehaviour:
             m_ObjectArgumentAssemblyTypeName: UnityEngine.AudioClip, UnityEngine
             m_IntArgument: 0
             m_FloatArgument: 0
-            m_StringArgument: 
+            m_StringArgument:
+            m_BoolArgument: 0
+          m_CallState: 1
+    - m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 0}
+          m_TargetAssemblyTypeName: InstantiateGameObject, Assembly-CSharp
+          m_MethodName: InstantiateFromTimeline
+          m_Mode: 2
+          m_Arguments:
+            m_ObjectArgument: {fileID: 6080883197992003042, guid: 777dffc3c0ae8f8489ed75a7df1e6286, type: 3}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument:
             m_BoolArgument: 0
           m_CallState: 1
 --- !u!114 &2897812531883903891

--- a/Assets/Timelines/0 - SIG/SIG_Sforzando_Hit.signal
+++ b/Assets/Timelines/0 - SIG/SIG_Sforzando_Hit.signal
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6fa2d92fc1b3f34da284357edf89c3b, type: 3}
+  m_Name: SIG_Sforzando_Hit
+  m_EditorClassIdentifier:

--- a/Assets/Timelines/0 - SIG/SIG_Sforzando_Hit.signal.meta
+++ b/Assets/Timelines/0 - SIG/SIG_Sforzando_Hit.signal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b290b75cb93343e380e8347d6d46edb8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -95,6 +95,13 @@ des possibilités de combinaisons qui n'imposent plus un repositionnement systé
 - **Gain** : aucun.
 - **Utilisation conseillée** : parfait pour les débutants qui peinent à atteindre les adversaires aériens. Les joueurs expérimentés pourront l'enchaîner avec des attaques terrestres pour réaliser des combinaisons originales.
 
+## MusicalMove : Sforzando
+- **Type** : Attaque téléportée.
+- **Effet** : Lucian se matérialise face à une cible unique et libère une onde percussive qui inflige 20 points de dégâts (plus la puissance courante) tout en générant 1 point d'harmonie supplémentaire.
+- **Coût** : 1 point d'harmonie et 1 point de fatigue.
+- **Gain** : +1 harmonie grâce à la puissance du choc musical.
+- **Utilisation conseillée** : idéal pour surprendre un adversaire isolé. L'attaque place Lucian au contact de sa cible ; les débutants peuvent l'utiliser comme finisher direct, tandis que les joueurs expérimentés profiteront du maintien en mêlée pour enchaîner immédiatement un combo ou préparer une interception.
+
 ## MusicalMove : Abîme Harmonique
 - **Type** : Altération
 - **Effet** : annule le sol sous la cible, la forçant à flotter et la rendant sensible aux stratégies aériennes.


### PR DESCRIPTION
## Résumé
- ajoute un signal dédié pour déclencher l'effet visuel/sonore du Sforzando et relie le TimelineManager à ce nouveau prefab
- met à jour la timeline d'exécution du Sforzando pour émettre les signaux d'onde de choc et d'impact au bon moment
- documente le move dans NouveauxContenus et précise sa description dans le ScriptableObject

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68c98dfa44108325b7a11f85fda497d2