### PR TITLE
Ajout du plan caméra épaule fixe regard cible

### DIFF
--- a/Assets/Scripts/Classes/BattleCameraRole.cs
+++ b/Assets/Scripts/Classes/BattleCameraRole.cs
@@ -46,5 +46,10 @@ public enum BattleCameraRole
     /// <summary>
     /// Plan final héroïque utilisé lors des victoires ou fin d'affrontement.
     /// </summary>
-    Victory = 7
+    Victory = 7,
+
+    /// <summary>
+    /// Plan épaule figé qui se cale sur l'ancre "Camera_Shoulder_Stay" du lanceur et garde la cible en mire.
+    /// </summary>
+    OverShoulderCasterLookTarget = 8
 }

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -93,7 +93,7 @@ public class ItemData : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    [Tooltip("Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle).")]
+    [Tooltip("Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle, OverShoulderCasterLookTarget = ancre Camera_Shoulder_Stay).")]
     public BattleCameraRole preparingCameraRole = BattleCameraRole.MainMenuIdle;
     [Tooltip("Plan cinématique utilisé pendant l'utilisation (None = conserver la caméra précédente).")]
     public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -140,7 +140,7 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    [Tooltip("Plan cinématique utilisé durant la préparation (None = conserver la caméra courante).")]
+    [Tooltip("Plan cinématique utilisé durant la préparation (None = conserver la caméra courante, OverShoulderCasterLookTarget = ancre Camera_Shoulder_Stay).")]
     public BattleCameraRole preparingCameraRole = BattleCameraRole.WideEstablish;
     [Tooltip("Plan cinématique utilisé durant l'exécution (None = conserver la caméra précédente).")]
     public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -515,6 +515,14 @@ public class BattleCameraManager : MonoBehaviour
             (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
             return 0.4f; // Transition douce entre plan large et épaule.
 
+        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.WideEstablish))
+            return 0.4f; // Même lisibilité que l'épaule classique pour présenter l'action.
+
+        if ((from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.OverShoulderCasterToTarget))
+            return 0.25f; // Cut plus nerveux entre les deux variantes de plan épaule.
+
         if (from == BattleCameraRole.Victory || to == BattleCameraRole.Victory)
             return 1f; // Plan final plus ample.
 
@@ -533,6 +541,14 @@ public class BattleCameraManager : MonoBehaviour
         if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterToTarget) ||
             (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
             return CinemachineBlendDefinition.Styles.EaseInOut;
+
+        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.WideEstablish))
+            return CinemachineBlendDefinition.Styles.EaseInOut;
+
+        if ((from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
+            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.OverShoulderCasterToTarget))
+            return CinemachineBlendDefinition.Styles.Cut;
 
         return null;
     }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
@@ -69,6 +69,10 @@ public class BattleCameraRig : MonoBehaviour
     [SerializeField] private float shoulderSideOffset = 0.65f;
     [SerializeField] private float shoulderLookHeight = 1.45f;
 
+    [Header("Over Shoulder (Stay)")]
+    [SerializeField, Tooltip("Champ de vision utilisé lorsque l'on se cale sur l'ancre fixe Camera_Shoulder_Stay.")]
+    private float shoulderStayFov = 50f;
+
     [Header("Close Push Caster")]
     [SerializeField] private float pushHeight = 1.7f;
     [SerializeField] private float pushDistance = 1.1f;
@@ -120,6 +124,7 @@ public class BattleCameraRig : MonoBehaviour
     private Transform target;
     private Transform casterFocusAnchor;
     private Transform targetFocusAnchor;
+    private CharacterUnit casterUnit;
     private Vector3? manualMidpoint;
 
     // Références mémorisées pour retirer proprement les membres du CinemachineTargetGroup.
@@ -131,10 +136,17 @@ public class BattleCameraRig : MonoBehaviour
     private float projectileTimer;
     private Vector3 attackNoiseSeed;
 
+    // Mémoire dédiée au plan "Over Shoulder Look Target" qui ne doit se calculer qu'une fois par action.
+    private Vector3 shoulderStayPosition;
+    private bool shoulderStayInitialized;
+
+    private const string ShoulderStayAnchorName = "Camera_Shoulder_Stay";
+
     private static readonly Dictionary<string, BattleCameraRole> NameToRole = new()
     {
         {"CMV_MainMenuIdle", BattleCameraRole.MainMenuIdle},
         {"CMV_OverShoulder_CasterToTarget", BattleCameraRole.OverShoulderCasterToTarget},
+        {"CMV_OverShoulder_CasterLookTarget", BattleCameraRole.OverShoulderCasterLookTarget},
         {"CMV_ClosePush_Caster", BattleCameraRole.ClosePushCaster},
         {"CMV_TargetReaction", BattleCameraRole.TargetReaction},
         {"CMV_WideEstablish", BattleCameraRole.WideEstablish},
@@ -243,17 +255,20 @@ public class BattleCameraRig : MonoBehaviour
     /// Configure les cibles suivies par le rig.
     /// </summary>
     public void ConfigureTargets(
-        CharacterUnit casterUnit,
-        CharacterUnit targetUnit,
+        CharacterUnit casterUnitParam,
+        CharacterUnit targetUnitParam,
         Vector3? midpointOverride = null,
         Transform casterAnchor = null,
         Transform targetAnchor = null)
     {
-        caster = casterUnit ? casterUnit.transform : null;
-        target = targetUnit ? targetUnit.transform : null;
+        casterUnit = casterUnitParam;
+        caster = casterUnitParam ? casterUnitParam.transform : null;
+        target = targetUnitParam ? targetUnitParam.transform : null;
         casterFocusAnchor = casterAnchor;
         targetFocusAnchor = targetAnchor;
         manualMidpoint = midpointOverride;
+
+        ResetShoulderStayAnchor();
 
         UpdateTargetGroupMembers();
     }
@@ -268,7 +283,18 @@ public class BattleCameraRig : MonoBehaviour
         manualMidpoint = null;
         casterFocusAnchor = null;
         targetFocusAnchor = null;
+        casterUnit = null;
+        ResetShoulderStayAnchor();
         UpdateTargetGroupMembers();
+    }
+
+    /// <summary>
+    /// Réinitialise la mémoire du plan épaule figé afin de recalculer la position lors du prochain déclenchement.
+    /// </summary>
+    private void ResetShoulderStayAnchor()
+    {
+        shoulderStayInitialized = false;
+        shoulderStayPosition = Vector3.zero;
     }
 
     private void UpdateTargetGroupMembers()
@@ -320,6 +346,9 @@ public class BattleCameraRig : MonoBehaviour
         currentActiveRole = role;
         if (role == BattleCameraRole.ProjectileFlyby)
             projectileTimer = 0f; // Ré-initialise le travelling à chaque activation.
+
+        if (role != BattleCameraRole.OverShoulderCasterLookTarget)
+            shoulderStayInitialized = false;
     }
 
     /// <summary>
@@ -342,6 +371,9 @@ public class BattleCameraRig : MonoBehaviour
                 break;
             case BattleCameraRole.OverShoulderCasterToTarget:
                 UpdateOverShoulderCamera(0f, true);
+                break;
+            case BattleCameraRole.OverShoulderCasterLookTarget:
+                UpdateOverShoulderStayCamera(0f, true);
                 break;
             case BattleCameraRole.ClosePushCaster:
                 UpdateClosePushCamera(0f, true);
@@ -391,6 +423,7 @@ public class BattleCameraRig : MonoBehaviour
         float dt = Time.deltaTime;
         UpdateIdleCamera(dt);
         UpdateOverShoulderCamera(dt);
+        UpdateOverShoulderStayCamera(dt);
         UpdateClosePushCamera(dt);
         UpdateTargetReactionCamera(dt);
         UpdateWideCamera(dt);
@@ -505,6 +538,75 @@ public class BattleCameraRig : MonoBehaviour
         cam.Lens.FieldOfView = forceSnap
             ? 52f
             : Mathf.Lerp(cam.Lens.FieldOfView, 52f, dt * 0.8f);
+    }
+
+    private void UpdateOverShoulderStayCamera(float dt, bool forceSnap = false)
+    {
+        if (!TryGetCamera(BattleCameraRole.OverShoulderCasterLookTarget, out var cam) || !caster)
+            return;
+
+        if (forceSnap || !shoulderStayInitialized)
+        {
+            // Capture une fois la position de l'ancre pour rester figé tout au long de la préparation.
+            shoulderStayPosition = ResolveShoulderStayPosition();
+            shoulderStayInitialized = true;
+        }
+
+        Vector3 desiredPos = shoulderStayPosition;
+        Vector3 lookPos = GetTargetFocusPosition(shoulderLookHeight);
+
+        // Vitesse nulle : la caméra reste collée à la position mémorisée sans suivre l'ancre si elle bouge ensuite.
+        SmoothPosition(cam, desiredPos, dt, 0f, forceSnap);
+        SmoothLookAt(
+            cam,
+            lookPos,
+            dt,
+            rotationLerpSpeed,
+            GetAttackRotationNoise(BattleCameraRole.OverShoulderCasterLookTarget),
+            forceSnap);
+
+        cam.Lens.FieldOfView = forceSnap
+            ? shoulderStayFov
+            : Mathf.Lerp(cam.Lens.FieldOfView, shoulderStayFov, dt * 0.8f);
+    }
+
+    private Vector3 ResolveShoulderStayPosition()
+    {
+        Transform anchor = null;
+
+        if (casterFocusAnchor && string.Equals(casterFocusAnchor.name, ShoulderStayAnchorName, StringComparison.OrdinalIgnoreCase))
+        {
+            anchor = casterFocusAnchor;
+        }
+        else if (casterUnit != null)
+        {
+            anchor = casterUnit.GetCameraAnchor(ShoulderStayAnchorName);
+        }
+
+        if (!anchor && caster)
+        {
+            anchor = FindAnchorTransform(caster, ShoulderStayAnchorName);
+        }
+
+        if (anchor)
+            return anchor.position;
+
+        Debug.LogWarning($"[BattleCameraRig] Point '{ShoulderStayAnchorName}' introuvable sur {caster?.name ?? "(caster nul)"}. Retombée sur un focus épaule générique.");
+        return GetCasterFocusPosition(shoulderHeight);
+    }
+
+    private Transform FindAnchorTransform(Transform root, string anchorName)
+    {
+        if (!root || string.IsNullOrEmpty(anchorName))
+            return null;
+
+        foreach (Transform child in root.GetComponentsInChildren<Transform>(true))
+        {
+            if (string.Equals(child.name, anchorName, StringComparison.OrdinalIgnoreCase))
+                return child;
+        }
+
+        return null;
     }
 
     private void UpdateClosePushCamera(float dt, bool forceSnap = false)

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.Playables; // 📽️ Gestion des timelines propres à l'unité
 using UnityEngine.Timeline;  // 🎼 Lecture des TimelineAsset assignés au PlayableDirector local
@@ -33,6 +34,9 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     // Indicateur évitant les multiples avertissements lorsque l'Animator enfant est introuvable.
     private bool hasLoggedMissingChildAnimator;
     private AwakeState awakeState;
+
+    // Mise en cache des ancres caméra pour éviter de reparcourir toute la hiérarchie à chaque requête.
+    private readonly Dictionary<string, Transform> cachedCameraAnchors = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// PlayableDirector individuel utilisé pour jouer les timelines de combat
@@ -172,6 +176,55 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         Animator casterAnimator = GetCasterAnimator();
         return casterAnimator != null ? casterAnimator.gameObject : gameObject;
+    }
+
+    /// <summary>
+    /// Recherche (et met en cache) une ancre caméra particulière sur le CharacterUnit.
+    /// </summary>
+    /// <param name="anchorName">Nom exact du point de caméra recherché.</param>
+    /// <param name="includeInactive">
+    /// Vrai pour parcourir également les objets désactivés (utile lorsque certains repères sont masqués dans l'éditeur).
+    /// </param>
+    /// <returns>La transform correspondant à l'ancre ou <c>null</c> si elle est introuvable.</returns>
+    public Transform GetCameraAnchor(string anchorName, bool includeInactive = true)
+    {
+        if (string.IsNullOrEmpty(anchorName))
+            return null;
+
+        if (cachedCameraAnchors.TryGetValue(anchorName, out var cached))
+        {
+            // Si l'ancre existe encore, on la renvoie directement.
+            if (cached != null)
+                return cached;
+
+            // Une valeur nulle indique que l'ancre est introuvable : on évite un nouveau parcours coûteux.
+            return null;
+        }
+
+        Transform located = LocateCameraAnchor(anchorName, includeInactive);
+        cachedCameraAnchors[anchorName] = located;
+
+        if (located == null)
+        {
+            Debug.LogWarning($"[CharacterUnit] Ancre caméra '{anchorName}' introuvable sur '{name}'.");
+        }
+
+        return located;
+    }
+
+    /// <summary>
+    /// Parcourt récursivement la hiérarchie pour trouver une ancre caméra.
+    /// </summary>
+    private Transform LocateCameraAnchor(string anchorName, bool includeInactive)
+    {
+        Transform[] children = GetComponentsInChildren<Transform>(includeInactive);
+        foreach (var child in children)
+        {
+            if (string.Equals(child.name, anchorName, StringComparison.OrdinalIgnoreCase))
+                return child;
+        }
+
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- ajout d’un rôle cinématique OverShoulderCasterLookTarget et de son mapping côté rig/manager
- ancrage de la caméra sur le point Camera_Shoulder_Stay avec mémorisation de la position et suivi du regard vers la cible
- mise en cache des ancres caméra dans CharacterUnit et mise à jour des infos d’éditeur pour MusicalMove et Item

## Tests
- aucun test automatisé n’a été exécuté (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68cfbea51f108325aca3bae94a174fb2