### PR TITLE
Ajuste des caméras Cinemachine pour les menus et l'intro

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -79,6 +79,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
         // Active immediatement la camera d'indice 0 si elle existe afin
         // d'avoir une vue de combat par defaut pour les menus et le ciblage.
         ActivateDefaultCameraPriorities();
+        UpdateActiveCameraStates(_current);
     }
 
     /// <summary>
@@ -148,6 +149,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
             c.Priority = (c == cameras[0]) ? activePriority : inactivePriority;
 
         _current = cameras[0];
+        UpdateActiveCameraStates(_current);
     }
 
     /// <summary>
@@ -191,6 +193,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
                 c.Priority = inactivePriority;
 
             _current = null;
+            UpdateActiveCameraStates(null);
             return;
         }
 
@@ -215,6 +218,7 @@ public class CinemachineBlendSwitcher : MonoBehaviour
             c.Priority = (c == next) ? activePriority : inactivePriority;
 
         _current = next;
+        UpdateActiveCameraStates(next);
     }
 
     /// <summary>
@@ -470,6 +474,27 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     }
 
     /// <summary>
+    /// Active uniquement la camera souhaitee et coupe toutes les autres afin d'eviter
+    /// qu'elles continuent a consommer des calculs alors qu'elles ne sont pas visibles.
+    /// </summary>
+    /// <param name="activeCamera">Camera qui doit rester active (ou <c>null</c> pour les desactiver toutes).</param>
+    private void UpdateActiveCameraStates(CinemachineCamera activeCamera)
+    {
+        if (cameras == null)
+            return;
+
+        foreach (var cam in cameras)
+        {
+            if (!cam)
+                continue;
+
+            bool shouldBeActive = cam == activeCamera;
+            if (cam.gameObject.activeSelf != shouldBeActive)
+                cam.gameObject.SetActive(shouldBeActive);
+        }
+    }
+
+    /// <summary>
     /// Nettoie les ressources utilisees par le fondu (texture temporaire et overlay).
     /// </summary>
     private void CleanupCrossFadeResources()
@@ -501,4 +526,19 @@ public class CinemachineBlendSwitcher : MonoBehaviour
 
         CleanupCrossFadeResources();
     }
+
+    /// <summary>
+    /// Retourne le nom de la camera actuellement prioritaire (<c>null</c> si aucune n'est active).
+    /// </summary>
+    public string CurrentCameraName => _current ? _current.gameObject.name : null;
+
+    /// <summary>
+    /// Indique si une camera Cinemachine dispose actuellement de la priorite.
+    /// </summary>
+    public bool HasActiveCamera => _current != null;
+
+    /// <summary>
+    /// Fournit l'instance de la <see cref="CinemachineCamera"/> actuellement prioritaire.
+    /// </summary>
+    public CinemachineCamera CurrentCamera => _current;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -20,6 +20,9 @@ public class BattleCameraManager : MonoBehaviour
     // Ensemble des cameras Cinemachine disponibles pour les moves.
     private readonly List<CinemachineCamera> availableCameras = new();
 
+    // Accès direct aux caméras via leur nom pour faciliter les repositionnements ponctuels.
+    private readonly Dictionary<string, CinemachineCamera> cameraByName = new();
+
     // Mapping role -> nom de caméra utilisé par le blend switcher.
     private readonly Dictionary<BattleCameraRole, string> roleToCameraName = new();
     private readonly Dictionary<string, BattleCameraRole> nameToRole = new();
@@ -49,6 +52,8 @@ public class BattleCameraManager : MonoBehaviour
                 availableCameras.Add(cam);
         }
 
+        RefreshCameraCache();
+
         cameraRig = FindFirstObjectByType<BattleCameraRig>();
         if (!cameraRig)
             Debug.LogWarning("[BattleCameraManager] Aucun BattleCameraRig détecté : les rôles caméra ne seront pas configurés.");
@@ -59,6 +64,20 @@ public class BattleCameraManager : MonoBehaviour
         // On force une transition immediate (duree 0) pour eviter un fondu au lancement.
         if (blendSwitcher)
             blendSwitcher.DisplayCamera(null, 0f);
+    }
+
+    /// <summary>
+    /// Reconstitue le dictionnaire nom -> caméra afin de toujours disposer d'une référence valide.
+    /// </summary>
+    private void RefreshCameraCache()
+    {
+        cameraByName.Clear();
+
+        // Nettoie les entrées nulles pouvant apparaître après un changement de scène.
+        availableCameras.RemoveAll(cam => cam == null);
+
+        foreach (var cam in availableCameras)
+            cameraByName[cam.gameObject.name] = cam;
     }
 
     /// <summary>
@@ -107,6 +126,66 @@ public class BattleCameraManager : MonoBehaviour
     public void ClearRigTargets()
     {
         cameraRig?.ClearTargets();
+    }
+
+    /// <summary>
+    /// Tente de récupérer une <see cref="CinemachineCamera"/> via son nom de GameObject.
+    /// </summary>
+    public bool TryGetCameraByName(string cameraName, out CinemachineCamera camera)
+    {
+        if (string.IsNullOrEmpty(cameraName))
+        {
+            camera = null;
+            return false;
+        }
+
+        if (!cameraByName.TryGetValue(cameraName, out camera) || camera == null)
+        {
+            RefreshCameraCache();
+            if (!cameraByName.TryGetValue(cameraName, out camera) || camera == null)
+            {
+                availableCameras.Clear();
+                foreach (var cam in FindObjectsOfType<CinemachineCamera>())
+                {
+                    if (cam != null)
+                        availableCameras.Add(cam);
+                }
+
+                RefreshCameraCache();
+                cameraByName.TryGetValue(cameraName, out camera);
+            }
+        }
+
+        return camera != null;
+    }
+
+    /// <summary>
+    /// Replace une caméra statique sur une ancre donnée puis lui donne la priorité.
+    /// Utile pour les menus qui disposent d'un point de vue par personnage.
+    /// </summary>
+    public void SwitchToCameraAndAlign(
+        string cameraName,
+        Transform anchor,
+        float blendTime = 0f,
+        CinemachineBlendDefinition.Styles? overrideStyle = null)
+    {
+        if (anchor == null)
+        {
+            Debug.LogWarning("[BattleCameraManager] Impossible d'aligner la caméra : ancre absente.");
+            return;
+        }
+
+        if (!TryGetCameraByName(cameraName, out var camera))
+        {
+            Debug.LogWarning($"[BattleCameraManager] Caméra inconnue : {cameraName}.");
+            return;
+        }
+
+        // Positionne immédiatement la caméra sur l'ancre du personnage pour garantir un cadrage cohérent.
+        camera.transform.SetPositionAndRotation(anchor.position, anchor.rotation);
+
+        // Puis donne la priorité à cette caméra en privilégiant un cut (blendTime = 0 par défaut).
+        SwitchToCamera(cameraName, blendTime, overrideStyle);
     }
 
     /// <summary>
@@ -246,4 +325,14 @@ public class BattleCameraManager : MonoBehaviour
 
         return null;
     }
+
+    /// <summary>
+    /// Nom de la caméra actuellement prioritaire (ou <c>null</c> si aucune Cinemachine n'est active).
+    /// </summary>
+    public string CurrentCinemachineCameraName => blendSwitcher ? blendSwitcher.CurrentCameraName : null;
+
+    /// <summary>
+    /// Indique si une Cinemachine est actuellement prioritaire dans le <see cref="CinemachineBrain"/>.
+    /// </summary>
+    public bool HasActiveCinemachineCamera => blendSwitcher && blendSwitcher.HasActiveCamera;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -454,9 +454,17 @@ public class BattleTransitionManager : MonoBehaviour
         {
             battleCamera.SetActive(true); // S'assure que la camera de combat est active
 
-            // Au lieu de jouer une timeline d'introduction, on affiche directement
-            // la camera orbitale autour du champ de bataille avec une transition instantanée.
-            BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish, 0f);
+            // Au lieu de jouer une timeline d'introduction, on priorise la Cinemachine dédiée
+            // à l'intro de combat. Si elle est indisponible, on conserve l'ancien plan large.
+            if (BattleCameraManager.Instance != null &&
+                BattleCameraManager.Instance.TryGetCameraByName("CMV_BattleIntro", out _))
+            {
+                BattleCameraManager.Instance.SwitchToCamera("CMV_BattleIntro", 0f);
+            }
+            else
+            {
+                BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish, 0f);
+            }
         }
         else
         {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -8,6 +8,7 @@ using UnityEngine.InputSystem;
 using TMPro;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
+using Unity.Cinemachine;
 
 #region TargetType
 public enum TargetType
@@ -131,6 +132,16 @@ public class NewBattleManager : MonoBehaviour
 
     /// <summary>Rôle caméra utilisé lors de l'attente de sélection d'objet.</summary>
     private const BattleCameraRole ItemPreparingCameraRole = BattleCameraRole.MainMenuIdle;
+    /// <summary>Nom de la Cinemachine dédiée au menu principal.</summary>
+    private const string MainMenuCameraName = "CMV_MainMenu";
+    /// <summary>Nom de la Cinemachine dédiée au menu des compétences.</summary>
+    private const string SkillsMenuCameraName = "CMV_SkillsMenu";
+    /// <summary>Nom de la Cinemachine dédiée au menu des objets.</summary>
+    private const string ItemsMenuCameraName = "CMV_ItemsMenu";
+    /// <summary>Style de transition privilégié pour les menus (cut instantané).</summary>
+    private const CinemachineBlendDefinition.Styles MenuCameraBlendStyle = CinemachineBlendDefinition.Styles.Cut;
+    /// <summary>Durée par défaut des transitions de menu (0 = cut immédiat).</summary>
+    private const float MenuCameraBlendDuration = 0f;
     /// <summary>Hash du state Animator "Item_Prepare" pour lancer rapidement l'animation correspondante.</summary>
     private static readonly int AnimatorStateItemPrepare = Animator.StringToHash("Item_Prepare");
     /// <summary>Hash du state Animator "Idle_Battle" afin de revenir proprement à la pose neutre.</summary>
@@ -223,9 +234,10 @@ public class NewBattleManager : MonoBehaviour
     private bool lookAtCasterDuringTargetSelection = false;
     // Indique si la caméra doit se placer sur la cible et regarder le lanceur (tour ennemi)
     private bool lookAtCasterFromTargetPoint = false;
-    private bool isOrbiting = false;
-    private float currentOrbitAngle;
-    private Transform orbitCenter;
+    // Indique si une Cinemachine de menu est actuellement prioritaire (afin de ne pas déplacer la caméra Unity).
+    private bool isMenuCinemachineActive = false;
+    // Mémorise le nom de la Cinemachine actuellement utilisée pour le menu afin de pouvoir la libérer proprement.
+    private string activeMenuCameraName;
 
     [Header("Cinématique de début de tour joueur")]
     [SerializeField, Tooltip("Durée du travelling inspiré de l'introduction de combat (en secondes).")]
@@ -2629,6 +2641,41 @@ public class NewBattleManager : MonoBehaviour
     #endregion
 
     #region Gestion des mouvements de la caméra de combat
+    /// <summary>
+    /// Donne la priorité à une Cinemachine de menu et l'aligne sur l'ancre fournie.
+    /// Retourne <c>true</c> si l'opération s'est déroulée correctement.
+    /// </summary>
+    private bool ActivateMenuCinemachineCamera(string cameraName, Transform anchor)
+    {
+        if (string.IsNullOrEmpty(cameraName) || anchor == null)
+            return false;
+
+        var manager = BattleCameraManager.Instance;
+        if (manager == null)
+            return false;
+
+        manager.SwitchToCameraAndAlign(cameraName, anchor, MenuCameraBlendDuration, MenuCameraBlendStyle);
+        isMenuCinemachineActive = true;
+        activeMenuCameraName = cameraName;
+        return true;
+    }
+
+    /// <summary>
+    /// Libère la Cinemachine dédiée aux menus si elle possède encore la priorité.
+    /// </summary>
+    private void DeactivateMenuCinemachineCamera()
+    {
+        if (!isMenuCinemachineActive)
+            return;
+
+        var manager = BattleCameraManager.Instance;
+        if (manager != null && manager.CurrentCinemachineCameraName == activeMenuCameraName)
+            manager.SwitchToCamera(null, MenuCameraBlendDuration, MenuCameraBlendStyle);
+
+        isMenuCinemachineActive = false;
+        activeMenuCameraName = null;
+    }
+
     public void UpdateCameraBehaviour(BattleState newState)
     {
         // On vérifie ponctuellement que la caméra de combat est bien référencée
@@ -2652,6 +2699,8 @@ public class NewBattleManager : MonoBehaviour
         // Désactive le focus spécial utilisé pendant le tour ennemi
         lookAtCasterFromTargetPoint = false;
 
+        bool handledByMenuCamera = false;
+
         switch (currentBattleState)
         {
             case BattleState.SquadUnit_MainMenu:
@@ -2669,6 +2718,7 @@ public class NewBattleManager : MonoBehaviour
                 {
                     OrientTransformTowardEnemyGroupSmoothXY(desiredTransform, 180f);
                 }
+                handledByMenuCamera = ActivateMenuCinemachineCamera(MainMenuCameraName, desiredTransform);
                 break;
 
             case BattleState.SquadUnit_SkillsMenu:
@@ -2680,6 +2730,7 @@ public class NewBattleManager : MonoBehaviour
                     "Camera_SkillsMenu",
                     "[BattleCameraManager] Aucun point 'Camera_SkillsMenu' trouvé."
                 );
+                handledByMenuCamera = ActivateMenuCinemachineCamera(SkillsMenuCameraName, desiredTransform);
                 break;
 
             case BattleState.SquadUnit_ItemsMenu:
@@ -2690,6 +2741,7 @@ public class NewBattleManager : MonoBehaviour
                     "Camera_ItemsMenu",
                     "[BattleCameraManager] Aucun point 'Camera_ItemsMenu' trouvé."
                 );
+                handledByMenuCamera = ActivateMenuCinemachineCamera(ItemsMenuCameraName, desiredTransform);
                 break;
 
             case BattleState.SquadUnit_TargetSelectionAmongSquadOrEnemies_OnSquad:
@@ -2772,6 +2824,9 @@ public class NewBattleManager : MonoBehaviour
                 desiredTransform = null;
                 break;
         }
+
+        if (!handledByMenuCamera)
+            DeactivateMenuCinemachineCamera();
     }
 
     /// <summary>
@@ -2935,10 +2990,12 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
+        // Lorsque les menus affichent une Cinemachine dédiée, on laisse cette dernière piloter le rendu.
+        if (isMenuCinemachineActive)
+            return;
+
         // Accès direct au transform de la caméra pour limiter les appels
         Transform camTransform = battleCamera.transform;
-
-        CameraController cc = CameraController.Instance;
         // Si une Timeline globale contrôle la caméra (cutscene ou attaque),
         // on laisse entièrement la main au TimelineManager.
         if (TimelineManager.Instance != null && TimelineManager.Instance.IsTimelinePlaying)


### PR DESCRIPTION
## Résumé
- donne la priorité aux Cinemachine des menus (Main/Skills/Items) en les alignant sur les ancres des unités actives
- désactive automatiquement les caméras virtuelles hors champ pour limiter la charge
- active CMV_BattleIntro au lancement du combat pour la présentation cinématique

## Tests
- Pas de tests automatisés (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68cf0ce833708325861ba6753f0d588e