### PR TITLE
Ajout des retours audio pour dash et menus de combat

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -96,6 +96,8 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Effets de déplacement")]
     [Tooltip("Système de particules utilisé pendant les déplacements rapides de cette unité.")]
     public GameObject dashParticlesPrefab;
+    [Tooltip("Effet sonore joué lorsque les particules de dash sont générées pour cette unité.")]
+    public AudioClip dashSoundClip;
 
     [Header("Animations spéciales")]
     // Animation générique de dégâts
@@ -115,6 +117,10 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Sons de déplacement")]
     public AudioClip moveStartClip;
     public AudioClip moveEndClip;
+
+    [Header("Effets sonores d'interface")]
+    [Tooltip("Clip joué lorsque cette unité devient active dans les menus de combat.")]
+    public AudioClip menuSelectionClip;
 
     [Header("Voix de deuil")]
     [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt")]

--- a/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
@@ -493,8 +493,29 @@ public class AudioManager : MonoBehaviour
     public void PlaySfx(int index)
     {
         AudioClip clip = soundEffects[index];
-        float factor = GetNormalizationFactor(clip);
+        PlaySfx(clip);
+    }
+
+    /// <summary>
+    /// Joue un effet sonore arbitraire en réutilisant les paramètres globaux du gestionnaire.
+    /// Cette surcharge simplifie l'utilisation d'effets dédiés (menus, dash, etc.) sans
+    /// imposer de réserver un slot dans <see cref="soundEffects"/>.
+    /// </summary>
+    /// <param name="clip">Clip à jouer immédiatement.</param>
+    /// <param name="volume">Facteur multiplicatif optionnel (1 = volume par défaut).</param>
+    public void PlaySfx(AudioClip clip, float volume = 1f)
+    {
+        if (clip == null)
+            return; // Rien à jouer : on quitte proprement.
+
+        // Recherche d'une source libre parmi les canaux SFX existants. La méthode utilitaire
+        // conserve l'ancien comportement : réutilisation du premier canal si tous sont occupés.
         AudioSource src = GetAvailableSource(sfxSources);
+
+        // Normalisation optionnelle du volume pour conserver une cohérence entre les clips très
+        // différents. On applique également le facteur fourni en paramètre, clampé entre 0 et 1.
+        float factor = GetNormalizationFactor(clip) * Mathf.Clamp01(volume);
+
         src.PlayOneShot(clip, factor);
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -326,6 +326,22 @@ public class NewBattleManager : MonoBehaviour
     public GameObject currentItemsMenuContainer;
     public List<Transform> currentItemsMenuSlots;
 
+    [Header("Effets sonores de navigation en combat")]
+    [SerializeField, Tooltip("Clip joué lorsque le menu principal s'affiche ou lorsque l'on y retourne.")]
+    private AudioClip mainMenuOpenClip;
+    [SerializeField, Tooltip("Clip joué dès que le joueur ouvre le menu des compétences.")]
+    private AudioClip skillsMenuOpenClip;
+    [SerializeField, Tooltip("Clip joué lors de l'accès au menu des objets.")]
+    private AudioClip itemsMenuOpenClip;
+    [SerializeField, Tooltip("Clip déclenché lorsque l'on passe en mode sélection de cible (compétence ou objet).")]
+    private AudioClip targetSelectionClip;
+    [SerializeField, Tooltip("Clip joué à chaque changement de cible pendant la navigation.")]
+    private AudioClip targetChangeClip;
+    [SerializeField, Tooltip("Clip joué lorsqu'une nouvelle page de compétences est affichée.")]
+    private AudioClip skillPageChangeClip;
+    [SerializeField, Tooltip("Effet utilisé lorsque l'unité active ne possède pas de clip personnalisé pour signaler sa sélection.")]
+    private AudioClip defaultCharacterSelectionClip;
+
     // -----------------------------------------------------------------------------------
 
     #region Awake/Start/Update()
@@ -2093,6 +2109,8 @@ public class NewBattleManager : MonoBehaviour
         ActionUIDisplayManager.Instance.DisplayInstruction_SelectItemSkillOrPass();
         ChangeBattleState(BattleState.SquadUnit_MainMenu);
         ToggleMenuContainers(true, false, false);
+        // Feedback audio systématique lorsque le menu principal devient visible.
+        PlayMenuClip(mainMenuOpenClip);
 
         // S'assure que l'action "Confirm" est bien active.
         // Elle peut avoir été désactivée à la fin d'un QTE.
@@ -2133,6 +2151,8 @@ public class NewBattleManager : MonoBehaviour
         // S'assure qu'aucun item n'est en cours de sélection
         currentItem = null;
         ToggleMenuContainers(false, true, false);
+        // Son distinct pour signaler l'entrée dans le menu des compétences.
+        PlayMenuClip(skillsMenuOpenClip);
         currentMenuIndex = 0;
 
         // Réinitialise la page affichée
@@ -2243,6 +2263,8 @@ public class NewBattleManager : MonoBehaviour
         if (currentSkillPageIndex < maxPage)
         {
             currentSkillPageIndex++;
+            // Retour audio pour confirmer le changement de page.
+            PlayMenuClip(skillPageChangeClip);
             RefreshSkillsMenuDisplay();
         }
     }
@@ -2256,6 +2278,8 @@ public class NewBattleManager : MonoBehaviour
         if (currentSkillPageIndex > 0)
         {
             currentSkillPageIndex--;
+            // Même feedback lors d'un retour vers une page précédente.
+            PlayMenuClip(skillPageChangeClip);
             RefreshSkillsMenuDisplay();
         }
     }
@@ -2270,6 +2294,8 @@ public class NewBattleManager : MonoBehaviour
         // S'assure qu'aucune compétence n'est en cours de sélection
         currentMove = null;
         ToggleMenuContainers(false, false, true);
+        // Clip spécifique pour différencier l'accès à l'inventaire.
+        PlayMenuClip(itemsMenuOpenClip);
         currentMenuIndex = 0;
 
         // Démarre la Timeline d'attente de sélection d'objet
@@ -2516,8 +2542,14 @@ public class NewBattleManager : MonoBehaviour
 
         int count = filteredUnits.Count;
         currentTargetIndex = (currentTargetIndex + direction + count) % count;
-
+        CharacterUnit previousTarget = currentTargetCharacter;
         currentTargetCharacter = filteredUnits[currentTargetIndex];
+
+        if (currentTargetCharacter != previousTarget)
+        {
+            // Joué à chaque bascule de cible pour informer le joueur du changement de focus.
+            PlayMenuClip(targetChangeClip);
+        }
     }
     #endregion
 
@@ -2667,6 +2699,8 @@ public class NewBattleManager : MonoBehaviour
                               || move.targetTypes.Contains(TargetType.AllAllies)
                               || move.targetTypes.Contains(TargetType.All);
         bool allowGroupSwitch = canTargetEnemies && canTargetAllies;
+        // Feedback audio unique pour signifier le passage en mode ciblage.
+        PlayMenuClip(targetSelectionClip);
         switch (move.defaultTargetType)
         {
             case TargetType.Self:
@@ -2733,6 +2767,8 @@ public class NewBattleManager : MonoBehaviour
                               item.targetTypes.Contains(TargetType.AllAllies) ||
                               item.targetTypes.Contains(TargetType.All);
         bool allowGroupSwitch = canTargetEnemies && canTargetAllies;
+        // Même signal sonore que pour les compétences afin de rester cohérent.
+        PlayMenuClip(targetSelectionClip);
 
         switch (item.defaultTargetType)
         {
@@ -3246,6 +3282,43 @@ public class NewBattleManager : MonoBehaviour
         rotation = Quaternion.LookRotation(mid - position, Vector3.up);
     }
 
+    /// <summary>
+    /// Joue un clip lié aux menus de combat via l'AudioManager.
+    /// Les garde-fous évitent toute exception lorsque l'audio n'est pas encore initialisé
+    /// (ex : scènes de test sans gestionnaire global).
+    /// </summary>
+    /// <param name="clip">Clip à jouer immédiatement.</param>
+    private void PlayMenuClip(AudioClip clip)
+    {
+        if (clip == null)
+            return; // Aucun son configuré pour cet évènement.
+
+        AudioManager audioManager = AudioManager.Instance;
+        if (audioManager == null)
+            return; // Le gestionnaire peut être absent dans certaines scènes d'édition.
+
+        audioManager.PlaySfx(clip);
+    }
+
+    /// <summary>
+    /// Déclenche l'éventuel clip personnalisé associé au personnage actuellement sélectionné.
+    /// Chaque unité peut fournir son propre son via <see cref="CharacterData.menuSelectionClip"/> ;
+    /// un fallback global est utilisé si aucun clip n'est défini pour garantir un feedback sonore.
+    /// </summary>
+    /// <param name="unit">Unité qui vient d'être mise en avant dans les menus.</param>
+    private void PlayCharacterSelectionClip(CharacterUnit unit)
+    {
+        if (unit == null)
+            return; // Sécurité : aucun personnage actif, donc aucun son à jouer.
+
+        CharacterData data = unit.Data;
+        AudioClip clipToPlay = data != null && data.menuSelectionClip != null
+            ? data.menuSelectionClip
+            : defaultCharacterSelectionClip;
+
+        PlayMenuClip(clipToPlay);
+    }
+
     public void ChangeBattleState(BattleState newState)
     {
         currentBattleState = newState;
@@ -3255,7 +3328,15 @@ public class NewBattleManager : MonoBehaviour
 
     private void ChangeCurrentCharacterUnit(CharacterUnit newCurrentCharacterUnit)
     {
+        if (currentCharacterUnit == newCurrentCharacterUnit)
+            return; // Aucun changement : on évite les répétitions sonores.
+
         currentCharacterUnit = newCurrentCharacterUnit;
+
+        if (currentCharacterUnit == null)
+            return; // Parfois utilisé lors des resets de combat : aucune unité active.
+
+        PlayCharacterSelectionClip(currentCharacterUnit);
     }
 
     private void EnsureBattleCamera()

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -51,6 +51,8 @@ public class RhythmQTEManager : MonoBehaviour
     [Header("Déplacements")]
     [Tooltip("Particules instanciées lors d'un déplacement classique afin d'accentuer la sensation de dash.")]
     [SerializeField] private ParticleSystem dashParticlesPrefab;
+    [Tooltip("Clip joué lorsqu'aucun son spécifique n'est défini sur le personnage pour l'effet de dash.")]
+    [SerializeField] private AudioClip defaultDashSound;
 
     // Tag de la caméra de combat à utiliser pour toutes les timelines
     private const string battleCameraTag = "BattleCamera";
@@ -66,30 +68,6 @@ public class RhythmQTEManager : MonoBehaviour
     // Gestion des effets sonores
     // ------------------------------------------------------------------------------
     /// <summary>
-    /// Récupère une source audio SFX disponible parmi AudioSource_Sfx_1 à 3.
-    /// On privilégie la première source qui ne joue aucun son afin d'éviter les
-    /// coupures lorsque plusieurs effets doivent être joués simultanément.
-    /// </summary>
-    /// <returns>Une source libre ou la première du tableau si toutes sont occupées</returns>
-    private AudioSource GetAvailableSfxSource()
-    {
-        // Sécurise l'accès au gestionnaire audio
-        var manager = AudioManager.Instance;
-        if (manager == null || manager.sfxSources == null || manager.sfxSources.Length == 0)
-            return null;
-
-        // Recherche de la première source inactive
-        foreach (var src in manager.sfxSources)
-        {
-            if (src != null && !src.isPlaying)
-                return src; // Source libre trouvée
-        }
-
-        // Toutes les sources sont en cours de lecture : on réutilise la première
-        return manager.sfxSources[0];
-    }
-
-    /// <summary>
     /// Joue un effet sonore à l'aide d'une source SFX disponible.
     /// </summary>
     /// <param name="clip">Clip audio à jouer</param>
@@ -98,9 +76,9 @@ public class RhythmQTEManager : MonoBehaviour
         if (clip == null)
             return;
 
-        // On récupère une source libre et on lance la lecture
-        var source = GetAvailableSfxSource();
-        source?.PlayOneShot(clip);
+        // Centralise la lecture via l'AudioManager afin de profiter de la normalisation et
+        // des volumes globaux configurés dans le projet.
+        AudioManager.Instance?.PlaySfx(clip);
     }
 
     private CharacterUnit currentCaster;
@@ -601,6 +579,13 @@ public class RhythmQTEManager : MonoBehaviour
 
         // Instancie le prefab directement à la position du lanceur pour éviter tout décalage visuel.
         ParticleSystem instance = Instantiate(dashParticlesPrefab, caster.transform.position, caster.transform.rotation);
+
+        // Lecture optionnelle du son associé : priorité au clip personnalisé du personnage,
+        // sinon utilisation d'un son par défaut défini dans le manager.
+        AudioClip dashClip = casterData != null && casterData.dashSoundClip != null
+            ? casterData.dashSoundClip
+            : defaultDashSound;
+        PlaySfx(dashClip);
 
         // Parentage temporaire : le système suit automatiquement l'unité pendant le déplacement.
         Transform instanceTransform = instance.transform;


### PR DESCRIPTION
## Résumé
* lecture d'un clip personnalisé lors de l'apparition des particules de dash avec repli sur un son par défaut
* ajout d'une surcharge PlaySfx dans l'AudioManager et branchement côté RhythmQTEManager
* instrumentation sonore complète des menus de combat (ouverture, changement de page, ciblage, sélection d'unité)

## Tests
* non effectués (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68d2ec50610083259c47ba41e635780e