### PR TITLE
Fix target cursor duplication

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -3251,8 +3251,20 @@ public class NewBattleManager : MonoBehaviour
 
     void EnsureTargetCursor()
     {
+        // Si un curseur existe déjà et n'a pas été détruit par ResetBattleInfos(),
+        // on évite d'en instancier un doublon. Sans cette vérification, un clone
+        // supplémentaire apparaissait au lancement du jeu puis du combat, car
+        // EnsureTargetCursor() est appelé dans Start() puis à nouveau dans StartBattle().
+        if (targetCursor != null)
+        {
+            return;
+        }
+
         if (targetCursorPrefab != null)
         {
+            // Instanciation « lazy » : on ne crée le visuel que lorsque c'est nécessaire.
+            // L'objet est immédiatement désactivé car il ne sera affiché qu'une fois
+            // la sélection de cible active.
             targetCursor = Instantiate(targetCursorPrefab, transform.position, Quaternion.identity);
             targetCursor.SetActive(false);
         }


### PR DESCRIPTION
## Summary
- prevent EnsureTargetCursor from instantiating a new cursor when one already exists
- add detailed comments describing why the guard is required and how the cursor is created lazily

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1a491c5588325a14e1f076ad6f20b