### PR TITLE
Assurer les bindings Root et Model des intros de combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -288,6 +288,83 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     }
 
     /// <summary>
+    /// Prépare la timeline d'introduction de combat en reliant explicitement
+    /// les pistes "Root" et "Model" du <see cref="PlayableDirector"/> local.
+    /// Les autres pistes potentiellement présentes sont nettoyées afin d'éviter
+    /// qu'un binding issu d'une précédente timeline ne perturbe la mise en scène.
+    /// </summary>
+    /// <param name="introTimeline">Timeline d'introduction à jouer.</param>
+    /// <returns>
+    /// Le <see cref="PlayableDirector"/> prêt à être lancé, ou <c>null</c> si la
+    /// configuration n'a pas pu être réalisée.
+    /// </returns>
+    public PlayableDirector PrepareIntroTimeline(TimelineAsset introTimeline)
+    {
+        if (introTimeline == null)
+            return null;
+
+        // Sécurise la récupération du PlayableDirector, indispensable pour jouer la timeline.
+        if (battleDirector == null)
+            battleDirector = GetComponent<PlayableDirector>();
+
+        // Si pour une raison quelconque le PlayableDirector est absent, on le recrée afin de garantir la lecture.
+        if (battleDirector == null)
+            battleDirector = gameObject.AddComponent<PlayableDirector>();
+
+        if (battleDirector == null)
+        {
+            Debug.LogError($"[CharacterUnit] Aucun PlayableDirector disponible sur {name}. La timeline d'introduction '{introTimeline.name}' ne peut pas être préparée.");
+            return null;
+        }
+
+        // Rafraîchit la référence à l'Animator au cas où l'unité aurait été instanciée dynamiquement.
+        if (animator == null)
+            animator = GetComponentInChildren<Animator>();
+
+        // Coupe toute éventuelle lecture en cours pour éviter qu'une timeline précédente ne continue.
+        battleDirector.Stop();
+
+        battleDirector.playableAsset = introTimeline;
+
+        // Parcourt toutes les pistes afin de ne conserver que les bindings nécessaires.
+        foreach (var track in introTimeline.GetOutputTracks())
+        {
+            // On se concentre sur les AnimationTrack car seules les pistes "Root" et "Model" doivent être reliées.
+            if (track is AnimationTrack)
+            {
+                string trackName = track.name;
+
+                // La piste "Root" manipule le GameObject principal portant le CharacterUnit.
+                if (string.Equals(trackName, "Root", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    battleDirector.SetGenericBinding(track, gameObject);
+                    continue; // Binding réalisé, on passe à la piste suivante.
+                }
+
+                // La piste "Model" anime l'objet contenant l'Animator du personnage.
+                if (string.Equals(trackName, "Model", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    if (animator != null)
+                    {
+                        battleDirector.SetGenericBinding(track, animator.gameObject);
+                        continue; // Binding réussi, rien à nettoyer.
+                    }
+
+                    // Si aucun Animator n'est disponible, on laisse le nettoyage se faire en sortie de boucle.
+                }
+            }
+
+            // Pour toutes les autres pistes, on supprime tout binding résiduel pour éviter des références incohérentes.
+            battleDirector.ClearGenericBinding(track);
+        }
+
+        // S'assure que la timeline repart du début lorsque le BattleManager la lancera.
+        battleDirector.time = 0d;
+
+        return battleDirector;
+    }
+
+    /// <summary>
     /// Arrête proprement la timeline de combat en cours sur cette unité. Cette
     /// méthode est utilisée notamment lors de la fermeture des menus d'objets.
     /// </summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -426,32 +426,14 @@ public class NewBattleManager : MonoBehaviour
         {
             var timeline = unit.Data.introTimeline;
 
-            // Recherche ou ajoute un PlayableDirector sur l'unité
-            var director = unit.GetComponent<PlayableDirector>();
+            // Demande à la CharacterUnit de préparer les bindings "Root" et "Model" de sa timeline d'intro.
+            PlayableDirector director = unit.PrepareIntroTimeline(timeline);
+
+            // Si la préparation échoue (timeline incomplète, aucun PlayableDirector, etc.), on ignore simplement cette unité.
             if (director == null)
-                director = unit.gameObject.AddComponent<PlayableDirector>();
+                continue;
 
-            // Associe la timeline au PlayableDirector
-            director.playableAsset = timeline;
-
-            // Parcourt les pistes de sortie de la timeline pour leur affecter
-            // les bons GameObjects avant de jouer l'animation.
-            foreach (var track in timeline.GetOutputTracks())
-            {
-                // La piste "Root" contrôle le GameObject principal portant le CharacterUnit.
-                if (track.name == "Root")
-                {
-                    director.SetGenericBinding(track, unit.gameObject);
-                }
-
-                // La piste "Model" anime l'enfant qui possède l'Animator.
-                else if (track.name == "Model" && unit.animator != null)
-                {
-                    director.SetGenericBinding(track, unit.animator.gameObject);
-                }
-            }
-
-            // Lance la lecture de la timeline correctement configurée
+            // Lance la lecture de la timeline correctement configurée et l'ajoute à la liste de suivi.
             director.Play();
             activeDirectors.Add(director);
         }


### PR DESCRIPTION
## Résumé
- ajoute à `CharacterUnit` une préparation de timeline d'introduction qui force les bindings "Root" et "Model"
- nettoie les autres pistes pour éviter les reliquats de timelines précédentes
- s'appuie sur cette nouvelle méthode depuis `NewBattleManager` lors du lancement des intros

## Tests
- non exécutés (projet Unity, tests automatiques non disponibles dans cet environnement)


------
https://chatgpt.com/codex/tasks/task_e_68c99d139b5083258b4615c731ab3953