### PR TITLE
Sécuriser la récupération de l'unité active pour les menus

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -19,6 +19,14 @@ public class BattleCameraManager : MonoBehaviour
     /// <summary>Accès global au gestionnaire de caméras de combat.</summary>
     public static BattleCameraManager Instance { get; private set; }
 
+    /// <summary>
+    /// Fournit un accès en lecture à l'unité actuellement propriétaire du tour.
+    /// Ce getter est principalement utilisé par le <see cref="NewBattleManager"/>
+    /// lorsque celui-ci doit reconstruire le contexte d'affichage des menus sans
+    /// perdre l'alignement des Cinemachine sur leurs ancres « CMVPoint_ ».
+    /// </summary>
+    public CharacterUnit CurrentTurnOwner => currentTurnOwner;
+
     /// <summary>BlendSwitcher responsable des transitions (0,5 s smooth imposé).</summary>
     private CinemachineBlendSwitcher blendSwitcher;
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2009,8 +2009,68 @@ public class NewBattleManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Vérifie qu'une unité est bien renseignée pour les menus et essaie de la récupérer sinon.
+    /// Cette méthode est indispensable pour garantir que les caméras Cinemachine (et notamment
+    /// « CMV_ItemsMenu ») disposent toujours d'une ancre valide lorsque l'on ouvre un menu.
+    /// </summary>
+    /// <param name="callerContext">Nom de la méthode appelante (utilisé dans les logs).</param>
+    private bool EnsureCurrentCharacterUnitForMenus(string callerContext)
+    {
+        if (currentCharacterUnit != null)
+            return true; // Cas nominal : rien à corriger.
+
+        CharacterUnit resolvedUnit = null;
+
+        // 1) Premier réflexe : demander au gestionnaire de caméras quelle unité il suit encore.
+        BattleCameraManager cameraManager = BattleCameraManager.Instance;
+        if (cameraManager != null)
+            resolvedUnit = cameraManager.CurrentTurnOwner;
+
+        // 2) Si la caméra n'a plus l'information, on tente de détecter l'unité dont la jauge ATB
+        //    a atteint le seuil. C'est normalement la seule à pouvoir ouvrir les menus de tour.
+        if (resolvedUnit == null)
+        {
+            resolvedUnit = activeCharacterUnits.FirstOrDefault(u =>
+                u != null &&
+                u.Data != null &&
+                u.Data.isPlayerControlled &&
+                u.currentHP > 0 &&
+                u.currentATB >= ATB_THRESHOLD);
+        }
+
+        // 3) Fallback supplémentaire : choisir la première unité jouable côté joueur encore en vie.
+        if (resolvedUnit == null)
+        {
+            resolvedUnit = activeCharacterUnits.FirstOrDefault(u =>
+                u != null &&
+                u.Data != null &&
+                u.Data.isPlayerControlled &&
+                u.currentHP > 0);
+        }
+
+        if (resolvedUnit == null)
+        {
+            Debug.LogError($"[{callerContext}] Impossible d'identifier l'unité active avant l'ouverture d'un menu. " +
+                           "La caméra ne peut donc pas se caler sur le CMVPoint approprié.");
+            return false;
+        }
+
+        // On mémorise la nouvelle unité pour que tout le pipeline (menus, caméra, timelines) reste cohérent.
+        ChangeCurrentCharacterUnit(resolvedUnit);
+
+        // Le gestionnaire caméra doit également être synchronisé afin de replacer immédiatement les rigs.
+        if (cameraManager != null && cameraManager.CurrentTurnOwner != resolvedUnit)
+            cameraManager.SetTurnOwner(resolvedUnit);
+
+        return true;
+    }
+
     public void ShowMainMenu()
     {
+        if (!EnsureCurrentCharacterUnitForMenus(nameof(ShowMainMenu)))
+            return;
+
         // Réaffiche la jauge de passage de tour si elle existe.
         PassTurnUI.Instance?.Show();
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectItemSkillOrPass();
@@ -2046,6 +2106,9 @@ public class NewBattleManager : MonoBehaviour
 
     public void OpenSkillsMenu()
     {
+        if (!EnsureCurrentCharacterUnitForMenus(nameof(OpenSkillsMenu)))
+            return;
+
         // Masque la jauge lorsque l'on ouvre le menu des compétences.
         PassTurnUI.Instance?.Hide();
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectSkill();
@@ -2182,6 +2245,9 @@ public class NewBattleManager : MonoBehaviour
 
     public void OpenItemMenu()
     {
+        if (!EnsureCurrentCharacterUnitForMenus(nameof(OpenItemMenu)))
+            return;
+
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectItem();
         ChangeBattleState(BattleState.SquadUnit_ItemsMenu);
         // S'assure qu'aucune compétence n'est en cours de sélection


### PR DESCRIPTION
## Résumé
- expose le tour en cours via BattleCameraManager afin de pouvoir resynchroniser les menus
- ajoute une vérification centralisée pour reconstruire currentCharacterUnit avant d’ouvrir un menu
- empêche l’ouverture des menus lorsque aucune unité valide n’est disponible, évitant les caméras mal positionnées

## Tests
- Aucun test automatisé n’a été exécuté (projet Unity non instrumenté dans ce contexte)


------
https://chatgpt.com/codex/tasks/task_e_68cfed180d408325b946c6c032bc0a7c