### PR TITLE
Activer une interpolation caméra d’une seconde

### DIFF
--- a/Assets/Prefabs/CameraSystem.prefab
+++ b/Assets/Prefabs/CameraSystem.prefab
@@ -20191,7 +20191,7 @@ MonoBehaviour:
   activePriority: 100
   inactivePriority: 10
   blendStyle: 1
-  defaultBlendDuration: 0.5
+  defaultBlendDuration: 1
   useVisualCrossFade: 1
   crossFadeCurve:
     serializedVersion: 2

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -383,13 +383,14 @@ public class BattleCameraManager : MonoBehaviour
     public void SwitchToCameraAndAlign(
         string cameraName,
         Transform anchor,
-        float blendTime = 0f,
+        float blendTime = -1f,
         CinemachineBlendDefinition.Styles? overrideStyle = null)
     {
         if (!AlignCameraToAnchor(cameraName, anchor))
             return;
 
-        // Puis donne la priorité à cette caméra en privilégiant un cut (blendTime = 0 par défaut).
+        // Puis donne la priorité à cette caméra en conservant la durée par défaut (désormais lissée sur
+        // une seconde via le BlendSwitcher) sauf indication contraire.
         SwitchToCamera(cameraName, blendTime, overrideStyle);
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -140,14 +140,26 @@ public class NewBattleManager : MonoBehaviour
     private const string TargetCursorCameraName = "CMV_TargetCursor";
     /// <summary>Nom de la Cinemachine utilisée lors de l'exécution d'une action (MusicalMove ou Item).</summary>
     private const string MoveCameraName = "CMV_Move";
-    /// <summary>Style de transition privilégié pour les menus (cut instantané).</summary>
-    private const CinemachineBlendDefinition.Styles MenuCameraBlendStyle = CinemachineBlendDefinition.Styles.Cut;
-    /// <summary>Durée par défaut des transitions de menu (0 = cut immédiat).</summary>
-    private const float MenuCameraBlendDuration = 0f;
-    /// <summary>Durée appliquée aux caméras contextuelles (ciblage, actions).</summary>
-    private const float ContextCameraBlendDuration = 0f;
-    /// <summary>Style de transition privilégié pour les caméras contextuelles.</summary>
-    private const CinemachineBlendDefinition.Styles ContextCameraBlendStyle = CinemachineBlendDefinition.Styles.Cut;
+    /// <summary>
+    /// Style de transition privilégié pour les menus : on adopte désormais un fondu doux pour guider le
+    /// regard du joueur sans rupture visuelle.
+    /// </summary>
+    private const CinemachineBlendDefinition.Styles MenuCameraBlendStyle = CinemachineBlendDefinition.Styles.EaseInOut;
+    /// <summary>
+    /// Durée par défaut des transitions de menu. Réglée sur une seconde pour offrir une interpolation
+    /// claire et lisible lors du passage d'un panneau à l'autre.
+    /// </summary>
+    private const float MenuCameraBlendDuration = 1f;
+    /// <summary>
+    /// Durée appliquée aux caméras contextuelles (ciblage, actions). Harmonisée sur une seconde afin de
+    /// conserver la cohérence avec les transitions de menus.
+    /// </summary>
+    private const float ContextCameraBlendDuration = 1f;
+    /// <summary>
+    /// Style de transition privilégié pour les caméras contextuelles. On privilégie un lissage progressif
+    /// pour mettre en valeur les animations sans cut brutal.
+    /// </summary>
+    private const CinemachineBlendDefinition.Styles ContextCameraBlendStyle = CinemachineBlendDefinition.Styles.EaseInOut;
     /// <summary>Hash du state Animator "Item_Prepare" pour lancer rapidement l'animation correspondante.</summary>
     private static readonly int AnimatorStateItemPrepare = Animator.StringToHash("Item_Prepare");
     /// <summary>Hash du state Animator "Idle_Battle" afin de revenir proprement à la pose neutre.</summary>


### PR DESCRIPTION
## Summary
- appliquer un blend EaseInOut d’une seconde aux menus et caméras contextuelles du NewBattleManager pour supprimer les cuts
- laisser SwitchToCameraAndAlign profiter de la durée par défaut du BlendSwitcher afin de bénéficier du même lissage
- mettre à jour le prefab CameraSystem pour fixer la durée de blend par défaut à une seconde

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cfb93fd6548325932f3db9c6976e07