### PR TITLE
Uniformiser les blends Cinemachine sur 0,5 s lissées

### DIFF
--- a/Assets/CinemachineBlendSwitcher.cs
+++ b/Assets/CinemachineBlendSwitcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +12,19 @@ using Unity.Cinemachine;
 [DisallowMultipleComponent]
 public class CinemachineBlendSwitcher : MonoBehaviour
 {
+    /// <summary>
+    /// Durée homogène imposée à tous les blends Cinemachine. Nous la rendons publique afin que l'ensemble
+    /// du code gameplay puisse y accéder sans avoir à dupliquer la valeur magique de 0.5 seconde dans
+    /// chaque script.
+    /// </summary>
+    public const float GlobalSmoothBlendDurationSeconds = 0.5f;
+
+    /// <summary>
+    /// Cache statique du style « Smooth ». Cela évite de lancer un <see cref="Enum.TryParse"/> à chaque
+    /// requête tout en gérant proprement les versions de Cinemachine qui n'exposeraient pas explicitement
+    /// ce style (on retombe alors sur un <see cref="CinemachineBlendDefinition.Styles.EaseInOut"/>).</summary>
+    private static CinemachineBlendDefinition.Styles? cachedSmoothStyle;
+
     [Header("Brain (auto si vide)")]
     [SerializeField] private CinemachineBrain brain;
 
@@ -24,14 +38,14 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     [Header("Style de blend par defaut")]
     [SerializeField]
     private CinemachineBlendDefinition.Styles blendStyle =
-        CinemachineBlendDefinition.Styles.EaseInOut;
+        CinemachineBlendDefinition.Styles.EaseInOut; // valeur par défaut réécrite dans Awake pour imposer le mode Smooth.
 
     [Tooltip("Duree par defaut du blend ou du fondu entre deux cameras (en secondes).")]
-    [SerializeField] private float defaultBlendDuration = 1f;
+    [SerializeField] private float defaultBlendDuration = GlobalSmoothBlendDurationSeconds;
 
     [Header("Fondu visuel")] // Permet de remplacer le mouvement par un fondu
     [Tooltip("Active la possibilite de realiser un fondu visuel entre deux plans.")]
-    [SerializeField] private bool useVisualCrossFade = true;
+    [SerializeField] private bool useVisualCrossFade = false;
 
     [Tooltip("Courbe d'evolution de l'opacite durant le fondu (0 = transparent, 1 = opaque).")]
     [SerializeField] private AnimationCurve crossFadeCurve = AnimationCurve.Linear(0f, 1f, 1f, 0f);
@@ -57,6 +71,17 @@ public class CinemachineBlendSwitcher : MonoBehaviour
 
     void Awake()
     {
+        // 🎯 Toutes les transitions doivent maintenant employer un mouvement lissé identique : on force donc
+        // dès l'initialisation un style Smooth et une durée fixe de 0.5 seconde. En cas d'indisponibilité
+        // du style "Smooth" (ancienne version de Cinemachine), on se replie automatiquement sur EaseInOut.
+        blendStyle = ResolveSmoothBlendStyle();
+        defaultBlendDuration = GlobalSmoothBlendDurationSeconds;
+
+        // 🪄 Les fondus visuels reposent sur des cuts forcés côté Cinemachine. Afin de garantir des mouvements
+        // réellement smooth, on les désactive systématiquement. Les anciennes données de scène qui auraient
+        // coché l'option sont ainsi neutralisées dès que le composant s'initialise.
+        useVisualCrossFade = false;
+
         // Recuperation du CinemachineBrain sur la camera de rendu.
         if (!brain && Camera.main) brain = Camera.main.GetComponent<CinemachineBrain>();
         if (!brain) Debug.LogWarning("[BlendSwitcher] Aucun CinemachineBrain trouve sur la camera de rendu.");
@@ -121,7 +146,14 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// <param name="overrideStyle">Style de blend à forcer (null = style par défaut).</param>
     public void DisplayCamera(string cameraName, float blendDuration, CinemachineBlendDefinition.Styles? overrideStyle = null)
     {
-        float resolvedDuration = blendDuration >= 0f ? blendDuration : defaultBlendDuration;
+        // 📴 Les fondus visuels étant interdits, on neutralise à nouveau le flag au cas où un autre composant
+        // aurait tenté de le réactiver avant cet appel (par exemple via une ancienne valeur sérialisée).
+        useVisualCrossFade = false;
+
+        // 🎯 Les paramètres externes peuvent encore tenter de fournir une durée personnalisée, mais la
+        // direction artistique impose désormais un unique blend smooth de 0,5 seconde. On ignore donc la
+        // valeur entrante et on applique systématiquement la durée globale homogène.
+        float resolvedDuration = SmoothBlendDuration;
 
         // Si la camera cible exige un fondu visuel, on lance une coroutine dediee qui
         // capture l'image actuelle avant de basculer sur la nouvelle camera.
@@ -627,4 +659,35 @@ public class CinemachineBlendSwitcher : MonoBehaviour
     /// Fournit l'instance de la <see cref="CinemachineCamera"/> actuellement prioritaire.
     /// </summary>
     public CinemachineCamera CurrentCamera => _current;
+
+    /// <summary>
+    /// Style de blend lissé utilisé par l'ensemble du projet. En accédant à cette propriété, les autres
+    /// composants (menus, transitions...) s'alignent automatiquement sur le réglage global sans avoir
+    /// besoin de dupliquer la logique de résolution du style.
+    /// </summary>
+    public CinemachineBlendDefinition.Styles SmoothBlendStyle => ResolveSmoothBlendStyle();
+
+    /// <summary>
+    /// Durée lissée appliquée à toutes les transitions Cinemachine. La constante centrale évite toute
+    /// dérive liée à d'anciennes valeurs sérialisées : chaque blend dure strictement 0,5 seconde.
+    /// </summary>
+    public float SmoothBlendDuration => GlobalSmoothBlendDurationSeconds;
+
+    /// <summary>
+    /// Résout dynamiquement le style « Smooth » en conservant un fallback compatible avec les anciennes
+    /// versions de Cinemachine. Cette méthode centralise la logique afin que toute évolution future se
+    /// propage automatiquement.
+    /// </summary>
+    public static CinemachineBlendDefinition.Styles ResolveSmoothBlendStyle()
+    {
+        if (cachedSmoothStyle.HasValue)
+            return cachedSmoothStyle.Value;
+
+        if (Enum.TryParse("Smooth", true, out CinemachineBlendDefinition.Styles parsedStyle))
+            cachedSmoothStyle = parsedStyle;
+        else
+            cachedSmoothStyle = CinemachineBlendDefinition.Styles.EaseInOut;
+
+        return cachedSmoothStyle.Value;
+    }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -37,6 +37,21 @@ public class BattleCameraManager : MonoBehaviour
     // Permet de connaître le plan actuellement prioritaire.
     private BattleCameraRole currentRole = BattleCameraRole.None;
 
+    /// <summary>
+    /// Style de blend lissé imposé par le <see cref="CinemachineBlendSwitcher"/>. Si le composant n'est
+    /// pas encore disponible (phase de bootstrap), on retombe sur la résolution statique du switcher afin
+    /// d'assurer la cohérence des transitions.
+    /// </summary>
+    public CinemachineBlendDefinition.Styles SmoothBlendStyle =>
+        blendSwitcher ? blendSwitcher.SmoothBlendStyle : CinemachineBlendSwitcher.ResolveSmoothBlendStyle();
+
+    /// <summary>
+    /// Durée unique (0,5 s) appliquée à toutes les transitions caméra. Cette propriété est exposée pour
+    /// faciliter sa réutilisation dans les différents gestionnaires de menus et de cutscenes.
+    /// </summary>
+    public float SmoothBlendDuration =>
+        blendSwitcher ? blendSwitcher.SmoothBlendDuration : CinemachineBlendSwitcher.GlobalSmoothBlendDurationSeconds;
+
     // ------------------------------------------------------------------------------
     // Gestion dédiée à la Cinemachine d'introduction
     // ------------------------------------------------------------------------------
@@ -89,10 +104,11 @@ public class BattleCameraManager : MonoBehaviour
         else
             BuildRoleMappings();
 
-        // Au demarrage du combat on revient sur la camera principale taggee "BattleCamera".
-        // On force une transition immediate (duree 0) pour eviter un fondu au lancement.
+        // Au démarrage du combat on revient sur la camera principale taggée "BattleCamera". Toutes les
+        // transitions doivent désormais respecter le blend smooth de 0.5 s : on s'appuie donc sur la durée
+        // globale imposée par le switcher plutôt que de forcer un cut instantané.
         if (blendSwitcher)
-            blendSwitcher.DisplayCamera(null, 0f);
+            blendSwitcher.DisplayCamera(null, SmoothBlendDuration);
     }
 
     /// <summary>
@@ -389,8 +405,8 @@ public class BattleCameraManager : MonoBehaviour
         if (!AlignCameraToAnchor(cameraName, anchor))
             return;
 
-        // Puis donne la priorité à cette caméra en conservant la durée par défaut (désormais lissée sur
-        // une seconde via le BlendSwitcher) sauf indication contraire.
+        // Puis donne la priorité à cette caméra en conservant la durée par défaut (0,5 s) imposée par
+        // le BlendSwitcher, sauf indication contraire.
         SwitchToCamera(cameraName, blendTime, overrideStyle);
     }
 
@@ -507,50 +523,16 @@ public class BattleCameraManager : MonoBehaviour
 
     private float ComputeBlendDuration(BattleCameraRole from, BattleCameraRole to)
     {
-        if ((from == BattleCameraRole.ClosePushCaster && to == BattleCameraRole.TargetReaction) ||
-            (from == BattleCameraRole.TargetReaction && to == BattleCameraRole.ClosePushCaster))
-            return 0.08f; // Cut nerveux pour les contres.
-
-        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterToTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
-            return 0.4f; // Transition douce entre plan large et épaule.
-
-        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.WideEstablish))
-            return 0.4f; // Même lisibilité que l'épaule classique pour présenter l'action.
-
-        if ((from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.OverShoulderCasterToTarget))
-            return 0.25f; // Cut plus nerveux entre les deux variantes de plan épaule.
-
-        if (from == BattleCameraRole.Victory || to == BattleCameraRole.Victory)
-            return 1f; // Plan final plus ample.
-
-        return -1f; // Conserve la durée par défaut du BlendSwitcher.
+        // 🎞️ Toutes les combinaisons utilisent désormais la même durée lissée afin de garantir une lecture
+        // cohérente des enchaînements caméra (plus aucun cut brutal).
+        return SmoothBlendDuration;
     }
 
     private CinemachineBlendDefinition.Styles? ComputeBlendStyle(BattleCameraRole from, BattleCameraRole to)
     {
-        if ((from == BattleCameraRole.ClosePushCaster && to == BattleCameraRole.TargetReaction) ||
-            (from == BattleCameraRole.TargetReaction && to == BattleCameraRole.ClosePushCaster))
-            return CinemachineBlendDefinition.Styles.Cut;
-
-        if (from == BattleCameraRole.Victory || to == BattleCameraRole.Victory)
-            return CinemachineBlendDefinition.Styles.EaseOut;
-
-        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterToTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.WideEstablish))
-            return CinemachineBlendDefinition.Styles.EaseInOut;
-
-        if ((from == BattleCameraRole.WideEstablish && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.WideEstablish))
-            return CinemachineBlendDefinition.Styles.EaseInOut;
-
-        if ((from == BattleCameraRole.OverShoulderCasterToTarget && to == BattleCameraRole.OverShoulderCasterLookTarget) ||
-            (from == BattleCameraRole.OverShoulderCasterLookTarget && to == BattleCameraRole.OverShoulderCasterToTarget))
-            return CinemachineBlendDefinition.Styles.Cut;
-
-        return null;
+        // 🎯 Même logique que pour la durée : on impose le style smooth unique afin d'éviter tout cut ou
+        // easing divergent suivant les rôles caméra.
+        return SmoothBlendStyle;
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -459,7 +459,9 @@ public class BattleTransitionManager : MonoBehaviour
             if (BattleCameraManager.Instance != null &&
                 BattleCameraManager.Instance.TryGetCameraByName("CMV_BattleIntro", out _))
             {
-                BattleCameraManager.Instance.SwitchToCamera("CMV_BattleIntro", 0f);
+                // Toutes les transitions caméra étant désormais lissées, on s'appuie sur la durée par défaut
+                // fournie par le BlendSwitcher plutôt que d'imposer un cut immédiat.
+                BattleCameraManager.Instance.SwitchToCamera("CMV_BattleIntro");
 
                 // Dès l'apparition du plan d'introduction, on déclenche son travelling le long de l'axe Z.
                 // Le point de mire est volontairement fixé à l'origine mondiale pour cadrer la scène de combat.
@@ -469,7 +471,7 @@ public class BattleTransitionManager : MonoBehaviour
             }
             else
             {
-                BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish, 0f);
+                BattleCameraManager.Instance?.SwitchToCamera(BattleCameraRole.WideEstablish);
             }
         }
         else

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -141,25 +141,31 @@ public class NewBattleManager : MonoBehaviour
     /// <summary>Nom de la Cinemachine utilisée lors de l'exécution d'une action (MusicalMove ou Item).</summary>
     private const string MoveCameraName = "CMV_Move";
     /// <summary>
-    /// Style de transition privilégié pour les menus : on adopte désormais un fondu doux pour guider le
-    /// regard du joueur sans rupture visuelle.
+    /// Style de transition privilégié pour les menus. Il est directement récupéré auprès du
+    /// <see cref="BattleCameraManager"/> pour rester parfaitement aligné avec la configuration globale du
+    /// <see cref="CinemachineBlendSwitcher"/> (smooth obligatoire).
     /// </summary>
-    private const CinemachineBlendDefinition.Styles MenuCameraBlendStyle = CinemachineBlendDefinition.Styles.EaseInOut;
+    private CinemachineBlendDefinition.Styles MenuCameraBlendStyle =>
+        BattleCameraManager.Instance ? BattleCameraManager.Instance.SmoothBlendStyle : CinemachineBlendSwitcher.ResolveSmoothBlendStyle();
+
     /// <summary>
-    /// Durée par défaut des transitions de menu. Réglée sur une seconde pour offrir une interpolation
-    /// claire et lisible lors du passage d'un panneau à l'autre.
+    /// Durée par défaut des transitions de menu. Toutes les transitions du jeu étant désormais figées à
+    /// 0,5 seconde, on utilise la propriété exposée par le gestionnaire caméra pour éviter toute divergence.
     /// </summary>
-    private const float MenuCameraBlendDuration = 1f;
+    private float MenuCameraBlendDuration =>
+        BattleCameraManager.Instance ? BattleCameraManager.Instance.SmoothBlendDuration : CinemachineBlendSwitcher.GlobalSmoothBlendDurationSeconds;
+
     /// <summary>
-    /// Durée appliquée aux caméras contextuelles (ciblage, actions). Harmonisée sur une seconde afin de
-    /// conserver la cohérence avec les transitions de menus.
+    /// Durée appliquée aux caméras contextuelles (ciblage, actions). Identique à celle des menus afin de
+    /// conserver une expérience fluide et prévisible pour le joueur.
     /// </summary>
-    private const float ContextCameraBlendDuration = 1f;
+    private float ContextCameraBlendDuration => MenuCameraBlendDuration;
+
     /// <summary>
-    /// Style de transition privilégié pour les caméras contextuelles. On privilégie un lissage progressif
-    /// pour mettre en valeur les animations sans cut brutal.
+    /// Style de transition privilégié pour les caméras contextuelles. Même valeur que pour les menus : un
+    /// unique réglage smooth garantit la cohérence visuelle quel que soit le rôle de la caméra active.
     /// </summary>
-    private const CinemachineBlendDefinition.Styles ContextCameraBlendStyle = CinemachineBlendDefinition.Styles.EaseInOut;
+    private CinemachineBlendDefinition.Styles ContextCameraBlendStyle => MenuCameraBlendStyle;
     /// <summary>Hash du state Animator "Item_Prepare" pour lancer rapidement l'animation correspondante.</summary>
     private static readonly int AnimatorStateItemPrepare = Animator.StringToHash("Item_Prepare");
     /// <summary>Hash du state Animator "Idle_Battle" afin de revenir proprement à la pose neutre.</summary>


### PR DESCRIPTION
## Résumé
- impose un style de blend Smooth et une durée fixe de 0,5 s dans le CinemachineBlendSwitcher
- expose la configuration lissée au BattleCameraManager et aligne tous les appels de switch caméra sur ces valeurs
- supprime les anciens cas particuliers (cuts, durées personnalisées) afin de garantir des transitions uniformes

## Tests
- non exécutés (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68cfd878ad1483259af7898a44f238fb