### PR TITLE
Alignement dynamique des Cinemachine contextuelles

### DIFF
--- a/Assets/Prefabs/CameraSystem.prefab
+++ b/Assets/Prefabs/CameraSystem.prefab
@@ -21722,6 +21722,7 @@ Transform:
   - {fileID: 6595896132668960984}
   - {fileID: 411919687188885756}
   - {fileID: 7398911953744187301}
+  - {fileID: 4670001122334455667}
   - {fileID: 4469592497006090902}
   - {fileID: 8634116392376175596}
   - {fileID: 7817978743507359198}
@@ -25314,8 +25315,83 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+  Priority:
+    Enabled: 0
+    m_Value: 0
+  OutputChannel: 1
+  StandbyUpdate: 2
+  m_StreamingVersion: 20241001
+  m_LegacyPriority: 0
+  Target:
+    TrackingTarget: {fileID: 0}
+    LookAtTarget: {fileID: 0}
+    CustomLookAtTarget: 0
+  Lens:
+    FieldOfView: 60.000004
+    OrthographicSize: 5
+    NearClipPlane: 0.3
+    FarClipPlane: 1500
+    Dutch: 0
+    ModeOverride: 0
+    PhysicalProperties:
+      GateFit: 2
+      SensorSize: {x: 21.946, y: 16.002}
+      LensShift: {x: 0, y: 0}
+      FocusDistance: 10
+      Iso: 200
+      ShutterSpeed: 0.005
+      Aperture: 16
+      BladeCount: 5
+      Curvature: {x: 2, y: 11}
+      BarrelClipping: 0.25
+      Anamorphism: 0
+  BlendHint: 0
+--- !u!1 &8350001122334455667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4670001122334455667}
+  - component: {fileID: 2050001122334455667}
+  m_Layer: 0
+  m_Name: CMV_TargetCursor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4670001122334455667
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8350001122334455667}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.6, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1318187734422061808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2050001122334455667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8350001122334455667}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f9dfa5b682dcd46bda6128250e975f58, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   Priority:
     Enabled: 0
     m_Value: 0

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -160,6 +160,33 @@ public class BattleCameraManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Aligne une Cinemachine sur un point de référence sans modifier ses priorités.
+    /// Cette méthode est utilisée par les menus, le ciblage et les actions pour
+    /// réutiliser les ancres placées sur chaque <see cref="CharacterUnit"/>.
+    /// </summary>
+    /// <param name="cameraName">Nom de la Cinemachine à repositionner.</param>
+    /// <param name="anchor">Ancre (souvent un enfant du personnage) servant de repère.</param>
+    /// <returns><c>true</c> si l'alignement a réussi, <c>false</c> sinon.</returns>
+    public bool AlignCameraToAnchor(string cameraName, Transform anchor)
+    {
+        if (anchor == null)
+        {
+            Debug.LogWarning("[BattleCameraManager] Impossible d'aligner la caméra : ancre absente.");
+            return false;
+        }
+
+        if (!TryGetCameraByName(cameraName, out var camera))
+        {
+            Debug.LogWarning($"[BattleCameraManager] Caméra inconnue : {cameraName}.");
+            return false;
+        }
+
+        // Le positionnement immédiat garantit que le prochain blend partira du bon endroit.
+        camera.transform.SetPositionAndRotation(anchor.position, anchor.rotation);
+        return true;
+    }
+
+    /// <summary>
     /// Replace une caméra statique sur une ancre donnée puis lui donne la priorité.
     /// Utile pour les menus qui disposent d'un point de vue par personnage.
     /// </summary>
@@ -169,20 +196,8 @@ public class BattleCameraManager : MonoBehaviour
         float blendTime = 0f,
         CinemachineBlendDefinition.Styles? overrideStyle = null)
     {
-        if (anchor == null)
-        {
-            Debug.LogWarning("[BattleCameraManager] Impossible d'aligner la caméra : ancre absente.");
+        if (!AlignCameraToAnchor(cameraName, anchor))
             return;
-        }
-
-        if (!TryGetCameraByName(cameraName, out var camera))
-        {
-            Debug.LogWarning($"[BattleCameraManager] Caméra inconnue : {cameraName}.");
-            return;
-        }
-
-        // Positionne immédiatement la caméra sur l'ancre du personnage pour garantir un cadrage cohérent.
-        camera.transform.SetPositionAndRotation(anchor.position, anchor.rotation);
 
         // Puis donne la priorité à cette caméra en privilégiant un cut (blendTime = 0 par défaut).
         SwitchToCamera(cameraName, blendTime, overrideStyle);

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -132,16 +132,22 @@ public class NewBattleManager : MonoBehaviour
 
     /// <summary>Rôle caméra utilisé lors de l'attente de sélection d'objet.</summary>
     private const BattleCameraRole ItemPreparingCameraRole = BattleCameraRole.MainMenuIdle;
-    /// <summary>Nom de la Cinemachine dédiée au menu principal.</summary>
+    /// <summary>Nom de la Cinemachine dédiée au menu principal et aux variations associées.</summary>
     private const string MainMenuCameraName = "CMV_MainMenu";
-    /// <summary>Nom de la Cinemachine dédiée au menu des compétences.</summary>
-    private const string SkillsMenuCameraName = "CMV_SkillsMenu";
     /// <summary>Nom de la Cinemachine dédiée au menu des objets.</summary>
     private const string ItemsMenuCameraName = "CMV_ItemsMenu";
+    /// <summary>Nom de la Cinemachine utilisée pour suivre le curseur de ciblage.</summary>
+    private const string TargetCursorCameraName = "CMV_TargetCursor";
+    /// <summary>Nom de la Cinemachine utilisée lors de l'exécution d'une action (MusicalMove ou Item).</summary>
+    private const string MoveCameraName = "CMV_Move";
     /// <summary>Style de transition privilégié pour les menus (cut instantané).</summary>
     private const CinemachineBlendDefinition.Styles MenuCameraBlendStyle = CinemachineBlendDefinition.Styles.Cut;
     /// <summary>Durée par défaut des transitions de menu (0 = cut immédiat).</summary>
     private const float MenuCameraBlendDuration = 0f;
+    /// <summary>Durée appliquée aux caméras contextuelles (ciblage, actions).</summary>
+    private const float ContextCameraBlendDuration = 0f;
+    /// <summary>Style de transition privilégié pour les caméras contextuelles.</summary>
+    private const CinemachineBlendDefinition.Styles ContextCameraBlendStyle = CinemachineBlendDefinition.Styles.Cut;
     /// <summary>Hash du state Animator "Item_Prepare" pour lancer rapidement l'animation correspondante.</summary>
     private static readonly int AnimatorStateItemPrepare = Animator.StringToHash("Item_Prepare");
     /// <summary>Hash du state Animator "Idle_Battle" afin de revenir proprement à la pose neutre.</summary>
@@ -238,6 +244,10 @@ public class NewBattleManager : MonoBehaviour
     private bool isMenuCinemachineActive = false;
     // Mémorise le nom de la Cinemachine actuellement utilisée pour le menu afin de pouvoir la libérer proprement.
     private string activeMenuCameraName;
+    // Indique si la Cinemachine dédiée au curseur de cible possède actuellement la priorité.
+    private bool isTargetCursorCinemachineActive = false;
+    // Indique si la Cinemachine d'action (moves/items) contrôle actuellement la vue.
+    private bool isMoveCinemachineActive = false;
 
     [Header("Cinématique de début de tour joueur")]
     [SerializeField, Tooltip("Durée du travelling inspiré de l'introduction de combat (en secondes).")]
@@ -945,7 +955,9 @@ public class NewBattleManager : MonoBehaviour
         yield return new WaitForSecondsRealtime(delay);
         // On arrête de forcer la caméra sur la cible avant d'exécuter l'attaque
         lookAtCasterFromTargetPoint = false;
+        ActivateMoveCinemachine(enemy);
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, enemy, target);
+        DeactivateMoveCinemachine();
 
         // Ajoute le move au codex et affiche sa découverte si nécessaire
         if (!alreadyKnown && MusicalCodexManager.Instance != null && MusicalCodexManager.Instance.TryAddNewMelody(move))
@@ -1007,6 +1019,7 @@ public class NewBattleManager : MonoBehaviour
             }
         }
         // Lecture d'un avertissement sonore si le mouvement en possède un
+        ActivateMoveCinemachine(caster);
         if (move.warningClip != null)
         {
             RhythmQTEManager.Instance?.PrepareQTEBar(move.notes);
@@ -1017,6 +1030,7 @@ public class NewBattleManager : MonoBehaviour
         }
 
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);
+        DeactivateMoveCinemachine();
 
         // Ajout du système de rage manuellement
         var rage = caster.GetComponent<RageSystem>();
@@ -1064,7 +1078,9 @@ public class NewBattleManager : MonoBehaviour
         OrientUnitTowardTarget(caster, target);
 
         // Animation ou Timeline d'utilisation
+        ActivateMoveCinemachine(caster);
         yield return RhythmQTEManager.Instance.ItemRoutine(item, caster, target);
+        DeactivateMoveCinemachine();
 
         bool crit = RhythmQTEManager.Instance.LastItemSuccess;
         if (crit)
@@ -2404,6 +2420,7 @@ public class NewBattleManager : MonoBehaviour
             }
             HideMultiTargetCursors();
             UpdateTargetCursorColor(true);
+            DeactivateTargetCursorCinemachine();
             return;
         }
 
@@ -2444,6 +2461,8 @@ public class NewBattleManager : MonoBehaviour
                     multiTargetCursors[i].SetActive(false);
                 }
             }
+
+            DeactivateTargetCursorCinemachine();
         }
         else
         {
@@ -2503,6 +2522,8 @@ public class NewBattleManager : MonoBehaviour
                     targetCursor.transform.position = currentTargetCharacter.transform.position;
                     UpdateTargetCursorColor(true);
                 }
+
+                UpdateTargetCursorCinemachine(currentTargetCharacter);
             }
         }
     }
@@ -2676,6 +2697,103 @@ public class NewBattleManager : MonoBehaviour
         activeMenuCameraName = null;
     }
 
+    /// <summary>
+    /// Met à jour la Cinemachine dédiée au curseur de cible pour qu'elle se cale sur l'ancre de la cible courante.
+    /// </summary>
+    /// <param name="target">Unité actuellement visée par le joueur (ou l'ennemi).</param>
+    private void UpdateTargetCursorCinemachine(CharacterUnit target)
+    {
+        if (targetCursor == null || !targetCursor.activeInHierarchy || target == null)
+        {
+            DeactivateTargetCursorCinemachine();
+            return;
+        }
+
+        Transform anchor = GetTargetedAnchorOrFallback(target);
+        if (anchor == null)
+        {
+            DeactivateTargetCursorCinemachine();
+            return;
+        }
+
+        var manager = BattleCameraManager.Instance;
+        if (manager == null)
+            return; // Aucun gestionnaire de caméra disponible : on laisse la caméra par défaut.
+
+        // Aligne systématiquement la caméra sur l'ancre pour suivre les éventuels déplacements du modèle.
+        manager.AlignCameraToAnchor(TargetCursorCameraName, anchor);
+
+        if (!isTargetCursorCinemachineActive)
+        {
+            manager.SwitchToCamera(TargetCursorCameraName, ContextCameraBlendDuration, ContextCameraBlendStyle);
+            isTargetCursorCinemachineActive = true;
+        }
+    }
+
+    /// <summary>
+    /// Coupe la Cinemachine dédiée au curseur de cible lorsque le joueur quitte une phase de ciblage.
+    /// </summary>
+    private void DeactivateTargetCursorCinemachine()
+    {
+        if (!isTargetCursorCinemachineActive)
+            return;
+
+        var manager = BattleCameraManager.Instance;
+        if (manager != null && !isMenuCinemachineActive && !isMoveCinemachineActive)
+            manager.SwitchToCamera(null, ContextCameraBlendDuration, ContextCameraBlendStyle);
+
+        isTargetCursorCinemachineActive = false;
+    }
+
+    /// <summary>
+    /// Active (ou réactualise) la Cinemachine utilisée pendant l'exécution d'un MusicalMove ou d'un Item.
+    /// </summary>
+    /// <param name="caster">Unité qui réalise l'action en cours.</param>
+    private void ActivateMoveCinemachine(CharacterUnit caster)
+    {
+        if (caster == null)
+        {
+            DeactivateMoveCinemachine();
+            return;
+        }
+
+        Transform anchor = ResolveCameraAnchor(
+            caster.transform,
+            "Camera_MoveReference",
+            "[BattleCameraManager] Aucun point 'Camera_MoveReference' trouvé pour aligner la caméra d'action."
+        );
+
+        var manager = BattleCameraManager.Instance;
+        if (manager == null)
+            return;
+
+        // On désactive immédiatement la caméra de ciblage pour éviter un conflit de priorité.
+        DeactivateTargetCursorCinemachine();
+
+        manager.AlignCameraToAnchor(MoveCameraName, anchor);
+
+        if (!isMoveCinemachineActive)
+        {
+            manager.SwitchToCamera(MoveCameraName, ContextCameraBlendDuration, ContextCameraBlendStyle);
+            isMoveCinemachineActive = true;
+        }
+    }
+
+    /// <summary>
+    /// Libère la Cinemachine d'action afin de rendre la main à la caméra par défaut ou au menu.
+    /// </summary>
+    private void DeactivateMoveCinemachine()
+    {
+        if (!isMoveCinemachineActive)
+            return;
+
+        var manager = BattleCameraManager.Instance;
+        if (manager != null && !isMenuCinemachineActive && !isTargetCursorCinemachineActive)
+            manager.SwitchToCamera(null, ContextCameraBlendDuration, ContextCameraBlendStyle);
+
+        isMoveCinemachineActive = false;
+    }
+
     public void UpdateCameraBehaviour(BattleState newState)
     {
         // On vérifie ponctuellement que la caméra de combat est bien référencée
@@ -2730,16 +2848,19 @@ public class NewBattleManager : MonoBehaviour
                     "Camera_SkillsMenu",
                     "[BattleCameraManager] Aucun point 'Camera_SkillsMenu' trouvé."
                 );
-                handledByMenuCamera = ActivateMenuCinemachineCamera(SkillsMenuCameraName, desiredTransform);
+                // La Cinemachine de menu principale est réutilisée pour garantir un cut cohérent entre
+                // le menu principal et la consultation des compétences.
+                handledByMenuCamera = ActivateMenuCinemachineCamera(MainMenuCameraName, desiredTransform);
                 break;
 
             case BattleState.SquadUnit_ItemsMenu:
                 isFollowingCurrentTarget = false;
-                // Point de vue spécialisé pour l'utilisation ou la préparation des objets.
+                // Les objets utilisent le même plan d'attente que le menu principal pour conserver
+                // la familiarité du cadrage.
                 desiredTransform = ResolveCameraAnchor(
                     currentCharacterUnit.transform,
-                    "Camera_ItemsMenu",
-                    "[BattleCameraManager] Aucun point 'Camera_ItemsMenu' trouvé."
+                    "Camera_MainMenu",
+                    "[BattleCameraManager] Aucun point 'Camera_MainMenu' trouvé pour le menu des objets."
                 );
                 handledByMenuCamera = ActivateMenuCinemachineCamera(ItemsMenuCameraName, desiredTransform);
                 break;
@@ -2798,6 +2919,19 @@ public class NewBattleManager : MonoBehaviour
                 desiredTransform = GetTargetedAnchorOrFallback(currentTargetCharacter);
                 break;
 
+            case BattleState.SquadUnit_PerformingMusicalMove:
+            case BattleState.SquadUnit_Item_Use:
+                // Pendant l'exécution d'une action joueur, on reste calé sur l'ancre dédiée pour
+                // assurer une cohérence avec la Cinemachine "CMV_Move".
+                isFollowingCurrentTarget = false;
+                lookAtCasterDuringTargetSelection = false;
+                desiredTransform = ResolveCameraAnchor(
+                    currentCharacterUnit.transform,
+                    "Camera_MoveReference",
+                    "[BattleCameraManager] Aucun point 'Camera_MoveReference' trouvé pour le lanceur."
+                );
+                break;
+
             case BattleState.EnemyUnit_Reflexion:
                 isFollowingCurrentTarget = false;
                 desiredTransform = GetTargetedAnchorOrFallback(currentTargetCharacter);
@@ -2824,6 +2958,15 @@ public class NewBattleManager : MonoBehaviour
                 desiredTransform = null;
                 break;
         }
+
+        bool isActionState =
+            currentBattleState == BattleState.SquadUnit_PerformingMusicalMove ||
+            currentBattleState == BattleState.SquadUnit_Item_Use ||
+            currentBattleState == BattleState.EnemyUnit_PerformingMusicalMove ||
+            currentBattleState == BattleState.EnemyUnit_Item_Use;
+
+        if (!isActionState)
+            DeactivateMoveCinemachine();
 
         if (!handledByMenuCamera)
             DeactivateMenuCinemachineCamera();


### PR DESCRIPTION
## Résumé
- aligne dynamiquement les caméras Cinemachine des menus sur les ancres des CharacterUnit selon le contexte (menu principal, compétences, objets)
- ajoute la Cinemachine CMV_TargetCursor au rig et pilote automatiquement la caméra de ciblage durant la sélection
- synchronise la caméra d’action CMV_Move avec le point Camera_MoveReference lors des MusicalMoves et de l’utilisation d’objets

## Tests
- Aucun test automatisé disponible (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68cf1586243483259738e3302cf09e07