### PR TITLE
Affiner les ancrages caméra de combat

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -90,27 +90,30 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// </summary>
     public void DisplayCamera(string cameraName)
     {
-        // Redirige vers la surcharge avec duree explicite en utilisant
-        // la duree de blend par defaut.
-        DisplayCamera(cameraName, defaultBlendDuration);
+        // Redirige vers la surcharge avec durée explicite en utilisant
+        // la durée de blend par défaut.
+        DisplayCamera(cameraName, defaultBlendDuration, null);
     }
 
     /// <summary>
     /// Active la <see cref="CinemachineCamera"/> nommee <paramref name="cameraName"/>.
     /// </summary>
     /// <param name="cameraName">Nom de la camera a activer.</param>
-    /// <param name="blendDuration">Duree du blend en secondes.</param>
-    public void DisplayCamera(string cameraName, float blendDuration)
+    /// <param name="blendDuration">Durée du blend en secondes.</param>
+    /// <param name="overrideStyle">Style de blend à forcer (null = style par défaut).</param>
+    public void DisplayCamera(string cameraName, float blendDuration, CinemachineBlendDefinition.Styles? overrideStyle = null)
     {
+        float resolvedDuration = blendDuration >= 0f ? blendDuration : defaultBlendDuration;
+
         // Si la camera cible exige un fondu visuel, on lance une coroutine dediee qui
         // capture l'image actuelle avant de basculer sur la nouvelle camera.
-        if (ShouldUseCrossFade(cameraName, blendDuration))
+        if (ShouldUseCrossFade(cameraName, resolvedDuration))
         {
             // Si le composant est desactive ou si la coroutine n'a pas le droit de tourner,
             // on retombe sur le comportement classique pour eviter de bloquer la transition.
             if (!isActiveAndEnabled)
             {
-                ApplyCameraSwitch(cameraName, blendDuration, false);
+                ApplyCameraSwitch(cameraName, resolvedDuration, false, overrideStyle);
                 return;
             }
 
@@ -124,12 +127,12 @@ public class CinemachineBlendSwitcher : MonoBehaviour
             }
 
             // Lancement du fondu asynchrone (capture + bascule + interpolation).
-            crossFadeRoutine = StartCoroutine(DisplayCameraWithCrossFade(cameraName, blendDuration));
+            crossFadeRoutine = StartCoroutine(DisplayCameraWithCrossFade(cameraName, resolvedDuration, overrideStyle));
             return;
         }
 
         // Sinon (fondu desactive ou duree nulle) on applique directement la transition.
-        ApplyCameraSwitch(cameraName, blendDuration, false);
+        ApplyCameraSwitch(cameraName, resolvedDuration, false, overrideStyle);
     }
 
     /// <summary>
@@ -169,14 +172,14 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// <param name="cameraName">Nom de la camera cible (ou <c>null</c>/<see cref="string.Empty"/> pour les cas speciaux).</param>
     /// <param name="blendDuration">Duree de blend desiree (utilisee si <paramref name="forceCut"/> est faux).</param>
     /// <param name="forceCut">Si vrai, impose un cut direct sans interpolation de position.</param>
-    private void ApplyCameraSwitch(string cameraName, float blendDuration, bool forceCut)
+    private void ApplyCameraSwitch(string cameraName, float blendDuration, bool forceCut, CinemachineBlendDefinition.Styles? overrideStyle)
     {
-        float duration = Mathf.Max(0f, blendDuration);
+        float duration = Mathf.Max(0f, blendDuration >= 0f ? blendDuration : defaultBlendDuration);
 
         // Cas : retour a la camera par defaut (indice 0).
         if (cameraName == null)
         {
-            ApplyBrainBlend(duration, forceCut);
+            ApplyBrainBlend(duration, forceCut, overrideStyle);
             ActivateDefaultCameraPriorities();
             return;
         }
@@ -205,7 +208,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
         if (_current == next) return;
 
         // Definition du blend par defaut juste avant le switch.
-        ApplyBrainBlend(duration, forceCut);
+        ApplyBrainBlend(duration, forceCut, overrideStyle);
 
         // Gestion des priorites : seule la camera cible obtient la priorite active.
         foreach (var c in cameras)
@@ -219,13 +222,13 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// </summary>
     /// <param name="blendDuration">Duree du blend si <paramref name="forceCut"/> est faux.</param>
     /// <param name="forceCut">Si vrai, force un cut instantane.</param>
-    private void ApplyBrainBlend(float blendDuration, bool forceCut)
+    private void ApplyBrainBlend(float blendDuration, bool forceCut, CinemachineBlendDefinition.Styles? overrideStyle)
     {
         if (!brain) return; // Rien a configurer si aucun brain n'est disponible.
 
         // Lors d'un fondu visuel, on force un cut afin d'eviter le mouvement.
-        var style = forceCut ? CinemachineBlendDefinition.Styles.Cut : blendStyle;
-        var duration = forceCut ? 0f : blendDuration;
+        var style = forceCut ? CinemachineBlendDefinition.Styles.Cut : (overrideStyle ?? blendStyle);
+        var duration = forceCut ? 0f : Mathf.Max(0f, blendDuration);
         brain.DefaultBlend = new CinemachineBlendDefinition(style, duration);
     }
 
@@ -233,13 +236,13 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// Lance un fondu visuel : capture du frame courant, activation de la nouvelle camera,
     /// puis interpolation de l'opacite de l'image capturee.
     /// </summary>
-    private IEnumerator DisplayCameraWithCrossFade(string cameraName, float fadeDuration)
+    private IEnumerator DisplayCameraWithCrossFade(string cameraName, float fadeDuration, CinemachineBlendDefinition.Styles? overrideStyle)
     {
         // S'assure que l'overlay est pret. Si ce n'est pas possible, on retombe
         // sur le comportement standard afin de ne pas bloquer le changement de plan.
         if (!EnsureCrossFadeOverlay())
         {
-            ApplyCameraSwitch(cameraName, fadeDuration, false);
+            ApplyCameraSwitch(cameraName, fadeDuration, false, overrideStyle);
             crossFadeRoutine = null;
             yield break;
         }
@@ -260,7 +263,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
         if (screenshot == null)
         {
             // Aucune capture disponible : retour au comportement classique.
-            ApplyCameraSwitch(cameraName, fadeDuration, false);
+            ApplyCameraSwitch(cameraName, fadeDuration, false, overrideStyle);
             crossFadeRoutine = null;
             yield break;
         }
@@ -274,7 +277,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
         SetCrossFadeAlpha(1f); // on commence totalement opaque
 
         // Bascule vers la nouvelle camera via un cut (aucun mouvement de camera).
-        ApplyCameraSwitch(cameraName, fadeDuration, true);
+        ApplyCameraSwitch(cameraName, fadeDuration, true, overrideStyle);
 
         float elapsed = 0f;
         while (elapsed < fadeDuration)

--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -52,8 +52,8 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 65cda8e58c0ff6344b3607c580c09e0a, type: 2}
   retreatTimeline: {fileID: 0}
-  preparingCameraName: CinemachineCamera_1_Corner_SU_R
-  performingCameraName: CinemachineCamera_1_Corner_SU_R
-  retreatCameraName: CinemachineCamera_6_Target_Near
+  preparingCameraRole: 2
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -55,6 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 11400000, guid: 4fa946d42fae10b48bc20bf37f9fc9eb, type: 2}
   performingTimeline: {fileID: 11400000, guid: 332f64de2f14fea46b6df0d3bc73ee75, type: 2}
   retreatTimeline: {fileID: 0}
-  preparingCameraName: CinemachineCamera_4_Corner_SU_L
-  performingCameraName: CinemachineCamera_4_Corner_SU_L
-  retreatCameraName: CinemachineCamera_3_Corner_EU_R
+  preparingCameraRole: 2
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -55,6 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 361e91e8ca92edc459ed5ed247a853bd, type: 2}
   retreatTimeline: {fileID: 0}
-  preparingCameraName: CinemachineCamera_5_Caster_Near
-  performingCameraName: CinemachineCamera_5_Caster_Near
-  retreatCameraName: CinemachineCamera_5_Caster_Near
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -55,6 +55,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
   retreatTimeline: {fileID: 0}
-  preparingCameraName: CinemachineCamera_5_Caster_Near
-  performingCameraName: CinemachineCamera_5_Caster_Near
-  retreatCameraName: CinemachineCamera_5_Caster_Near
+  preparingCameraRole: 3
+  performingCameraRole: 3
+  retreatCameraRole: 3

--- a/Assets/Prefabs/CameraSystem.prefab
+++ b/Assets/Prefabs/CameraSystem.prefab
@@ -2249,7 +2249,7 @@ GameObject:
   - component: {fileID: 4735788714483284901}
   - component: {fileID: 2167005796374108094}
   m_Layer: 0
-  m_Name: CinemachineCamera_0_BattleCamera
+  m_Name: CMV_MainMenuIdle
   m_TagString: BattleCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2664,7 +2664,7 @@ GameObject:
   - component: {fileID: 3584404135210767579}
   - component: {fileID: 7391020172167444715}
   m_Layer: 0
-  m_Name: CinemachineCamera_5_Caster_Near
+  m_Name: CMV_ClosePush_Caster
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2804,7 +2804,7 @@ GameObject:
   - component: {fileID: 7671916787481824121}
   - component: {fileID: 8633783132696690773}
   m_Layer: 0
-  m_Name: CinemachineCamera_7_Caster_Far
+  m_Name: CMV_Victory
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3888,7 +3888,7 @@ GameObject:
   - component: {fileID: 5372850260111355708}
   - component: {fileID: 3770441389169143508}
   m_Layer: 0
-  m_Name: CinemachineCamera_1_Corner_SU_R
+  m_Name: CMV_OverShoulder_CasterToTarget
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -17268,7 +17268,7 @@ GameObject:
   - component: {fileID: 8978484750989929765}
   - component: {fileID: 5142582960034785498}
   m_Layer: 0
-  m_Name: CinemachineCamera_6_Target_Near
+  m_Name: CMV_TargetReaction
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -21911,6 +21911,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1318187734422061808}
+  - component: {fileID: 3823861060166874}
   m_Layer: 0
   m_Name: BattleCinemachineCameras
   m_TagString: Untagged
@@ -21944,6 +21945,54 @@ Transform:
   - {fileID: 8634116392376175596}
   m_Father: {fileID: 3949434785713621470}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3823861060166874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6266393350085746885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 917f9cea1dea49739bd0d736665aebf8, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  baseLerpSpeed: 6
+  rotationLerpSpeed: 8
+  epsilon: 0.0001
+  idleOrbitRadius: 3.5
+  idleOrbitSpeed: 0.35
+  idleFocusHeight: 1.6
+  idleFovAmplitude: 2.5
+  idleFovSpeed: 0.75
+  idleBaseDistance: 2.25
+  shoulderHeight: 1.55
+  shoulderDistance: 2.6
+  shoulderSideOffset: 0.65
+  shoulderLookHeight: 1.45
+  pushHeight: 1.7
+  pushDistance: 1.1
+  pushSideSwing: 0.35
+  pushFov: 42
+  reactionHeight: 1.4
+  reactionDistance: 2.2
+  reactionFov: 48
+  wideHeight: 4
+  wideDepth: 9
+  wideSide: 1.25
+  wideFov: 55
+  wideCasterWeight: 0.6
+  wideTargetWeight: 0.4
+  projectileHeight: 1.8
+  projectileOffset: 4
+  projectileSpeed: 1.35
+  projectileSideAmplitude: 0.65
+  projectileSideFrequency: 1.2
+  projectileFocusHeight: 1.5
+  victoryHeight: 2.4
+  victoryDistance: 3.5
+  victoryFov: 38
+  victoryTilt: 12
 --- !u!1 &6269623845448164628
 GameObject:
   m_ObjectHideFlags: 0
@@ -23259,7 +23308,7 @@ GameObject:
   - component: {fileID: 8581123000290381111}
   - component: {fileID: 8461187766339815685}
   m_Layer: 0
-  m_Name: CinemachineCamera_8_Target_Far
+  m_Name: CMV_Projectile_Flyby
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26781,7 +26830,7 @@ GameObject:
   - component: {fileID: 6135393580583796001}
   - component: {fileID: 4476130508735556143}
   m_Layer: 0
-  m_Name: CinemachineCamera_10_OrbitAroundBattlefield
+  m_Name: CMV_WideEstablish
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/Classes/BattleCameraRole.cs
+++ b/Assets/Scripts/Classes/BattleCameraRole.cs
@@ -1,0 +1,50 @@
+using System;
+
+/// <summary>
+/// Liste les rôles cinématiques proposés pendant les combats.
+/// Chaque valeur correspond à une ambiance visuelle précise
+/// inspirée de Clair Obscur: Expedition 33.
+/// </summary>
+[Serializable]
+public enum BattleCameraRole
+{
+    /// <summary>
+    /// Valeur neutre : aucune caméra particulière, la vue par défaut est utilisée.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Plan d'attente utilisé pour les menus ou l'introduction (respiration légère du cadre).
+    /// </summary>
+    MainMenuIdle = 1,
+
+    /// <summary>
+    /// Plan épaule du lanceur vers la cible pour souligner l'intention de l'attaque.
+    /// </summary>
+    OverShoulderCasterToTarget = 2,
+
+    /// <summary>
+    /// Plan serré sur le lanceur (push caméra) pour les phases d'incantation.
+    /// </summary>
+    ClosePushCaster = 3,
+
+    /// <summary>
+    /// Plan réaction sur la cible afin de mettre en avant l'impact.
+    /// </summary>
+    TargetReaction = 4,
+
+    /// <summary>
+    /// Plan large englobant lanceur et cible via un cadrage de groupe.
+    /// </summary>
+    WideEstablish = 5,
+
+    /// <summary>
+    /// Plan travelling suivant un projectile ou un effet en vol.
+    /// </summary>
+    ProjectileFlyby = 6,
+
+    /// <summary>
+    /// Plan final héroïque utilisé lors des victoires ou fin d'affrontement.
+    /// </summary>
+    Victory = 7
+}

--- a/Assets/Scripts/Classes/BattleCameraRole.cs.meta
+++ b/Assets/Scripts/Classes/BattleCameraRole.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71a748e28943432abc97943566f8b8f8

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -93,15 +93,12 @@ public class ItemData : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    // Nom de la caméra pendant la préparation de l'objet.
-    [Tooltip("CinemachineCamera active lors de la préparation.\nLaisser vide pour conserver la caméra en cours.")]
-    public string preparingCameraName;
-    // Nom de la caméra pendant l'utilisation de l'objet.
-    [Tooltip("CinemachineCamera active pendant l'utilisation.\nLaisser vide pour garder la caméra précédente.")]
-    public string performingCameraName;
-    // Nom de la caméra pendant la phase de repli.
-    [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
-    public string retreatCameraName;
+    [Tooltip("Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle).")]
+    public BattleCameraRole preparingCameraRole = BattleCameraRole.MainMenuIdle;
+    [Tooltip("Plan cinématique utilisé pendant l'utilisation (None = conserver la caméra précédente).")]
+    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;
+    [Tooltip("Plan cinématique utilisé lors du repli (None = conserver la caméra précédente).")]
+    public BattleCameraRole retreatCameraRole = BattleCameraRole.TargetReaction;
 
 #if UNITY_EDITOR
     // ------------------------------------------------------------------
@@ -122,12 +119,12 @@ public class ItemData : ScriptableObject
             return;
 
         // Applique les valeurs par défaut uniquement si les champs sont vides.
-        if (string.IsNullOrEmpty(preparingCameraName))
-            preparingCameraName = reference.preparingCameraName;
-        if (string.IsNullOrEmpty(performingCameraName))
-            performingCameraName = reference.performingCameraName;
-        if (string.IsNullOrEmpty(retreatCameraName))
-            retreatCameraName = reference.retreatCameraName;
+        if (preparingCameraRole == BattleCameraRole.None)
+            preparingCameraRole = reference.preparingCameraRole;
+        if (performingCameraRole == BattleCameraRole.None)
+            performingCameraRole = reference.performingCameraRole;
+        if (retreatCameraRole == BattleCameraRole.None)
+            retreatCameraRole = reference.retreatCameraRole;
     }
 #endif
 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -140,15 +140,12 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    // Nom de la caméra utilisée pendant la phase de préparation.
-    [Tooltip("CinemachineCamera active lors de la préparation.\nLaisser vide pour conserver la caméra actuelle.")]
-    public string preparingCameraName;
-    // Nom de la caméra utilisée pendant la phase d'exécution.
-    [Tooltip("CinemachineCamera active pendant l'exécution.\nLaisser vide pour garder la caméra précédente.")]
-    public string performingCameraName;
-    // Nom de la caméra utilisée pendant la phase de repli.
-    [Tooltip("CinemachineCamera active lors du repli.\nLaisser vide pour garder la caméra précédente.")]
-    public string retreatCameraName;
+    [Tooltip("Plan cinématique utilisé durant la préparation (None = conserver la caméra courante).")]
+    public BattleCameraRole preparingCameraRole = BattleCameraRole.WideEstablish;
+    [Tooltip("Plan cinématique utilisé durant l'exécution (None = conserver la caméra précédente).")]
+    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;
+    [Tooltip("Plan cinématique utilisé durant le repli (None = conserver la caméra précédente).")]
+    public BattleCameraRole retreatCameraRole = BattleCameraRole.ClosePushCaster;
 
 #if UNITY_EDITOR
     // ------------------------------------------------------------------
@@ -175,12 +172,12 @@ public class MusicalMoveSO : ScriptableObject
         // celle de "MusicalMove_Rhapsodie". Les concepteurs peuvent ensuite
         // remplacer ces valeurs manuellement selon les besoins spécifiques
         // du nouveau move.
-        if (string.IsNullOrEmpty(preparingCameraName))
-            preparingCameraName = reference.preparingCameraName;
-        if (string.IsNullOrEmpty(performingCameraName))
-            performingCameraName = reference.performingCameraName;
-        if (string.IsNullOrEmpty(retreatCameraName))
-            retreatCameraName = reference.retreatCameraName;
+        if (preparingCameraRole == BattleCameraRole.None)
+            preparingCameraRole = reference.preparingCameraRole;
+        if (performingCameraRole == BattleCameraRole.None)
+            performingCameraRole = reference.performingCameraRole;
+        if (retreatCameraRole == BattleCameraRole.None)
+            retreatCameraRole = reference.retreatCameraRole;
     }
 #endif
 

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -14,8 +14,18 @@ public class BattleCameraManager : MonoBehaviour
     // Composant responsable du changement de camera via les priorites.
     private CinemachineBlendSwitcher blendSwitcher;
 
+    // Rig dédié qui anime les caméras selon des rôles précis.
+    private BattleCameraRig cameraRig;
+
     // Ensemble des cameras Cinemachine disponibles pour les moves.
     private readonly List<CinemachineCamera> availableCameras = new();
+
+    // Mapping role -> nom de caméra utilisé par le blend switcher.
+    private readonly Dictionary<BattleCameraRole, string> roleToCameraName = new();
+    private readonly Dictionary<string, BattleCameraRole> nameToRole = new();
+
+    // Permet de connaître le plan actuellement prioritaire.
+    private BattleCameraRole currentRole = BattleCameraRole.None;
 
     void Awake()
     {
@@ -39,10 +49,91 @@ public class BattleCameraManager : MonoBehaviour
                 availableCameras.Add(cam);
         }
 
+        cameraRig = FindFirstObjectByType<BattleCameraRig>();
+        if (!cameraRig)
+            Debug.LogWarning("[BattleCameraManager] Aucun BattleCameraRig détecté : les rôles caméra ne seront pas configurés.");
+        else
+            BuildRoleMappings();
+
         // Au demarrage du combat on revient sur la camera principale taggee "BattleCamera".
         // On force une transition immediate (duree 0) pour eviter un fondu au lancement.
         if (blendSwitcher)
             blendSwitcher.DisplayCamera(null, 0f);
+    }
+
+    /// <summary>
+    /// Met à jour les correspondances rôle &lt;-&gt; nom de caméra à partir du rig présent dans la scène.
+    /// </summary>
+    private void BuildRoleMappings()
+    {
+        roleToCameraName.Clear();
+        nameToRole.Clear();
+
+        foreach (BattleCameraRole role in System.Enum.GetValues(typeof(BattleCameraRole)))
+        {
+            if (role == BattleCameraRole.None)
+                continue;
+
+            if (cameraRig.TryGetCameraName(role, out var cameraName))
+            {
+                roleToCameraName[role] = cameraName;
+                if (!nameToRole.ContainsKey(cameraName))
+                    nameToRole.Add(cameraName, role);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fournit les cibles au rig pour positionner correctement les plans.
+    /// </summary>
+    /// <param name="caster">Unité qui initie l'action.</param>
+    /// <param name="target">Unité subissant l'action (peut être <c>null</c> pour les selfs casts).</param>
+    /// <param name="midpoint">Point manuel optionnel utilisé par certains moves.</param>
+    /// <param name="casterAnchor">Ancre précise à suivre pour le lanceur (poitrine, tête...).</param>
+    /// <param name="targetAnchor">Ancre précise pour la cible.</param>
+    public void ConfigureActionTargets(
+        CharacterUnit caster,
+        CharacterUnit target,
+        Vector3? midpoint = null,
+        Transform casterAnchor = null,
+        Transform targetAnchor = null)
+    {
+        cameraRig?.ConfigureTargets(caster, target, midpoint, casterAnchor, targetAnchor);
+    }
+
+    /// <summary>
+    /// Efface les cibles connues du rig (fin de move ou retour au neutre).
+    /// </summary>
+    public void ClearRigTargets()
+    {
+        cameraRig?.ClearTargets();
+    }
+
+    /// <summary>
+    /// Active une caméra en s'appuyant sur un rôle cinématique.
+    /// </summary>
+    public void SwitchToCamera(BattleCameraRole role, float blendTime = -1f, CinemachineBlendDefinition.Styles? overrideStyle = null)
+    {
+        if (role == BattleCameraRole.None)
+        {
+            currentRole = BattleCameraRole.None;
+            cameraRig?.NotifyActiveRole(BattleCameraRole.None);
+            SwitchToCamera((string)null, blendTime, overrideStyle);
+            return;
+        }
+
+        if (!roleToCameraName.TryGetValue(role, out var cameraName))
+        {
+            Debug.LogWarning($"[BattleCameraManager] Aucun GameObject associé au rôle caméra {role}.");
+            return;
+        }
+
+        float duration = blendTime >= 0f ? blendTime : ComputeBlendDuration(currentRole, role);
+        var style = overrideStyle ?? ComputeBlendStyle(currentRole, role);
+
+        currentRole = role;
+        cameraRig?.NotifyActiveRole(role);
+        SwitchToCamera(cameraName, duration, style);
     }
 
     /// <summary>
@@ -55,7 +146,7 @@ public class BattleCameraManager : MonoBehaviour
     /// Duree du fondu en secondes. Utiliser une valeur negative pour conserver
     /// la duree definie dans le <see cref="CinemachineBlendSwitcher"/>.
     /// </param>
-    public void SwitchToCamera(string cameraName, float blendTime = -1f)
+    public void SwitchToCamera(string cameraName, float blendTime = -1f, CinemachineBlendDefinition.Styles? overrideStyle = null)
     {
         if (!blendSwitcher)
             return; // Impossible de switcher sans blendSwitcher
@@ -63,10 +154,19 @@ public class BattleCameraManager : MonoBehaviour
         // Cas 1 : aucun move/item en cours -> on revient sur la camera par defaut.
         if (cameraName == null)
         {
+            currentRole = BattleCameraRole.None;
+            cameraRig?.NotifyActiveRole(BattleCameraRole.None);
             if (blendTime >= 0f)
-                blendSwitcher.DisplayCamera(null, blendTime); // Transition forcee
+                blendSwitcher.DisplayCamera(null, blendTime, overrideStyle); // Transition forcee
             else
-                blendSwitcher.DisplayCamera(null); // Duree par defaut
+                blendSwitcher.DisplayCamera(null, blendTime, overrideStyle); // Duree par defaut
+            return;
+        }
+
+        if (nameToRole.TryGetValue(cameraName, out var resolvedRole))
+        {
+            // Permet de rester compatible avec les appels legacy basés sur le nom.
+            SwitchToCamera(resolvedRole, blendTime, overrideStyle);
             return;
         }
 
@@ -80,20 +180,56 @@ public class BattleCameraManager : MonoBehaviour
             }
             else
             {
+                currentRole = BattleCameraRole.None;
+                cameraRig?.NotifyActiveRole(BattleCameraRole.None);
                 // Si aucune camera speciale n'est disponible, on retourne sur la camera
                 // principale avec la duree de blend souhaitee ou celle par defaut.
                 if (blendTime >= 0f)
-                    blendSwitcher.DisplayCamera(null, blendTime);
+                    blendSwitcher.DisplayCamera(null, blendTime, overrideStyle);
                 else
-                    blendSwitcher.DisplayCamera(null);
+                    blendSwitcher.DisplayCamera(null, blendTime, overrideStyle);
                 return;
             }
         }
 
+        currentRole = BattleCameraRole.None;
+        cameraRig?.NotifyActiveRole(BattleCameraRole.None);
         // Affiche la camera demandee avec la duree de blend appropriee.
         if (blendTime >= 0f)
-            blendSwitcher.DisplayCamera(cameraName, blendTime);
+            blendSwitcher.DisplayCamera(cameraName, blendTime, overrideStyle);
         else
-            blendSwitcher.DisplayCamera(cameraName);
+            blendSwitcher.DisplayCamera(cameraName, blendTime, overrideStyle);
+    }
+
+    private float ComputeBlendDuration(BattleCameraRole from, BattleCameraRole to)
+    {
+        if ((from == BattleCameraRole.ClosePushCaster && to == BattleCameraRole.TargetReaction) ||
+            (from == BattleCameraRole.TargetReaction && to == BattleCameraRole.ClosePushCaster))
+            return 0.08f; // Cut nerveux pour les contres.
+
+        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterToTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
+            return 0.4f; // Transition douce entre plan large et épaule.
+
+        if (from == BattleCameraRole.Victory || to == BattleCameraRole.Victory)
+            return 1f; // Plan final plus ample.
+
+        return -1f; // Conserve la durée par défaut du BlendSwitcher.
+    }
+
+    private CinemachineBlendDefinition.Styles? ComputeBlendStyle(BattleCameraRole from, BattleCameraRole to)
+    {
+        if ((from == BattleCameraRole.ClosePushCaster && to == BattleCameraRole.TargetReaction) ||
+            (from == BattleCameraRole.TargetReaction && to == BattleCameraRole.ClosePushCaster))
+            return CinemachineBlendDefinition.Styles.Cut;
+
+        if (from == BattleCameraRole.Victory || to == BattleCameraRole.Victory)
+            return CinemachineBlendDefinition.Styles.EaseOut;
+
+        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterToTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
+            return CinemachineBlendDefinition.Styles.EaseInOut;
+
+        return null;
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
@@ -1,0 +1,617 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Unity.Cinemachine;
+
+/// <summary>
+/// Prépare et anime les différents points de vue cinématiques utilisés pendant les combats.
+/// L'objectif est de reproduire une grammaire proche de Clair Obscur: Expedition 33
+/// avec des plans identifiés (épaule, réaction, travelling projectile, etc.).
+/// </summary>
+[DisallowMultipleComponent]
+public class BattleCameraRig : MonoBehaviour
+{
+    // ------------------------------------------------------------------------------
+    // Configuration générale
+    // ------------------------------------------------------------------------------
+    [Header("Général")]
+    [Tooltip("Vitesse globale d'interpolation utilisée pour lisser les déplacements de caméra.")]
+    [SerializeField] private float baseLerpSpeed = 6f;
+
+    [Tooltip("Facteur appliqué aux interpolations d'angle pour éviter les rotations brusques.")]
+    [SerializeField] private float rotationLerpSpeed = 8f;
+
+    [Tooltip("Distance minimale utilisée pour éviter les divisions par zéro lors des calculs directionnels.")]
+    [SerializeField] private float epsilon = 0.0001f;
+
+    [Header("Points de focus par défaut")]
+    [SerializeField, Tooltip("Hauteur de référence utilisée lorsque le lanceur ne fournit pas d'ancrage caméra dédié.")]
+    private float defaultCasterFocusHeight = 1.6f;
+
+    [SerializeField, Tooltip("Hauteur de référence pour la cible lorsque aucun point précis n'est communiqué.")]
+    private float defaultTargetFocusHeight = 1.5f;
+
+    [Header("Bruit cinématique (attaques)")]
+    [SerializeField, Tooltip("Amplitude du bruit positionnel appliqué aux plans d'attaque rapprochés (en mètres).")]
+    private float attackNoiseAmplitude = 0.12f;
+
+    [SerializeField, Tooltip("Facteur appliqué sur l'axe vertical afin de conserver un mouvement plus subtil.")]
+    private float attackNoiseVerticalMultiplier = 0.45f;
+
+    [SerializeField, Tooltip("Fréquence du bruit cinématique appliqué lors des attaques (en oscillations par seconde).")]
+    private float attackNoiseFrequency = 2.2f;
+
+    [SerializeField, Tooltip("Amplitude maximale du bruit de rotation (en degrés) pour renforcer l'impact visuel.")]
+    private float attackNoiseRotationAmplitude = 0.9f;
+
+    [Header("Main Menu Idle")]
+    [SerializeField, Tooltip("Distance orbitale du plan d'attente autour du caster.")]
+    private float idleOrbitRadius = 3.5f;
+
+    [SerializeField, Tooltip("Vitesse de l'orbite micro autour du point visé.")]
+    private float idleOrbitSpeed = 0.35f;
+
+    [SerializeField, Tooltip("Hauteur du point focal pendant le plan d'attente.")]
+    private float idleFocusHeight = 1.6f;
+
+    [SerializeField, Tooltip("Amplitude (en degrés) de la respiration de FOV du plan d'attente.")]
+    private float idleFovAmplitude = 2.5f;
+
+    [SerializeField, Tooltip("Vitesse de la respiration de FOV du plan d'attente.")]
+    private float idleFovSpeed = 0.75f;
+
+    [SerializeField, Tooltip("Distance radiale de base avant application de l'orbite.")]
+    private float idleBaseDistance = 2.25f;
+
+    [Header("Over Shoulder")]
+    [SerializeField] private float shoulderHeight = 1.55f;
+    [SerializeField] private float shoulderDistance = 2.6f;
+    [SerializeField] private float shoulderSideOffset = 0.65f;
+    [SerializeField] private float shoulderLookHeight = 1.45f;
+
+    [Header("Close Push Caster")]
+    [SerializeField] private float pushHeight = 1.7f;
+    [SerializeField] private float pushDistance = 1.1f;
+    [SerializeField] private float pushSideSwing = 0.35f;
+    [SerializeField] private float pushFov = 42f;
+
+    [Header("Target Reaction")]
+    [SerializeField] private float reactionHeight = 1.4f;
+    [SerializeField] private float reactionDistance = 2.2f;
+    [SerializeField] private float reactionFov = 48f;
+
+    [Header("Wide Establish")] 
+    [SerializeField] private float wideHeight = 4f;
+    [SerializeField] private float wideDepth = 9f;
+    [SerializeField] private float wideSide = 1.25f;
+    [SerializeField] private float wideFov = 55f;
+    [SerializeField] private float wideCasterWeight = 0.6f;
+    [SerializeField] private float wideTargetWeight = 0.4f;
+
+    [Header("Projectile Flyby")]
+    [SerializeField] private float projectileHeight = 1.8f;
+    [SerializeField] private float projectileOffset = 4f;
+    [SerializeField] private float projectileSpeed = 1.35f;
+    [SerializeField] private float projectileSideAmplitude = 0.65f;
+    [SerializeField] private float projectileSideFrequency = 1.2f;
+    [SerializeField] private float projectileFocusHeight = 1.5f;
+
+    [Header("Victory")] 
+    [SerializeField] private float victoryHeight = 2.4f;
+    [SerializeField] private float victoryDistance = 3.5f;
+    [SerializeField] private float victoryFov = 38f;
+    [SerializeField] private float victoryTilt = 12f;
+
+    // ------------------------------------------------------------------------------
+    // Etat interne
+    // ------------------------------------------------------------------------------
+    private readonly Dictionary<BattleCameraRole, CinemachineCamera> cameraByRole = new();
+    private readonly Dictionary<BattleCameraRole, string> legacyNames = new();
+
+    private CinemachineTargetGroup targetGroup;
+    private Transform midAnchor;
+    private Transform caster;
+    private Transform target;
+    private Transform casterFocusAnchor;
+    private Transform targetFocusAnchor;
+    private Vector3? manualMidpoint;
+
+    // Références mémorisées pour retirer proprement les membres du CinemachineTargetGroup.
+    private Transform activeCasterGroupMember;
+    private Transform activeTargetGroupMember;
+    private Transform activeMidGroupMember;
+
+    private BattleCameraRole currentActiveRole = BattleCameraRole.None;
+    private float projectileTimer;
+    private Vector3 attackNoiseSeed;
+
+    private static readonly Dictionary<string, BattleCameraRole> NameToRole = new()
+    {
+        {"CMV_MainMenuIdle", BattleCameraRole.MainMenuIdle},
+        {"CMV_OverShoulder_CasterToTarget", BattleCameraRole.OverShoulderCasterToTarget},
+        {"CMV_ClosePush_Caster", BattleCameraRole.ClosePushCaster},
+        {"CMV_TargetReaction", BattleCameraRole.TargetReaction},
+        {"CMV_WideEstablish", BattleCameraRole.WideEstablish},
+        {"CMV_Projectile_Flyby", BattleCameraRole.ProjectileFlyby},
+        {"CMV_Victory", BattleCameraRole.Victory}
+    };
+
+    /// <summary>
+    /// Permet d'accéder au groupe de cibles utilisé par le plan large.
+    /// Exposé afin que le BattleCameraManager puisse l'alimenter si nécessaire.
+    /// </summary>
+    public CinemachineTargetGroup TargetGroup => targetGroup;
+
+    private void Awake()
+    {
+        CacheCameras();
+        PrepareTargetGroup();
+        PrepareMidAnchor();
+        PrepareImpulseListener();
+        attackNoiseSeed = new Vector3(
+            UnityEngine.Random.Range(0f, 1000f),
+            UnityEngine.Random.Range(0f, 1000f),
+            UnityEngine.Random.Range(0f, 1000f));
+    }
+
+    private void CacheCameras()
+    {
+        cameraByRole.Clear();
+        legacyNames.Clear();
+
+        foreach (var cam in GetComponentsInChildren<CinemachineCamera>(true))
+        {
+            if (!NameToRole.TryGetValue(cam.gameObject.name, out var role))
+                continue;
+
+            cameraByRole[role] = cam;
+            legacyNames[role] = cam.gameObject.name;
+            DisableLegacyControllers(cam);
+        }
+    }
+
+    private void PrepareTargetGroup()
+    {
+        targetGroup = GetComponentInChildren<CinemachineTargetGroup>();
+        if (!targetGroup)
+        {
+            var go = new GameObject("CombatTargetGroup");
+            go.transform.SetParent(transform, false);
+            targetGroup = go.AddComponent<CinemachineTargetGroup>();
+        }
+
+        // Initialisation : on purge les membres pour éviter les doublons lors des recharges de scène.
+        ClearTargetGroupMembers();
+    }
+
+    private void PrepareMidAnchor()
+    {
+        var existing = transform.Find("DynamicMidPoint");
+        if (existing != null)
+            midAnchor = existing;
+        else
+        {
+            var go = new GameObject("DynamicMidPoint");
+            go.transform.SetParent(transform, false);
+            go.hideFlags = HideFlags.DontSave;
+            midAnchor = go.transform;
+        }
+    }
+
+    private void PrepareImpulseListener()
+    {
+        var brain = Camera.main ? Camera.main.GetComponent<CinemachineBrain>() : null;
+        if (brain != null && !brain.TryGetComponent(out CinemachineImpulseListener listener))
+        {
+            listener = brain.gameObject.AddComponent<CinemachineImpulseListener>();
+            listener.m_ReactionSettings.m_ReactionScale = 0.85f;
+            listener.m_ReactionSettings.m_TimeToPeak = 0.12f;
+            listener.m_ReactionSettings.m_DecayTime = 0.45f;
+        }
+    }
+
+    private void DisableLegacyControllers(CinemachineCamera cam)
+    {
+        var followCaster = cam.GetComponent<FollowBattleCaster>();
+        if (followCaster) followCaster.enabled = false;
+
+        var lookAtCaster = cam.GetComponent<LookAtBattleCaster>();
+        if (lookAtCaster) lookAtCaster.enabled = false;
+
+        var lookAtMiddle = cam.GetComponent<LookAtMiddleEnemy>();
+        if (lookAtMiddle) lookAtMiddle.enabled = false;
+
+        var lookAtAll = cam.GetComponent<LookAtAllCharacters>();
+        if (lookAtAll) lookAtAll.enabled = false;
+
+        var moveTo = cam.GetComponent<MoveToVector3>();
+        if (moveTo) moveTo.enabled = false;
+
+        var orbit = cam.GetComponent<OrbitWithScale>();
+        if (orbit) orbit.enabled = false;
+    }
+
+    /// <summary>
+    /// Configure les cibles suivies par le rig.
+    /// </summary>
+    public void ConfigureTargets(
+        CharacterUnit casterUnit,
+        CharacterUnit targetUnit,
+        Vector3? midpointOverride = null,
+        Transform casterAnchor = null,
+        Transform targetAnchor = null)
+    {
+        caster = casterUnit ? casterUnit.transform : null;
+        target = targetUnit ? targetUnit.transform : null;
+        casterFocusAnchor = casterAnchor;
+        targetFocusAnchor = targetAnchor;
+        manualMidpoint = midpointOverride;
+
+        UpdateTargetGroupMembers();
+    }
+
+    /// <summary>
+    /// Efface les références de cibles lorsque l'action est terminée.
+    /// </summary>
+    public void ClearTargets()
+    {
+        caster = null;
+        target = null;
+        manualMidpoint = null;
+        casterFocusAnchor = null;
+        targetFocusAnchor = null;
+        UpdateTargetGroupMembers();
+    }
+
+    private void UpdateTargetGroupMembers()
+    {
+        if (!targetGroup)
+            return;
+
+        ClearTargetGroupMembers();
+
+        Transform casterMember = casterFocusAnchor ? casterFocusAnchor : caster;
+        if (casterMember)
+        {
+            targetGroup.AddMember(casterMember, wideCasterWeight, 0.5f);
+            activeCasterGroupMember = casterMember;
+        }
+
+        Transform targetMember = targetFocusAnchor ? targetFocusAnchor : target;
+        if (targetMember)
+        {
+            targetGroup.AddMember(targetMember, wideTargetWeight, 0.5f);
+            activeTargetGroupMember = targetMember;
+        }
+
+        if (manualMidpoint.HasValue)
+        {
+            midAnchor.position = manualMidpoint.Value;
+            targetGroup.AddMember(midAnchor, 0.2f, 0.1f);
+            activeMidGroupMember = midAnchor;
+        }
+    }
+
+    /// <summary>
+    /// Retourne la caméra associée à un rôle donné.
+    /// </summary>
+    public bool TryGetCamera(BattleCameraRole role, out CinemachineCamera camera)
+        => cameraByRole.TryGetValue(role, out camera);
+
+    /// <summary>
+    /// Retourne le nom d'origine de la caméra (utile pour le BlendSwitcher).
+    /// </summary>
+    public bool TryGetCameraName(BattleCameraRole role, out string cameraName)
+        => legacyNames.TryGetValue(role, out cameraName);
+
+    /// <summary>
+    /// Notifie le rig du rôle actuellement prioritaire afin d'adapter certains effets.
+    /// </summary>
+    public void NotifyActiveRole(BattleCameraRole role)
+    {
+        currentActiveRole = role;
+        if (role == BattleCameraRole.ProjectileFlyby)
+            projectileTimer = 0f; // Ré-initialise le travelling à chaque activation.
+    }
+
+    private void ClearTargetGroupMembers()
+    {
+        if (!targetGroup)
+            return;
+
+        // Retire systématiquement les anciennes références avant de réinjecter les cibles.
+        if (activeCasterGroupMember)
+        {
+            targetGroup.RemoveMember(activeCasterGroupMember);
+            activeCasterGroupMember = null;
+        }
+
+        if (activeTargetGroupMember)
+        {
+            targetGroup.RemoveMember(activeTargetGroupMember);
+            activeTargetGroupMember = null;
+        }
+
+        if (activeMidGroupMember)
+        {
+            targetGroup.RemoveMember(activeMidGroupMember);
+            activeMidGroupMember = null;
+        }
+    }
+
+    private void LateUpdate()
+    {
+        float dt = Time.deltaTime;
+        UpdateIdleCamera(dt);
+        UpdateOverShoulderCamera(dt);
+        UpdateClosePushCamera(dt);
+        UpdateTargetReactionCamera(dt);
+        UpdateWideCamera(dt);
+        UpdateProjectileCamera(dt);
+        UpdateVictoryCamera(dt);
+    }
+
+    private Vector3 GetCasterFocusBase()
+    {
+        if (casterFocusAnchor)
+            return casterFocusAnchor.position;
+
+        if (caster)
+            return caster.position + Vector3.up * defaultCasterFocusHeight;
+
+        return transform.position + Vector3.up * defaultCasterFocusHeight;
+    }
+
+    private Vector3 GetTargetFocusBase()
+    {
+        if (targetFocusAnchor)
+            return targetFocusAnchor.position;
+
+        if (target)
+            return target.position + Vector3.up * defaultTargetFocusHeight;
+
+        return GetCasterFocusBase();
+    }
+
+    private Vector3 GetCasterFocusPosition()
+        => GetCasterFocusBase();
+
+    private Vector3 GetCasterFocusPosition(float desiredHeight)
+        => GetCasterFocusBase() + Vector3.up * (desiredHeight - defaultCasterFocusHeight);
+
+    private Vector3 GetTargetFocusPosition()
+        => GetTargetFocusBase();
+
+    private Vector3 GetTargetFocusPosition(float desiredHeight)
+        => GetTargetFocusBase() + Vector3.up * (desiredHeight - defaultTargetFocusHeight);
+
+    private Vector3 GetWeightedCenter()
+    {
+        bool hasCaster = caster || casterFocusAnchor;
+        bool hasTarget = target || targetFocusAnchor;
+
+        if (!hasCaster && !hasTarget)
+            return transform.position;
+
+        Vector3 casterPos = GetCasterFocusPosition();
+        Vector3 targetPos = GetTargetFocusPosition();
+
+        if (hasCaster && hasTarget)
+        {
+            float totalWeight = Mathf.Max(0.001f, wideCasterWeight + wideTargetWeight);
+            return (casterPos * wideCasterWeight + targetPos * wideTargetWeight) / totalWeight;
+        }
+
+        return hasCaster ? casterPos : targetPos;
+    }
+
+    private void UpdateIdleCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.MainMenuIdle, out var cam))
+            return;
+
+        Vector3 anchorPos = GetCasterFocusPosition(idleFocusHeight);
+        float orbitAngle = Time.time * idleOrbitSpeed;
+
+        Vector3 orbitOffset = new(
+            Mathf.Cos(orbitAngle) * idleOrbitRadius,
+            0f,
+            Mathf.Sin(orbitAngle) * idleOrbitRadius);
+
+        Vector3 direction = (anchorPos - cam.transform.position).normalized;
+        if (direction.sqrMagnitude < epsilon)
+            direction = Vector3.forward;
+
+        Vector3 baseOffset = -direction * idleBaseDistance;
+        Vector3 desiredPos = anchorPos + orbitOffset + baseOffset;
+
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed * 0.5f);
+        SmoothLookAt(cam, anchorPos, dt, rotationLerpSpeed * 0.5f);
+
+        float targetFov = 50f + Mathf.Sin(Time.time * idleFovSpeed) * idleFovAmplitude;
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, targetFov, dt * 0.5f);
+    }
+
+    private void UpdateOverShoulderCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.OverShoulderCasterToTarget, out var cam) || !caster)
+            return;
+
+        Vector3 casterFocus = GetCasterFocusPosition(shoulderHeight);
+        Vector3 targetFocus = GetTargetFocusPosition(shoulderLookHeight);
+
+        Vector3 focusDir = targetFocus - casterFocus;
+        if (focusDir.sqrMagnitude < epsilon)
+            focusDir = caster.forward;
+        Vector3 normalizedDir = focusDir.normalized;
+
+        Vector3 side = Vector3.Cross(Vector3.up, normalizedDir).normalized;
+        Vector3 desiredPos = casterFocus - normalizedDir * shoulderDistance + side * shoulderSideOffset;
+        Vector3 lookPos = targetFocus;
+
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed);
+        SmoothLookAt(cam, lookPos, dt, rotationLerpSpeed);
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, 52f, dt * 0.8f);
+    }
+
+    private void UpdateClosePushCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.ClosePushCaster, out var cam) || !caster)
+            return;
+
+        Vector3 casterFocus = GetCasterFocusPosition(pushHeight);
+        Vector3 targetFocus = GetTargetFocusPosition();
+        Vector3 toTarget = targetFocus - casterFocus;
+        if (toTarget.sqrMagnitude < epsilon)
+            toTarget = caster.forward;
+        Vector3 direction = toTarget.normalized;
+
+        Vector3 side = Vector3.Cross(Vector3.up, direction).normalized;
+        Vector3 desiredPos = casterFocus - direction * pushDistance + side * pushSideSwing;
+        desiredPos = ApplyAttackPositionNoise(desiredPos, BattleCameraRole.ClosePushCaster);
+
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed * 1.1f);
+
+        Vector3 lookPos = GetCasterFocusPosition(pushHeight + 0.2f) + direction * 0.15f;
+        SmoothLookAt(cam, lookPos, dt, rotationLerpSpeed * 1.2f, GetAttackRotationNoise(BattleCameraRole.ClosePushCaster));
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, pushFov, dt * 1.5f);
+    }
+
+    private void UpdateTargetReactionCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.TargetReaction, out var cam) || !target)
+            return;
+
+        Vector3 targetFocus = GetTargetFocusPosition(reactionHeight);
+        Vector3 fromCaster = targetFocus - GetCasterFocusPosition();
+        if (fromCaster.sqrMagnitude < epsilon)
+            fromCaster = target.forward.sqrMagnitude > epsilon ? -target.forward : Vector3.back;
+        Vector3 direction = fromCaster.normalized;
+
+        Vector3 desiredPos = targetFocus + direction * reactionDistance;
+        desiredPos = ApplyAttackPositionNoise(desiredPos, BattleCameraRole.TargetReaction);
+
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed * 0.9f);
+        Vector3 lookPos = GetTargetFocusPosition(reactionHeight + 0.1f);
+        SmoothLookAt(cam, lookPos, dt, rotationLerpSpeed, GetAttackRotationNoise(BattleCameraRole.TargetReaction));
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, reactionFov, dt * 0.9f);
+    }
+
+    private void UpdateWideCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.WideEstablish, out var cam))
+            return;
+
+        Vector3 center = GetWeightedCenter();
+        Vector3 separation = GetTargetFocusPosition() - GetCasterFocusPosition();
+        if (separation.sqrMagnitude < epsilon)
+            separation = caster ? caster.forward : Vector3.forward;
+
+        Vector3 forward = separation.normalized;
+        Vector3 side = Vector3.Cross(Vector3.up, forward).normalized;
+
+        Vector3 desiredPos = center - forward * wideDepth + side * wideSide + Vector3.up * wideHeight;
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed * 0.6f);
+        SmoothLookAt(cam, center + Vector3.up * 1.2f, dt, rotationLerpSpeed * 0.6f);
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, wideFov, dt * 0.5f);
+    }
+
+    private void UpdateProjectileCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.ProjectileFlyby, out var cam) || !caster || !target)
+            return;
+
+        if (currentActiveRole == BattleCameraRole.ProjectileFlyby)
+            projectileTimer += dt * projectileSpeed;
+        else
+            projectileTimer = Mathf.Max(0f, projectileTimer - dt * projectileSpeed);
+
+        float t = Mathf.Clamp01(projectileTimer);
+        Vector3 casterPos = GetCasterFocusPosition(projectileHeight);
+        Vector3 targetPos = GetTargetFocusPosition(projectileHeight);
+        Vector3 direction = (targetPos - casterPos);
+        if (direction.sqrMagnitude < epsilon)
+            direction = caster.forward;
+        Vector3 forward = direction.normalized;
+        Vector3 side = Vector3.Cross(Vector3.up, forward).normalized;
+
+        Vector3 start = casterPos - forward * projectileOffset;
+        Vector3 end = targetPos + forward * projectileOffset;
+        Vector3 lerp = Vector3.Lerp(start, end, t);
+        float sine = Mathf.Sin(projectileTimer * projectileSideFrequency) * projectileSideAmplitude;
+        Vector3 desiredPos = lerp + side * sine;
+
+        cam.transform.position = desiredPos;
+        Vector3 midFocus = Vector3.Lerp(
+            GetCasterFocusPosition(projectileFocusHeight),
+            GetTargetFocusPosition(projectileFocusHeight),
+            t);
+        SmoothLookAt(cam, midFocus, dt, rotationLerpSpeed * 1.4f);
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, 60f, dt);
+    }
+
+    private void UpdateVictoryCamera(float dt)
+    {
+        if (!TryGetCamera(BattleCameraRole.Victory, out var cam) || !caster)
+            return;
+
+        Vector3 focus = GetCasterFocusPosition(victoryHeight);
+        Vector3 backward = caster.forward.sqrMagnitude > epsilon ? -caster.forward.normalized : Vector3.back;
+        Vector3 desiredPos = focus + backward * victoryDistance;
+
+        SmoothPosition(cam, desiredPos, dt, baseLerpSpeed * 0.4f);
+        Quaternion targetRot = Quaternion.LookRotation((focus - desiredPos).normalized, Vector3.up) * Quaternion.Euler(victoryTilt, 0f, 0f);
+        cam.transform.rotation = Quaternion.Slerp(cam.transform.rotation, targetRot, dt * rotationLerpSpeed * 0.5f);
+        cam.Lens.FieldOfView = Mathf.Lerp(cam.Lens.FieldOfView, victoryFov, dt * 0.6f);
+    }
+
+    private bool IsAttackNoiseActive(BattleCameraRole role)
+    {
+        if (currentActiveRole != role)
+            return false;
+
+        return attackNoiseAmplitude > 0f || attackNoiseRotationAmplitude > 0f;
+    }
+
+    private Vector3 ApplyAttackPositionNoise(Vector3 basePosition, BattleCameraRole role)
+    {
+        if (!IsAttackNoiseActive(role) || attackNoiseAmplitude <= 0f)
+            return basePosition;
+
+        float t = Time.time * attackNoiseFrequency;
+        float x = (Mathf.PerlinNoise(attackNoiseSeed.x, t) - 0.5f) * attackNoiseAmplitude;
+        float y = (Mathf.PerlinNoise(attackNoiseSeed.y, t) - 0.5f) * attackNoiseAmplitude * attackNoiseVerticalMultiplier;
+        float z = (Mathf.PerlinNoise(attackNoiseSeed.z, t) - 0.5f) * attackNoiseAmplitude;
+        return basePosition + new Vector3(x, y, z);
+    }
+
+    private Vector3 GetAttackRotationNoise(BattleCameraRole role)
+    {
+        if (!IsAttackNoiseActive(role) || attackNoiseRotationAmplitude <= 0f)
+            return Vector3.zero;
+
+        float t = Time.time * attackNoiseFrequency;
+        float pitch = (Mathf.PerlinNoise(attackNoiseSeed.x + 31.7f, t) - 0.5f) * attackNoiseRotationAmplitude;
+        float yaw = (Mathf.PerlinNoise(attackNoiseSeed.y + 78.2f, t) - 0.5f) * attackNoiseRotationAmplitude;
+        return new Vector3(pitch, yaw, 0f);
+    }
+
+    private void SmoothPosition(CinemachineCamera cam, Vector3 desiredPos, float dt, float speed)
+    {
+        Vector3 current = cam.transform.position;
+        Vector3 next = Vector3.Lerp(current, desiredPos, Mathf.Clamp01(dt * speed));
+        cam.transform.position = next;
+    }
+
+    private void SmoothLookAt(CinemachineCamera cam, Vector3 targetPos, float dt, float speed, Vector3 noiseEuler = default)
+    {
+        Vector3 direction = targetPos - cam.transform.position;
+        if (direction.sqrMagnitude < epsilon)
+            return;
+
+        Quaternion targetRot = Quaternion.LookRotation(direction.normalized, Vector3.up);
+        if (noiseEuler != Vector3.zero)
+            targetRot *= Quaternion.Euler(noiseEuler);
+        cam.transform.rotation = Quaternion.Slerp(cam.transform.rotation, targetRot, Mathf.Clamp01(dt * speed));
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 917f9cea1dea49739bd0d736665aebf8

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -456,7 +456,7 @@ public class BattleTransitionManager : MonoBehaviour
 
             // Au lieu de jouer une timeline d'introduction, on affiche directement
             // la camera orbitale autour du champ de bataille avec une transition instantanée.
-            BattleCameraManager.Instance?.SwitchToCamera("CinemachineCamera_10_OrbitAroundBattlefield", 0f);
+            BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish, 0f);
         }
         else
         {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -129,8 +129,8 @@ public class NewBattleManager : MonoBehaviour
     public TimelineAsset itemPreparingTimeline;
     private bool itemMenuTimelineActive = false;
 
-    /// <summary>Nom de la CinemachineCamera dédiée à l'attente de sélection d'objet.</summary>
-    private const string ItemPreparingCameraName = "CinemachineCamera_9_Item_Preparing";
+    /// <summary>Rôle caméra utilisé lors de l'attente de sélection d'objet.</summary>
+    private const BattleCameraRole ItemPreparingCameraRole = BattleCameraRole.MainMenuIdle;
     /// <summary>Hash du state Animator "Item_Prepare" pour lancer rapidement l'animation correspondante.</summary>
     private static readonly int AnimatorStateItemPrepare = Animator.StringToHash("Item_Prepare");
     /// <summary>Hash du state Animator "Idle_Battle" afin de revenir proprement à la pose neutre.</summary>
@@ -477,13 +477,13 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator PlayIntroCameraSequence()
     {
         // 🎥 Donne immédiatement la priorité à la caméra orbitale pour présenter le champ de bataille.
-        BattleCameraManager.Instance?.SwitchToCamera("CinemachineCamera_10_OrbitAroundBattlefield", 0f);
+        BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish, 0f);
 
         // 🎬 Lance les timelines d'introduction en mode ralenti et attend leur terminaison.
         yield return PlayIntroTimelinesWithSlowTime();
 
         // 📷 Retourne ensuite sur la caméra de combat standard avec un léger fondu.
-        BattleCameraManager.Instance?.SwitchToCamera(null, 0.5f);
+        BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.None, 0.5f);
     }
     #endregion
 
@@ -2202,7 +2202,20 @@ public class NewBattleManager : MonoBehaviour
         }
 
         // Confie la priorité caméra à la Cinemachine dédiée à l'attente d'objet.
-        BattleCameraManager.Instance?.SwitchToCamera(ItemPreparingCameraName);
+        Transform casterCameraAnchor = null;
+        if (currentCharacterUnit != null)
+        {
+            GameObject casterBinding = currentCharacterUnit.GetCasterBindingTarget();
+            casterCameraAnchor = casterBinding != null ? casterBinding.transform : null;
+        }
+
+        BattleCameraManager.Instance?.ConfigureActionTargets(
+            currentCharacterUnit,
+            null,
+            null,
+            casterCameraAnchor,
+            null);
+        BattleCameraManager.Instance?.SwitchToCamera(ItemPreparingCameraRole);
 
         // L'objet d'animation sert de point d'ancrage pour la timeline et l'alignement caméra.
         GameObject animGO = casterAnimator != null ? casterAnimator.gameObject : currentCharacterUnit.GetCasterBindingTarget();
@@ -2232,7 +2245,8 @@ public class NewBattleManager : MonoBehaviour
             return;
 
         // On redonne la priorité à la BattleCamera classique pour la suite des actions.
-        BattleCameraManager.Instance?.SwitchToCamera(null);
+        BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.None);
+        BattleCameraManager.Instance?.ClearRigTargets();
 
         if (currentCharacterUnit != null)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -195,14 +195,14 @@ public class RhythmQTEManager : MonoBehaviour
     /// <param name="cameraTarget">Objet servant d'ancre pour la caméra.</param>
     /// <param name="autoRestore">Indique si la caméra doit être restaurée automatiquement.</param>
     /// <param name="initialRotation">Rotation de référence à conserver.</param>
-    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, CharacterUnit caster, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation, string cameraName = null)
+    private void StartTimelinePhase(TimelineAsset timeline, bool overlay, CharacterUnit caster, GameObject animatorGO, GameObject cameraTarget, bool autoRestore, Quaternion initialRotation, BattleCameraRole cameraRole = BattleCameraRole.None)
     {
         if (timeline == null || BattleTimelineManager.Instance == null || caster == null)
             return;
 
         // 🎥 Active la caméra dédiée à cette phase si elle est renseignée.
-        if (!string.IsNullOrWhiteSpace(cameraName))
-            BattleCameraManager.Instance?.SwitchToCamera(cameraName);
+        if (cameraRole != BattleCameraRole.None)
+            BattleCameraManager.Instance?.SwitchToCamera(cameraRole);
 
         // 📽️ La caméra n'étant plus pilotée par les timelines des moves/items,
         // nous ré-alignons simplement l'origine avant de lancer la timeline du lanceur.
@@ -292,13 +292,30 @@ public class RhythmQTEManager : MonoBehaviour
         // - L'exécution doit suivre la cible directe du sort.
         // - Les phases de préparation et de repli se recentrent sur le lanceur
         //   pour garder une mise en scène cohérente.
-        GameObject performingCameraTarget = target != null
-            ? target.gameObject         // 🎯 Caméra sur la CharacterUnit ciblée pendant l'exécution
-            : casterAnimatorGO;         // 🔁 Retombe sur le lanceur si aucune cible
+        GameObject performingCameraTarget = null;
+        if (target != null)
+        {
+            // On privilégie l'ancre animée de la cible pour obtenir un cadrage stable.
+            performingCameraTarget = target.GetCasterBindingTarget();
+            if (performingCameraTarget == null)
+                performingCameraTarget = target.gameObject;
+        }
+        else
+        {
+            performingCameraTarget = casterAnimatorGO; // 🔁 Retombe sur le lanceur si aucune cible
+        }
         GameObject casterCameraTarget = casterAnimatorGO; // 📌 Ancre sur le lanceur pour préparation et repli
         // Détermine si une timeline caméra couvrant toute l'action est disponible.
         // Ce système est remplacé par l'utilisation de caméras Cinemachine dédiées.
         bool useOverlay = false;
+
+        // Configure le rig caméra avec les cibles du move avant de démarrer la mise en scène.
+        BattleCameraManager.Instance?.ConfigureActionTargets(
+            caster,
+            target,
+            null,
+            casterCameraTarget != null ? casterCameraTarget.transform : null,
+            performingCameraTarget != null ? performingCameraTarget.transform : null);
 
         // Éventuel délai de pré-animation.
         // 🔄 Cette attente se produit désormais AVANT toute timeline
@@ -319,7 +336,7 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             move.performingTimeline == null && move.retreatTimeline == null,
             initialRotation,
-            move.preparingCameraName);
+            move.preparingCameraRole);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay, caster);
 
         // Déplacement ou téléportation vers la cible si nécessaire.
@@ -345,7 +362,7 @@ public class RhythmQTEManager : MonoBehaviour
             performingCameraTarget,
             move.retreatTimeline == null,
             initialRotation,
-            move.performingCameraName);
+            move.performingCameraRole);
 
         if (pendingNotes == 0)
         {
@@ -385,7 +402,7 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             true,
             initialRotation,
-            move.retreatCameraName);
+            move.retreatCameraRole);
         yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay, caster);
 
         // Attente finale de la timeline caméra complète (désactivée).
@@ -402,7 +419,8 @@ public class RhythmQTEManager : MonoBehaviour
         currentTarget = null;
 
         // Restaure la caméra par défaut en fin de move.
-        BattleCameraManager.Instance?.SwitchToCamera(null);
+        BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.None);
+        BattleCameraManager.Instance?.ClearRigTargets();
 
         // Nettoie la barre de QTE une fois la séquence terminée
         ClearQTEBar();
@@ -451,14 +469,29 @@ public class RhythmQTEManager : MonoBehaviour
         // 🧭 Détermination des cibles de caméra pour les différentes phases :
         //   * exécution -> focus sur la cible de l'objet si elle existe ;
         //   * préparation et repli -> recentrage sur le lanceur.
-        GameObject performingCameraTarget = target != null
-            ? target.gameObject         // 🎯 Cible privilégiée pendant l'utilisation
-            : casterAnimatorGO;         // 🔁 Retombe sur le lanceur en absence de cible
+        GameObject performingCameraTarget = null;
+        if (target != null)
+        {
+            performingCameraTarget = target.GetCasterBindingTarget();
+            if (performingCameraTarget == null)
+                performingCameraTarget = target.gameObject;
+        }
+        else
+        {
+            performingCameraTarget = casterAnimatorGO; // 🔁 Retombe sur le lanceur en absence de cible
+        }
         GameObject casterCameraTarget = casterAnimatorGO; // 📌 Référence fixe sur le lanceur
 
         // L'ancien système de timeline caméra est remplacé par les caméras Cinemachine.
         bool useOverlay = false;
         // Lancement de timeline globale désactivé.
+
+        BattleCameraManager.Instance?.ConfigureActionTargets(
+            caster,
+            target,
+            null,
+            casterCameraTarget != null ? casterCameraTarget.transform : null,
+            performingCameraTarget != null ? performingCameraTarget.transform : null);
 
         // --- Phase de préparation ---
         StartTimelinePhase(
@@ -469,7 +502,7 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             item.performingTimeline == null && item.retreatTimeline == null,
             initialRotation,
-            item.preparingCameraName);
+            item.preparingCameraRole);
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay, caster);
 
         // Déplacement ou téléportation éventuel vers la cible.
@@ -495,7 +528,7 @@ public class RhythmQTEManager : MonoBehaviour
             performingCameraTarget,
             item.retreatTimeline == null,
             initialRotation,
-            item.performingCameraName);
+            item.performingCameraRole);
 
         // QTE associé à l'objet durant l'utilisation.
         LastItemSuccess = true;
@@ -526,7 +559,7 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             true,
             initialRotation,
-            item.retreatCameraName);
+            item.retreatCameraRole);
         yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay, caster);
 
         isActive = false;
@@ -538,7 +571,8 @@ public class RhythmQTEManager : MonoBehaviour
         ClearQTEBar();
 
         // Retour à la caméra par défaut.
-        BattleCameraManager.Instance?.SwitchToCamera(null);
+        BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.None);
+        BattleCameraManager.Instance?.ClearRigTargets();
     }
 
     private IEnumerator SimpleMoveTo(CharacterUnit caster, CharacterUnit target, ItemData item)

--- a/Docs/NouveauxContenus.md
+++ b/Docs/NouveauxContenus.md
@@ -23,19 +23,22 @@ opportunités tactiques que les novices peuvent appréhender facilement tout en
 permettant aux vétérans de créer des enchaînements complexes.
 
 ## Caméras par phase
-Chaque **MusicalMove** et chaque **Item** peut désormais définir trois noms de
-caméras Cinemachine :
-`preparingCameraName`, `performingCameraName` et `retreatCameraName`.
-Ces champs autorisent l'utilisation d'une caméra différente pour chaque
-phase sans obligation. Laisser un champ vide conserve la caméra active, ce
-qui garantit une transition fluide.
+Chaque **MusicalMove** et chaque **Item** référence désormais un rôle de caméra
+cinématique plutôt qu'un nom explicite :
+`preparingCameraRole`, `performingCameraRole` et `retreatCameraRole`.
+Ces rôles correspondent aux plans définis par le nouveau rig
+(`MainMenuIdle`, `OverShoulderCasterToTarget`, `ClosePushCaster`,
+`TargetReaction`, `WideEstablish`, `ProjectileFlyby`, `Victory`).
+Sélectionner `None` conserve la caméra actuellement active afin de garantir une
+transition fluide.
 
 ### Valeurs par défaut recommandées
 Pour assurer une expérience cohérente, tout **nouveau MusicalMove** doit
 initialiser ces trois champs avec les valeurs définies dans
-**MusicalMove_Rhapsodie**. De même, les **nouveaux Items** doivent se baser
-sur les valeurs utilisées par **Item_LonguePortee**. Les concepteurs
-peuvent ensuite adapter ces paramètres selon les besoins spécifiques du
+**MusicalMove_Rhapsodie** (WideEstablish → OverShoulder → TargetReaction).
+De même, les **nouveaux Items** doivent se baser sur les valeurs utilisées par
+**Item_LonguePortee** (OverShoulder → OverShoulder → TargetReaction). Les
+concepteurs peuvent ensuite adapter ces paramètres selon les besoins spécifiques du
 contenu ajouté.
 
 Ce nouveau système remplace l'ancien champ `cameraName` unique ainsi que


### PR DESCRIPTION
## Résumé
- prise en charge d’ancres de focus pour le caster et la cible dans le BattleCameraRig afin d’alimenter automatiquement le CinemachineTargetGroup et d’orchestrer les différents plans
- adoucissement des mouvements de caméra en fonction des hauteurs cibles, ajout d’un bruit cinématique sur les plans d’attaque et interpolation revue pour OverShoulder, ClosePush, TargetReaction, Wide et Projectile
- mise à jour des appels BattleCameraManager.ConfigureActionTargets pour transmettre les transforms d’animation pertinents (RhythmQTEManager, NewBattleManager)

## Tests
- non exécutés (aucune suite automatisée disponible)


------
https://chatgpt.com/codex/tasks/task_e_68cd74b6ea788325840860037c02ff77