### PR TITLE
Ajuste les caméras de combat

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -51,6 +51,10 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     private Coroutine crossFadeRoutine; // coroutine de fondu en cours
     private Texture2D lastCapturedFrame; // reference du screenshot utilise pendant le fondu
 
+    // 📝 Mémorise la dernière configuration « lissée » demandée au brain afin de la restaurer après un cut forcé.
+    private CinemachineBlendDefinition lastSmoothBlendDefinition;
+    private bool hasLastSmoothBlend;
+
     void Awake()
     {
         // Recuperation du CinemachineBrain sur la camera de rendu.
@@ -65,6 +69,12 @@ public class CinemachineBlendSwitcher : MonoBehaviour
 
         // Prepare l'overlay de fondu si necessaire (creation automatique si references vides).
         if (useVisualCrossFade) EnsureCrossFadeOverlay();
+
+        // 💾 Initialise le profil de blend à restaurer après les coupes instantanées.
+        lastSmoothBlendDefinition = new CinemachineBlendDefinition(
+            blendStyle,
+            Mathf.Max(defaultBlendDuration, 0.0001f));
+        hasLastSmoothBlend = true;
 
         // Construction du dictionnaire d'acces rapide par nom.
         _byName.Clear();
@@ -253,6 +263,17 @@ public class CinemachineBlendSwitcher : MonoBehaviour
 
         _current = next;
         UpdateActiveCameraStates(next);
+
+        // 🔁 Après un cut forcé (principalement lors des fondus visuels), on restaure un blend doux pour les prochains plans.
+        if (forceCut && brain)
+        {
+            var fallbackBlend = hasLastSmoothBlend
+                ? lastSmoothBlendDefinition
+                : new CinemachineBlendDefinition(blendStyle, Mathf.Max(defaultBlendDuration, 0.0001f));
+            brain.DefaultBlend = fallbackBlend;
+            lastSmoothBlendDefinition = fallbackBlend;
+            hasLastSmoothBlend = true;
+        }
     }
 
     /// <summary>
@@ -267,7 +288,15 @@ public class CinemachineBlendSwitcher : MonoBehaviour
         // Lors d'un fondu visuel, on force un cut afin d'eviter le mouvement.
         var style = forceCut ? CinemachineBlendDefinition.Styles.Cut : (overrideStyle ?? blendStyle);
         var duration = forceCut ? 0f : Mathf.Max(0f, blendDuration);
-        brain.DefaultBlend = new CinemachineBlendDefinition(style, duration);
+        var definition = new CinemachineBlendDefinition(style, duration);
+        brain.DefaultBlend = definition;
+
+        // 📚 On conserve uniquement les configurations réellement lissées pour servir de référence.
+        if (!forceCut && duration > 0.0001f)
+        {
+            lastSmoothBlendDefinition = definition;
+            hasLastSmoothBlend = true;
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraRig.cs
@@ -146,6 +146,9 @@ public class BattleCameraRig : MonoBehaviour
     };
     private static readonly string[] TargetReactionAnchorCandidates =
     {
+        // 🩸 Priorité absolue : les moves doivent cadrer précisément l'impact reçu.
+        "Camera_HitPoint",
+        // 🎯 Retombée classique pour les scènes qui n'exposent pas encore le point d'impact.
         "Camera_TargetReaction",
         "Camera_TargetedPoint"
     };

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -607,6 +607,10 @@ public class NewBattleManager : MonoBehaviour
         //4 Réinitialise les ATB
         ResetAllATB();
 
+        // ⚡ Identifie au plus tôt l'unité qui ouvrira le bal afin d'orienter le menu sur le bon personnage.
+        CharacterUnit upcomingFirstPlayer = ReturnFirstStrikeCharacter();
+        PrimeMainMenuCameraForFirstUnit(upcomingFirstPlayer);
+
         //6 Intro Camera
         // Lance la séquence d'introduction des caméras avant de débuter les tours.
         yield return PlayIntroCameraSequence();
@@ -656,6 +660,30 @@ public class NewBattleManager : MonoBehaviour
             .FirstOrDefault();
 
         return firstPlayer;
+    }
+
+    /// <summary>
+    /// Pré-positionne la caméra de menu sur l'ancre de l'unité qui agira en premier.
+    /// </summary>
+    /// <param name="candidate">Unité pressentie pour jouer en ouverture.</param>
+    private void PrimeMainMenuCameraForFirstUnit(CharacterUnit candidate)
+    {
+        if (candidate == null)
+        {
+            Debug.LogWarning("[BattleTurnManager] Aucun combattant joueur n'est disponible pour préparer la caméra du menu.");
+            return;
+        }
+
+        Transform mainMenuAnchor = candidate.GetCameraAnchor("Camera_MainMenu");
+        if (mainMenuAnchor == null)
+        {
+            Debug.LogWarning(
+                $"[BattleTurnManager] Impossible de trouver l'ancre 'Camera_MainMenu' sur {candidate.name} pour anticiper le zoom.");
+            return;
+        }
+
+        // 🗺️ On replace immédiatement la Cinemachine afin que le fondu post-intro démarre déjà sur la bonne pose.
+        BattleCameraManager.Instance?.AlignCameraToAnchor(MainMenuCameraName, mainMenuAnchor);
     }
 
     //7 Démarre la boucle de tours


### PR DESCRIPTION
## Résumé
- privilégie l’ancre `Camera_HitPoint` pour la CMV_TargetReaction afin de cadrer directement l’impact
- mémorise et restaure le blend lissé du CinemachineBrain après les cuts forcés pour éviter les transitions instantanées
- anticipe l’unité qui jouera en premier et aligne `CMV_MainMenu` sur son ancre `Camera_MainMenu`

## Tests
- non testés (projet Unity, vérification manuelle requise)


------
https://chatgpt.com/codex/tasks/task_e_68cfcb6e2b9483259be4a983b0e130a1