### PR TITLE
Replace AudioClip references with AudioClipSO configurations

### DIFF
--- a/Assets/PlayMusicOnStart.cs
+++ b/Assets/PlayMusicOnStart.cs
@@ -3,12 +3,18 @@ using UnityEngine;
 [RequireComponent(typeof(AudioSource))]
 public class PlayMusicOnStart : MonoBehaviour
 {
-    public AudioClip clipToPlay;
+    [Tooltip("ScriptableObject contenant le clip et ses paramètres par défaut.")]
+    public AudioClipSO clipToPlay;
 
     void Start()
     {
         AudioSource audioSource = GetComponent<AudioSource>();
-        audioSource.clip = clipToPlay;
+        if (clipToPlay == null || clipToPlay.Clip == null)
+            return;
+
+        audioSource.loop = clipToPlay.Loop;
+        audioSource.clip = clipToPlay.Clip;
+        audioSource.volume = clipToPlay.Volume;
         audioSource.Play();
     }
 }

--- a/Assets/Scripts/Classes/AudioClipSO.cs
+++ b/Assets/Scripts/Classes/AudioClipSO.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// ScriptableObject générique encapsulant un AudioClip et ses paramètres par défaut.
+/// Utilisé pour harmoniser la configuration des sons dans tout le projet.
+/// </summary>
+[CreateAssetMenu(fileName = "AudioClipSO", menuName = "Audio/Audio Clip", order = 0)]
+public class AudioClipSO : ScriptableObject
+{
+    [Header("Clip de référence")]
+    [Tooltip("Clip audio à jouer.")]
+    public AudioClip audioClip;
+
+    [Header("Paramètres de lecture par défaut")]
+    [Range(0f, 1f)]
+    [Tooltip("Volume appliqué par défaut lorsque ce clip est joué.")]
+    public float volume = 0.8f;
+
+    [Tooltip("Lecture en boucle activée par défaut pour ce clip.")]
+    public bool loop = false;
+
+    /// <summary>
+    /// Retourne le volume sécurisé (compris entre 0 et 1).
+    /// </summary>
+    public float Volume => Mathf.Clamp01(volume);
+
+    /// <summary>
+    /// Retourne le clip à jouer. Peut être null si non assigné.
+    /// </summary>
+    public AudioClip Clip => audioClip;
+
+    /// <summary>
+    /// Indique si le clip doit boucler par défaut.
+    /// </summary>
+    public bool Loop => loop;
+}

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -82,14 +82,14 @@ public class CharacterData : ScriptableObject, ITargetable
     public float currentInterceptionChance;
 
     [Header("Effets visuels et sonores")]
-    public AudioClip hitSound;
+    public AudioClipSO hitSound;
     // Voix jouée lors d'un coup dévastateur
-    public AudioClip criticalHitSound;
+    public AudioClipSO criticalHitSound;
     // Voix jouée lorsque l'unité est interceptée
-    public AudioClip interceptedSound;
+    public AudioClipSO interceptedSound;
     // Voix jouée lorsque l'unité intercepte une autre unité
-    public AudioClip interceptionSound;
-    [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClip prematureDeathTaunt;
+    public AudioClipSO interceptionSound;
+    [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClipSO prematureDeathTaunt;
     public GameObject hitEffect;
     public GameObject deathEffect;
 
@@ -97,7 +97,7 @@ public class CharacterData : ScriptableObject, ITargetable
     [Tooltip("Système de particules utilisé pendant les déplacements rapides de cette unité.")]
     public GameObject dashParticlesPrefab;
     [Tooltip("Effet sonore joué lorsque les particules de dash sont générées pour cette unité.")]
-    public AudioClip dashSoundClip;
+    public AudioClipSO dashSoundClip;
 
     [Header("Animations spéciales")]
     // Animation générique de dégâts
@@ -115,24 +115,24 @@ public class CharacterData : ScriptableObject, ITargetable
     public TimelineAsset introTimeline;
 
     [Header("Sons de déplacement")]
-    public AudioClip moveStartClip;
-    public AudioClip moveEndClip;
+    public AudioClipSO moveStartClip;
+    public AudioClipSO moveEndClip;
 
     [Header("Effets sonores d'interface")]
     [Tooltip("Clip joué lorsque cette unité devient active dans les menus de combat.")]
-    public AudioClip menuSelectionClip;
+    public AudioClipSO menuSelectionClip;
 
     [Header("Voix de deuil")]
     [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt")]
-    public AudioClip weepForLucianDeath;
+    public AudioClipSO weepForLucianDeath;
     [Tooltip("Lamentation jouée par ce personnage quand Thalia meurt")]
-    public AudioClip weepForThaliaDeath;
+    public AudioClipSO weepForThaliaDeath;
     [Tooltip("Lamentation jouée par ce personnage quand Kael meurt")]
-    public AudioClip weepForKaelDeath;
+    public AudioClipSO weepForKaelDeath;
     [Tooltip("Lamentation jouée par ce personnage quand Link meurt")]
-    public AudioClip weepForLinkDeath;
+    public AudioClipSO weepForLinkDeath;
     [Tooltip("Lamentation jouée par ce personnage quand Luna meurt")]
-    public AudioClip weepForLunaDeath;
+    public AudioClipSO weepForLunaDeath;
 
     [Header("Awake Mechanics")]
     [Tooltip("Nombre d'harmoniques requis pour entrer en Awake")] public int resonancePoint = 1;

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -80,9 +80,9 @@ public class ItemData : ScriptableObject
     // Effet visuel déclenché à l'arrivée du téléport
     public GameObject tpVfx_End;
     // Son joué au départ du téléport
-    public AudioClip tpSFx_Start;
+    public AudioClipSO tpSFx_Start;
     // Son joué à l'arrivée du téléport
-    public AudioClip tpSFx_End;
+    public AudioClipSO tpSFx_End;
 
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation de l'item")]
@@ -135,10 +135,10 @@ public class ItemData : ScriptableObject
     public class NoteVariant
     {
         public string label = "Frappe 1";
-        public AudioClip baseNote;
-        public AudioClip onParry;
-        public AudioClip onEvade;
-        public AudioClip onHit;
+        public AudioClipSO baseNote;
+        public AudioClipSO onParry;
+        public AudioClipSO onEvade;
+        public AudioClipSO onHit;
     }
 
     [Header("Notes avec Variantes Sonores")]

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -116,13 +116,13 @@ public class MusicalMoveSO : ScriptableObject
     // Effet visuel déclenché à l'arrivée du téléport
     public GameObject tpVfx_End;
     // Son joué au départ du téléport
-    public AudioClip tpSFx_Start;
+    public AudioClipSO tpSFx_Start;
     // Son joué à l'arrivée du téléport
-    public AudioClip tpSFx_End;
+    public AudioClipSO tpSFx_End;
 
     [Header("Effets sonores")]
     [Tooltip("Son d'avertissement joué avant l'attaque pour prévenir le joueur")]
-    public AudioClip warningClip;
+    public AudioClipSO warningClip;
 
     [Header("Timing")]
     // ⏱️ Délai ajouté avant toute timeline de préparation.

--- a/Assets/Scripts/Classes/ZoneSO.cs
+++ b/Assets/Scripts/Classes/ZoneSO.cs
@@ -12,8 +12,8 @@ public class ZoneSO : ScriptableObject
     public List<GameObject> battlefields = new List<GameObject>();
 
     [Header("Musics")]
-    public AudioClip zoneMusic;
-    public AudioClip[] battleMusic;
+    public AudioClipSO zoneMusic;
+    public AudioClipSO[] battleMusic;
 
     [Header("Harmonique prédominante")]
     [Tooltip("Harmonique mise en avant lorsque les musiques de cette zone sont jouées.")]

--- a/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
@@ -71,7 +71,7 @@ public class AnimationEventsManager : MonoBehaviour
         Time.timeScale = 1;
     }
 
-    public void PlayVoice(AudioClip audioClip)
+    public void PlayVoice(AudioClipSO audioClip)
     {
         if (audioClip != null)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AudioManager.cs
@@ -4,9 +4,34 @@ using System.Collections.Generic;
 
 public class AudioManager : MonoBehaviour
 {
-    public AudioClip[] musicTracks;
-    public AudioClip[] soundEffects;
-    public AudioClip[] voiceEffects;
+    public AudioClipSO[] musicTracks;
+    public AudioClipSO[] soundEffects;
+    public AudioClipSO[] voiceEffects;
+
+    // Règles sonores par défaut imposées par la documentation de production.
+    private const float DefaultVolume = 0.8f;
+    private const bool DefaultLoop = false;
+
+    /// <summary>
+    /// Récupère le clip Unity encapsulé dans le ScriptableObject.
+    /// </summary>
+    private static AudioClip ResolveClip(AudioClipSO clipAsset) => clipAsset != null ? clipAsset.Clip : null;
+
+    /// <summary>
+    /// Calcule un volume effectif en combinant la valeur du ScriptableObject et un éventuel fallback.
+    /// </summary>
+    private static float ResolveVolume(AudioClipSO clipAsset, float fallback = DefaultVolume)
+    {
+        return clipAsset != null ? clipAsset.Volume : Mathf.Clamp01(fallback);
+    }
+
+    /// <summary>
+    /// Indique si le clip doit être lu en boucle selon les données configurées.
+    /// </summary>
+    private static bool ResolveLoop(AudioClipSO clipAsset, bool fallback = DefaultLoop)
+    {
+        return clipAsset != null ? clipAsset.Loop : fallback;
+    }
 
     [Header("Audio Sources")]
     // Tableaux de sources permettant de jouer plusieurs pistes simultanément
@@ -49,7 +74,7 @@ public class AudioManager : MonoBehaviour
     private Coroutine timelineFadeRoutine;
     // Coroutine gérant l'atténuation temporaire lors de la lecture d'un warning
     private Coroutine warningRoutine;
-    private AudioClip lastExplorationClip;
+    private AudioClipSO lastExplorationClip;
     private float lastExplorationTime;
 
     private bool isInCombat = false;
@@ -60,10 +85,11 @@ public class AudioManager : MonoBehaviour
 
     // 📊 Sauvegarde l'état avant l'entrée en timeline.
     private bool wasInCombatBeforeTimeline = false; // → vrai si l'on était en combat avant la cinématique
-    private AudioClip clipBeforeTimeline;           // → musique en cours avant la timeline
+    private AudioClipSO clipBeforeTimeline;         // → musique en cours avant la timeline
     private float timeBeforeTimeline;               // → position de lecture de cette musique
 
-    private Dictionary<AudioClip, float> explorationPlaybackPositions = new Dictionary<AudioClip, float>();
+    private readonly Dictionary<AudioClipSO, float> explorationPlaybackPositions = new Dictionary<AudioClipSO, float>();
+    private AudioClipSO currentMusicAsset;
     private Dictionary<AudioClip, float> normalizationCache = new Dictionary<AudioClip, float>();
 
     /// <summary>
@@ -237,11 +263,13 @@ public class AudioManager : MonoBehaviour
 
     #region 🎵 Musique : Transitions
 
-    public void PlayExplorationMusic(AudioClip newExplorationClip)
+    public void PlayExplorationMusic(AudioClipSO newExplorationClip)
     {
-        // Empêche tout changement si une timeline ou un combat est en cours
-        // Utilise la propriété "CurrentMusicSource" pour récupérer la source active
-        if (isInCombat || isInTimeline || newExplorationClip == CurrentMusicSource.clip)
+        AudioClip clip = ResolveClip(newExplorationClip);
+        if (clip == null)
+            return;
+
+        if (isInCombat || isInTimeline || currentMusicAsset == newExplorationClip)
             return;
 
         lastExplorationClip = newExplorationClip;
@@ -254,22 +282,22 @@ public class AudioManager : MonoBehaviour
         isInCombat = false;
     }
 
-    public void TransitionToNewExplorationZone(AudioClip newExplorationClip)
+    public void TransitionToNewExplorationZone(AudioClipSO newExplorationClip)
     {
-        // Aucun fondu si une timeline ou un combat est actif, ou si le clip est identique
-        // On compare avec "CurrentMusicSource" afin d'éviter les erreurs de variable inexistante
-        if (isInCombat || isInTimeline || newExplorationClip == CurrentMusicSource.clip)
+        AudioClip clip = ResolveClip(newExplorationClip);
+        if (clip == null)
             return;
 
-        // Sauvegarde la position de la musique actuelle (si c'était une musique d'exploration)
-        if (!isInCombat && CurrentMusicSource.clip != null)
+        if (isInCombat || isInTimeline || currentMusicAsset == newExplorationClip)
+            return;
+
+        if (!isInCombat && currentMusicAsset != null && CurrentMusicSource.clip != null)
         {
-            explorationPlaybackPositions[CurrentMusicSource.clip] = CurrentMusicSource.time;
+            explorationPlaybackPositions[currentMusicAsset] = CurrentMusicSource.time;
         }
 
         lastExplorationClip = newExplorationClip;
 
-        // Si on a déjà une position sauvegardée, on la reprend
         float resumeTime = explorationPlaybackPositions.TryGetValue(newExplorationClip, out float savedTime)
             ? savedTime
             : 0f;
@@ -277,43 +305,39 @@ public class AudioManager : MonoBehaviour
         StartCrossfade(newExplorationClip, resumeTime);
     }
 
-    public void TransitionToCombat(AudioClip combatClip)
+    public void TransitionToCombat(AudioClipSO combatClip)
     {
-        // 🚫 Ignore si l'on est déjà en combat
+        AudioClip clip = ResolveClip(combatClip);
+        if (clip == null)
+            return;
+
         if (isInCombat)
             return;
 
         if (isInTimeline)
         {
-            // ✅ Un combat est lancé depuis une timeline
-            //    → on met fin à la timeline sans relancer l'exploration
             isInTimeline = false;
 
-            // Si la timeline provenait de l'exploration, on mémorise la musique à reprendre
             if (!wasInCombatBeforeTimeline)
             {
                 lastExplorationClip = clipBeforeTimeline;
                 lastExplorationTime = timeBeforeTimeline;
             }
 
-            // Stoppe tout fondu éventuel lancé par la timeline
             if (timelineFadeRoutine != null)
             {
                 StopCoroutine(timelineFadeRoutine);
                 timelineFadeRoutine = null;
             }
 
-            // La source active peut avoir été mise en pause : on la remet en lecture
             CurrentMusicSource.UnPause();
         }
-        else
+        else if (currentMusicAsset != null)
         {
-            // Combat lancé hors timeline : on sauvegarde la musique d'exploration actuelle
-            lastExplorationClip = CurrentMusicSource.clip;
+            lastExplorationClip = currentMusicAsset;
             lastExplorationTime = CurrentMusicSource.time;
         }
 
-        // On passe en mode combat puis on bascule immédiatement sur le thème approprié
         isInCombat = true;
         SwitchImmediately(combatClip);
     }
@@ -332,31 +356,24 @@ public class AudioManager : MonoBehaviour
     /// (exploration ou combat).
     /// </summary>
     /// <param name="timelineClip">Musique à jouer durant la cinématique.</param>
-    public void TransitionToTimeline(AudioClip timelineClip)
+    public void TransitionToTimeline(AudioClipSO timelineClip)
     {
-        // Évite toute action si une timeline est déjà en cours
         if (isInTimeline)
             return;
 
-        // Sauvegarde le contexte musical actuel avant d'entrer en timeline
-        // "CurrentMusicSource" renvoie la source de musique active
         wasInCombatBeforeTimeline = isInCombat;
-        clipBeforeTimeline = CurrentMusicSource.clip;
+        clipBeforeTimeline = currentMusicAsset;
         timeBeforeTimeline = CurrentMusicSource.time;
 
-        // Les timelines ne sont ni exploration ni combat
         isInTimeline = true;
         isInCombat = false;
 
-        // Si un clip de timeline est fourni, on réalise un crossfade classique
-        if (timelineClip != null)
+        if (ResolveClip(timelineClip) != null)
         {
             StartCrossfade(timelineClip, 0f);
         }
         else
         {
-            // Sinon, on coupe progressivement la musique actuelle pour laisser place
-            // aux sons propres de la timeline (voix, bruitages...).
             if (timelineFadeRoutine != null)
                 StopCoroutine(timelineFadeRoutine);
             timelineFadeRoutine = StartCoroutine(FadeOutCurrentMusic());
@@ -371,23 +388,18 @@ public class AudioManager : MonoBehaviour
         if (!isInTimeline)
             return;
 
-        // Rétablit l'état initial (combat ou exploration)
         isInCombat = wasInCombatBeforeTimeline;
         isInTimeline = false;
 
         if (clipBeforeTimeline == null)
             return;
 
-        // Si un clip spécifique était joué pendant la timeline, on le remplace
-        // par la musique précédente via un crossfade.
-        if (CurrentMusicSource.clip != clipBeforeTimeline)
+        if (currentMusicAsset != clipBeforeTimeline)
         {
             StartCrossfade(clipBeforeTimeline, timeBeforeTimeline);
         }
         else
         {
-            // Aucun clip de timeline : la musique avait été simplement mise en pause.
-            // On la relance et on remonte le volume progressivement.
             if (timelineFadeRoutine != null)
                 StopCoroutine(timelineFadeRoutine);
             CurrentMusicSource.UnPause();
@@ -438,66 +450,107 @@ public class AudioManager : MonoBehaviour
         timelineFadeRoutine = null;
     }
 
-    private void StartCrossfade(AudioClip newClip, float startTime)
+    private void StartCrossfade(AudioClipSO newClip, float startTime)
     {
+        currentMusicAsset = newClip;
+
         if (crossfadeRoutine != null)
             StopCoroutine(crossfadeRoutine);
 
         crossfadeRoutine = StartCoroutine(CrossfadeMusic(newClip, startTime));
     }
 
-    private void SwitchImmediately(AudioClip newClip)
+    private void SwitchImmediately(AudioClipSO newClip)
     {
+        currentMusicAsset = newClip;
+
         if (crossfadeRoutine != null)
             StopCoroutine(crossfadeRoutine);
 
         CurrentMusicSource.Stop();
 
-        // Échange des indices des sources musicales
         int temp = currentMusicIndex;
         currentMusicIndex = nextMusicIndex;
         nextMusicIndex = temp;
 
         AudioSource source = CurrentMusicSource;
-        source.clip = newClip;
+        AudioClip clip = ResolveClip(newClip);
+
+        if (clip == null)
+        {
+            source.clip = null;
+            source.loop = ResolveLoop(newClip);
+            source.volume = 0f;
+            return;
+        }
+
+        source.clip = clip;
+        source.loop = ResolveLoop(newClip);
         source.time = 0f;
-        source.volume = musicVolume * GetNormalizationFactor(newClip);
+
+        float normalization = GetNormalizationFactor(clip);
+        float volumeFactor = ResolveVolume(newClip, DefaultVolume);
+        source.volume = musicVolume * normalization * volumeFactor;
         source.Play();
     }
 
-    private IEnumerator CrossfadeMusic(AudioClip newClip, float startTime)
+    private IEnumerator CrossfadeMusic(AudioClipSO newClip, float startTime)
     {
         AudioSource fromSource = CurrentMusicSource;
+        float fromInitialVolume = fromSource.volume;
         float fromFactor = GetNormalizationFactor(fromSource.clip);
+        float baseVolume = Mathf.Max(0.0001f, musicVolume * fromFactor);
+        float previousVolumeFactor = baseVolume > 0f ? Mathf.Clamp01(fromInitialVolume / baseVolume) : 1f;
 
-        // Choix de la prochaine source pour le crossfade
         int toIndex = (currentMusicIndex + 1) % musicSources.Length;
         AudioSource toSource = musicSources[toIndex];
 
-        toSource.clip = newClip;
-        toSource.time = startTime;
-        float toFactor = GetNormalizationFactor(newClip);
+        AudioClip clip = ResolveClip(newClip);
+        if (clip == null)
+        {
+            float t = 0f;
+            while (t < fadeDuration)
+            {
+                t += Time.deltaTime;
+                float progress = t / fadeDuration;
+                fromSource.volume = Mathf.Lerp(fromInitialVolume, 0f, progress);
+                yield return null;
+            }
+
+            fromSource.Stop();
+            fromSource.volume = musicVolume * fromFactor * previousVolumeFactor;
+            crossfadeRoutine = null;
+            yield break;
+        }
+
+        toSource.clip = clip;
+        toSource.loop = ResolveLoop(newClip);
+        float clampedStart = Mathf.Clamp(startTime, 0f, clip.length > 0f ? clip.length : 0f);
+        toSource.time = clampedStart;
+        float toFactor = GetNormalizationFactor(clip);
+        float toVolumeFactor = ResolveVolume(newClip, DefaultVolume);
+        float targetVolume = musicVolume * toFactor * toVolumeFactor;
         toSource.volume = 0f;
         toSource.Play();
 
         currentMusicIndex = toIndex;
         nextMusicIndex = (toIndex + 1) % musicSources.Length;
 
-        float t = 0f;
+        float tCrossfade = 0f;
 
-        while (t < fadeDuration)
+        while (tCrossfade < fadeDuration)
         {
-            t += Time.deltaTime;
-            float progress = t / fadeDuration;
+            tCrossfade += Time.deltaTime;
+            float progress = tCrossfade / fadeDuration;
 
-            toSource.volume = Mathf.Lerp(0f, musicVolume * toFactor, progress);
-            fromSource.volume = Mathf.Lerp(musicVolume * fromFactor, 0f, progress);
+            toSource.volume = Mathf.Lerp(0f, targetVolume, progress);
+            fromSource.volume = Mathf.Lerp(fromInitialVolume, 0f, progress);
             yield return null;
         }
 
         fromSource.Stop();
-        fromSource.volume = musicVolume * GetNormalizationFactor(fromSource.clip);
-        toSource.volume = musicVolume * toFactor;
+        fromSource.volume = musicVolume * fromFactor * previousVolumeFactor;
+        toSource.volume = targetVolume;
 
         crossfadeRoutine = null;
     }
@@ -675,8 +728,21 @@ public class AudioManager : MonoBehaviour
 
     public void PlaySfx(int index)
     {
-        AudioClip clip = soundEffects[index];
-        PlaySfx(clip);
+        if (soundEffects == null || index < 0 || index >= soundEffects.Length)
+            return;
+
+        PlaySfx(soundEffects[index]);
+    }
+
+    /// <summary>
+    /// Lecture simplifiée d'un effet sonore configuré via un <see cref="AudioClipSO"/>.
+    /// </summary>
+    public void PlaySfx(AudioClipSO clipAsset)
+    {
+        if (clipAsset == null)
+            return;
+
+        PlaySfx(ResolveClip(clipAsset), ResolveVolume(clipAsset), ResolveLoop(clipAsset));
     }
 
     /// <summary>
@@ -686,16 +752,15 @@ public class AudioManager : MonoBehaviour
     /// </summary>
     /// <param name="clip">Clip à jouer immédiatement.</param>
     /// <param name="volume">Facteur multiplicatif optionnel (1 = volume par défaut).</param>
-    public void PlaySfx(AudioClip clip, float volume = 1f)
+    /// <param name="loop">Lecture en boucle ?</param>
+    public void PlaySfx(AudioClip clip, float volume = DefaultVolume, bool loop = DefaultLoop)
     {
         if (clip == null)
             return; // Rien à jouer : on quitte proprement.
 
         AudioSource template = GetTemplateSource(sfxSources);
-        AudioSource src = CreateManagedSource("SFX", template);
+        AudioSource src = CreateManagedSource("SFX", template, loop);
 
-        // Stockage du facteur de volume permettant de recalculer la valeur lorsque
-        // le volume global change ou lorsqu'un warning est actif.
         DynamicAudioHandle handle = new DynamicAudioHandle
         {
             Source = src,
@@ -707,17 +772,37 @@ public class AudioManager : MonoBehaviour
         ApplyVolume(handle, sfxVolume);
         src.Play();
 
-        StartCoroutine(DestroySourceWhenFinished(src, activeSfxHandles, handle));
+        if (!loop)
+            StartCoroutine(DestroySourceWhenFinished(src, activeSfxHandles, handle));
     }
 
-    public void PlayVoice(int index, float volume = 1f) => PlayVoice(voiceEffects[index], volume);
+    public void PlayVoice(int index, float volume = DefaultVolume)
+    {
+        if (voiceEffects == null || index < 0 || index >= voiceEffects.Length)
+            return;
 
-    public void PlayVoice(AudioClip clip, float volume = 1f)
+        PlayVoice(voiceEffects[index], volume);
+    }
+
+    /// <summary>
+    /// Lecture d'une voix via un <see cref="AudioClipSO"/>.
+    /// </summary>
+    public void PlayVoice(AudioClipSO clipAsset, float volumeMultiplier = 1f)
+    {
+        if (clipAsset == null)
+            return;
+
+        float baseVolume = ResolveVolume(clipAsset);
+        float finalVolume = Mathf.Clamp01(baseVolume * Mathf.Clamp01(volumeMultiplier));
+        PlayVoice(ResolveClip(clipAsset), finalVolume, ResolveLoop(clipAsset));
+    }
+
+    public void PlayVoice(AudioClip clip, float volume = DefaultVolume, bool loop = DefaultLoop)
     {
         if (clip == null) return;
 
         AudioSource template = GetTemplateSource(voiceSources);
-        AudioSource src = CreateManagedSource("Voice", template);
+        AudioSource src = CreateManagedSource("Voice", template, loop);
 
         DynamicAudioHandle handle = new DynamicAudioHandle
         {
@@ -730,19 +815,21 @@ public class AudioManager : MonoBehaviour
         ApplyVolume(handle, voiceVolume);
         src.Play();
 
-        StartCoroutine(DestroySourceWhenFinished(src, activeVoiceHandles, handle));
+        if (!loop)
+            StartCoroutine(DestroySourceWhenFinished(src, activeVoiceHandles, handle));
     }
 
     /// <summary>
     /// Joue un clip d'avertissement en utilisant la source dédiée.
     /// </summary>
-    public void PlayWarningClip(AudioClip clip)
+    public void PlayWarningClip(AudioClipSO clipAsset)
     {
+        AudioClip clip = ResolveClip(clipAsset);
         if (clip == null) return;
 
-        float factor = GetNormalizationFactor(clip);
+        float normalization = GetNormalizationFactor(clip);
+        float clipVolume = ResolveVolume(clipAsset, DefaultVolume);
 
-        // Arrête toute atténuation précédente
         if (warningRoutine != null)
         {
             StopCoroutine(warningRoutine);
@@ -751,15 +838,14 @@ public class AudioManager : MonoBehaviour
             warningRoutine = null;
         }
 
-        // Lance la coroutine gérant l'atténuation temporaire
-        warningRoutine = StartCoroutine(WarningCoroutine(clip, factor));
+        warningRoutine = StartCoroutine(WarningCoroutine(clipAsset, clip, normalization, clipVolume));
     }
 
     /// <summary>
     /// Coroutine qui réduit temporairement le volume des autres sources pendant
     /// la lecture d'un warning clip, puis restaure les volumes initiaux.
     /// </summary>
-    private IEnumerator WarningCoroutine(AudioClip clip, float factor)
+    private IEnumerator WarningCoroutine(AudioClipSO clipAsset, AudioClip clip, float normalizationFactor, float volumeFactor)
     {
         // Sauvegarde des volumes actuels
         float[] musicVols = new float[musicSources.Length];
@@ -788,9 +874,9 @@ public class AudioManager : MonoBehaviour
 
         // Lecture du warning clip via une AudioSource dédiée créée pour l'occasion.
         AudioSource warningTemplate = warningClipSource != null ? warningClipSource : GetTemplateSource(sfxSources);
-        AudioSource warningSource = CreateManagedSource("Warning", warningTemplate);
+        AudioSource warningSource = CreateManagedSource("Warning", warningTemplate, ResolveLoop(clipAsset));
         warningSource.clip = clip;
-        warningSource.volume = Mathf.Clamp01(warningBaseVolume * factor);
+        warningSource.volume = Mathf.Clamp01(warningBaseVolume * normalizationFactor * volumeFactor);
         warningSource.Play();
         currentWarningSource = warningSource;
 
@@ -807,9 +893,19 @@ public class AudioManager : MonoBehaviour
         PlaySfx(clip);
     }
 
+    public void PlaySound(AudioClipSO clipAsset)
+    {
+        PlaySfx(clipAsset);
+    }
+
     public void PlayTempSfx(AudioClip clip)
     {
         PlaySfx(clip);
+    }
+
+    public void PlayTempSfx(AudioClipSO clipAsset)
+    {
+        PlaySfx(clipAsset);
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraShatter.cs
@@ -9,7 +9,7 @@ using UnityEngine.Rendering.HighDefinition;
 public class BattleCameraShatter : MonoBehaviour
 {
     [Tooltip("Son joué lors du bris de la caméra")]
-    public AudioClip shatterSound;
+    public AudioClipSO shatterSound;
     [Tooltip("Volume contenant les effets de post-processing")]
     public Volume volume;
     [Tooltip("Texture utilisée pour la salissure de l'objectif")]

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -18,10 +18,10 @@ public class BattleTransitionManager : MonoBehaviour
     [SerializeField] private ParticleSystem maskRingParticles;
 
     [Header("SFX")]
-    [SerializeField] private List<AudioClip> transitionSFXClips = new();
+    [SerializeField] private List<AudioClipSO> transitionSFXClips = new();
     [SerializeField] private AudioSource sfxSource;
-    [SerializeField] private AudioClip brokenGlassSound;
-    [SerializeField] private AudioClip versusThunder;
+    [SerializeField] private AudioClipSO brokenGlassSound;
+    [SerializeField] private AudioClipSO versusThunder;
 
     [Header("Music")]
     [SerializeField] private AudioSource musicSource;
@@ -318,7 +318,7 @@ public class BattleTransitionManager : MonoBehaviour
         // Active uniquement les caméras nécessaires au lancement du combat
         CameraActivationManager.Instance?.ActivateBattleAndVersusCameras();
 
-        AudioClip randomClip = null;
+        AudioClipSO randomClip = null;
         ZoneSO currentZone = ZoneManager.Instance != null ? ZoneManager.Instance.currentZone : null;
         if (currentZone != null && currentZone.battleMusic != null && currentZone.battleMusic.Length > 0)
         {
@@ -395,7 +395,8 @@ public class BattleTransitionManager : MonoBehaviour
         if (PostProcessManager.Instance != null)
             StartCoroutine(PostProcessManager.Instance.PulseLensDistortion(-1f, 0.5f));
 
-        AudioManager.Instance.PlaySound(versusThunder);
+        if (versusThunder != null)
+            AudioManager.Instance.PlaySound(versusThunder);
         StartCoroutine(VersusThunderFlash()); // Déclenche un flash blanc synchronisé avec le son
 
         battleCamera.SetActive(true);
@@ -443,7 +444,8 @@ public class BattleTransitionManager : MonoBehaviour
         if (CameraActivationManager.Instance != null)
             StartCoroutine(CameraActivationManager.Instance.DisableVersusAfterAnimation(glass));
 
-        AudioManager.Instance.PlaySound(brokenGlassSound);
+        if (brokenGlassSound != null)
+            AudioManager.Instance.PlaySound(brokenGlassSound);
 
         // Les unités apparaissent après l'explosion
         NewBattleManager.Instance.SpawnAll();
@@ -686,11 +688,23 @@ public class BattleTransitionManager : MonoBehaviour
             yield break;
         }
 
-        foreach (var clip in transitionSFXClips)
+        foreach (var clipAsset in transitionSFXClips)
         {
-            sfxSource.clip = clip;
+            if (clipAsset == null || clipAsset.Clip == null)
+                continue;
+
+            // Respecte la configuration du ScriptableObject (volume/loop) tout en conservant
+            // les réglages de mixage de la source renseignés dans l'inspecteur.
+            sfxSource.loop = clipAsset.Loop;
+            sfxSource.clip = clipAsset.Clip;
+            sfxSource.volume = clipAsset.Volume;
             sfxSource.Play();
-            yield return new WaitForSeconds(clip.length);
+
+            float waitDuration = clipAsset.Clip.length > 0f ? clipAsset.Clip.length : 0f;
+            if (waitDuration > 0f)
+                yield return new WaitForSeconds(waitDuration);
+            else
+                yield return null;
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -858,12 +858,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             return;
 
         CharacterUnit randomAlly = allies[UnityEngine.Random.Range(0, allies.Count)];
-        AudioClip clip = GetWeepClip(randomAlly.Data, Data.characterName);
+        AudioClipSO clip = GetWeepClip(randomAlly.Data, Data.characterName);
         if (clip != null)
             AudioManager.Instance?.PlayVoice(clip);
     }
 
-    AudioClip GetWeepClip(CharacterData allyData, string deadName)
+    AudioClipSO GetWeepClip(CharacterData allyData, string deadName)
     {
         return deadName switch
         {
@@ -914,12 +914,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             return;
 
         // Sélection du clip approprié
-        AudioClip clip = (isDevastating && Data.criticalHitSound != null)
+        AudioClipSO clip = (isDevastating && Data.criticalHitSound != null)
             ? Data.criticalHitSound
             : Data.hitSound;
 
-        if (clip != null)
-            audioSource.PlayOneShot(clip);
+        if (clip != null && clip.Clip != null)
+            audioSource.PlayOneShot(clip.Clip, clip.Volume);
     }
 
     /// <summary>
@@ -927,8 +927,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public void PlayInterceptedSound()
     {
-        if (Data.interceptedSound != null && audioSource != null)
-            audioSource.PlayOneShot(Data.interceptedSound);
+        if (Data.interceptedSound != null && Data.interceptedSound.Clip != null && audioSource != null)
+            audioSource.PlayOneShot(Data.interceptedSound.Clip, Data.interceptedSound.Volume);
     }
 
     /// <summary>
@@ -937,8 +937,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public void PlayInterceptionSound()
     {
-        if (Data.interceptionSound != null && audioSource != null)
-            audioSource.PlayOneShot(Data.interceptionSound);
+        if (Data.interceptionSound != null && Data.interceptionSound.Clip != null && audioSource != null)
+            audioSource.PlayOneShot(Data.interceptionSound.Clip, Data.interceptionSound.Volume);
     }
 
     public void PlayMoveStartSound()

--- a/Assets/Scripts/MonoBehavioursUsed/FootstepAudio.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/FootstepAudio.cs
@@ -21,9 +21,9 @@ public class FootstepAudio : MonoBehaviour
         [Tooltip("Tag du sol, par ex. 'Concrete', 'Sand', 'Wood'.")]
         public string groundTag;
         [Tooltip("Clips joués lorsque le joueur marche sur cette surface.")]
-        public AudioClip[] walkClips;
+        public AudioClipSO[] walkClips;
         [Tooltip("Clips joués lorsque le joueur court sur cette surface.")]
-        public AudioClip[] runClips;
+        public AudioClipSO[] runClips;
     }
 
     [Header("Références")]
@@ -35,8 +35,8 @@ public class FootstepAudio : MonoBehaviour
     [SerializeField] private SurfaceClips[] surfaceClips;
 
     [Header("Sons par défaut (si aucun tag n'est reconnu)")]
-    [SerializeField] private AudioClip[] defaultWalkClips;
-    [SerializeField] private AudioClip[] defaultRunClips;
+    [SerializeField] private AudioClipSO[] defaultWalkClips;
+    [SerializeField] private AudioClipSO[] defaultRunClips;
 
     // Référence au contrôleur pour connaître l'état de course.
     private ThirdPersonPlayerController movement;
@@ -124,13 +124,14 @@ public class FootstepAudio : MonoBehaviour
     private void StartLoop(string groundTag, bool running)
     {
         // Choisir un clip (aléatoire) correspondant à la surface.
-        AudioClip clip = GetRandomClip(groundTag, running);
-        if (clip == null || fallbackSource == null)
+        AudioClipSO clipAsset = GetRandomClip(groundTag, running);
+        if (clipAsset == null || clipAsset.Clip == null || fallbackSource == null)
             return;
 
-        // Préparation de la source pour la lecture en boucle.
-        fallbackSource.loop = true;
-        fallbackSource.clip = clip;
+        // Préparation de la source pour la lecture en tenant compte des paramètres designers.
+        fallbackSource.loop = clipAsset.Loop;
+        fallbackSource.clip = clipAsset.Clip;
+        fallbackSource.volume = clipAsset.Volume;
         fallbackSource.Play();
 
         _isLoopPlaying = true;
@@ -154,10 +155,10 @@ public class FootstepAudio : MonoBehaviour
     /// <summary>
     /// Sélectionne un clip aléatoire en fonction du type de sol et de l'état (marche/course).
     /// </summary>
-    private AudioClip GetRandomClip(string groundTag, bool running)
+    private AudioClipSO GetRandomClip(string groundTag, bool running)
     {
         string key = NormalizeTag(groundTag);
-        AudioClip[] clips = GetClipsFor(key, running);
+        AudioClipSO[] clips = GetClipsFor(key, running);
 
         if (clips == null || clips.Length == 0)
             return null;
@@ -170,7 +171,7 @@ public class FootstepAudio : MonoBehaviour
     /// <summary>
     /// Retourne le tableau de clips correspondant à la surface (ou défaut) et à l'état (walk/run).
     /// </summary>
-    private AudioClip[] GetClipsFor(string normalizedKey, bool running)
+    private AudioClipSO[] GetClipsFor(string normalizedKey, bool running)
     {
         // Si la surface est connue, utiliser ses clips.
         if (_surfaceMap.TryGetValue(normalizedKey, out var surface))

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -328,19 +328,19 @@ public class NewBattleManager : MonoBehaviour
 
     [Header("Effets sonores de navigation en combat")]
     [SerializeField, Tooltip("Clip joué lorsque le menu principal s'affiche ou lorsque l'on y retourne.")]
-    private AudioClip mainMenuOpenClip;
+    private AudioClipSO mainMenuOpenClip;
     [SerializeField, Tooltip("Clip joué dès que le joueur ouvre le menu des compétences.")]
-    private AudioClip skillsMenuOpenClip;
+    private AudioClipSO skillsMenuOpenClip;
     [SerializeField, Tooltip("Clip joué lors de l'accès au menu des objets.")]
-    private AudioClip itemsMenuOpenClip;
+    private AudioClipSO itemsMenuOpenClip;
     [SerializeField, Tooltip("Clip déclenché lorsque l'on passe en mode sélection de cible (compétence ou objet).")]
-    private AudioClip targetSelectionClip;
+    private AudioClipSO targetSelectionClip;
     [SerializeField, Tooltip("Clip joué à chaque changement de cible pendant la navigation.")]
-    private AudioClip targetChangeClip;
+    private AudioClipSO targetChangeClip;
     [SerializeField, Tooltip("Clip joué lorsqu'une nouvelle page de compétences est affichée.")]
-    private AudioClip skillPageChangeClip;
+    private AudioClipSO skillPageChangeClip;
     [SerializeField, Tooltip("Effet utilisé lorsque l'unité active ne possède pas de clip personnalisé pour signaler sa sélection.")]
-    private AudioClip defaultCharacterSelectionClip;
+    private AudioClipSO defaultCharacterSelectionClip;
 
     // -----------------------------------------------------------------------------------
 
@@ -3288,7 +3288,7 @@ public class NewBattleManager : MonoBehaviour
     /// (ex : scènes de test sans gestionnaire global).
     /// </summary>
     /// <param name="clip">Clip à jouer immédiatement.</param>
-    private void PlayMenuClip(AudioClip clip)
+    private void PlayMenuClip(AudioClipSO clip)
     {
         if (clip == null)
             return; // Aucun son configuré pour cet évènement.
@@ -3312,7 +3312,7 @@ public class NewBattleManager : MonoBehaviour
             return; // Sécurité : aucun personnage actif, donc aucun son à jouer.
 
         CharacterData data = unit.Data;
-        AudioClip clipToPlay = data != null && data.menuSelectionClip != null
+        AudioClipSO clipToPlay = data != null && data.menuSelectionClip != null
             ? data.menuSelectionClip
             : defaultCharacterSelectionClip;
 

--- a/Assets/Scripts/MonoBehavioursUsed/PlaySound.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlaySound.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 public class PlaySound : MonoBehaviour
 {
     [Tooltip("Clip joué automatiquement au démarrage si playAtStart est activé.")]
-    public AudioClip soundClip; // Clip par défaut
+    public AudioClipSO soundClip; // Clip par défaut
 
     [Tooltip("Active la lecture automatique de 'soundClip' au Start.")]
     public bool playAtStart = false; // Contrôle la lecture au Start
@@ -37,31 +37,38 @@ public class PlaySound : MonoBehaviour
     /// sinon via l'AudioSource locale. Cette méthode est privée pour
     /// centraliser la logique de lecture.
     /// </summary>
-    /// <param name="clip">Le clip audio à jouer.</param>
-    private void PlaySoundClip(AudioClip clip)
+    /// <param name="clipAsset">Le clip audio à jouer.</param>
+    private void PlaySoundClip(AudioClipSO clipAsset)
     {
-        if (clip == null)
+        if (clipAsset == null || clipAsset.Clip == null)
         {
             Debug.LogWarning("[PlaySound] Aucun clip fourni pour la lecture.");
             return;
         }
+        if (AudioManager.Instance != null)
+        {
+            // Passage par le gestionnaire global afin de respecter les volumes et priorités du mixage.
+            AudioManager.Instance.PlaySfx(clipAsset);
+            return;
+        }
+
         if (_audioSource != null)
         {
-            _audioSource.PlayOneShot(clip);
+            // Fallback local (scènes de test) : on applique malgré tout le volume conseillé par le designer.
+            _audioSource.PlayOneShot(clipAsset.Clip, clipAsset.Volume);
+            return;
         }
-        else
-        {
-            Debug.LogWarning("[PlaySound] AudioManager absent et aucune AudioSource trouvée sur l'objet.");
-        }
+
+        Debug.LogWarning("[PlaySound] AudioManager absent et aucune AudioSource trouvée sur l'objet.");
     }
 
     /// <summary>
     /// Méthode publique destinée à être appelée depuis une Timeline
     /// (via un Signal, Activation Track, etc.).
     /// </summary>
-    /// <param name="clip">Le clip audio à jouer.</param>
-    public void PlaySoundFromTimeline(AudioClip clip)
+    /// <param name="clipAsset">Le clip audio à jouer.</param>
+    public void PlaySoundFromTimeline(AudioClipSO clipAsset)
     {
-        PlaySoundClip(clip);
+        PlaySoundClip(clipAsset);
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PlayerDetection.cs
@@ -36,7 +36,7 @@ public class PlayerDetection : MonoBehaviour
 
     [Header("Effets sonores")]
     [Tooltip("Clips vocaux joués lors de la première détection d'un ennemi")]
-    public List<AudioClip> firstDetectionVoices = new List<AudioClip>();
+    public List<AudioClipSO> firstDetectionVoices = new List<AudioClipSO>();
 
     [Tooltip("Volume appliqué au clip de première détection")]
     [Range(0f, 1f)]
@@ -92,7 +92,7 @@ public class PlayerDetection : MonoBehaviour
         if (!firstEnemyDetected && firstDetectionVoices.Count > 0)
         {
             // Sélection aléatoire d'un clip parmi la liste disponible
-            AudioClip clip = firstDetectionVoices[UnityEngine.Random.Range(0, firstDetectionVoices.Count)];
+            AudioClipSO clip = firstDetectionVoices[UnityEngine.Random.Range(0, firstDetectionVoices.Count)];
 
             // Lecture du clip avec le volume choisi dans l'inspecteur
             AudioManager.Instance?.PlayVoice(clip, firstDetectionVoiceVolume);

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -52,14 +52,14 @@ public class RhythmQTEManager : MonoBehaviour
     [Tooltip("Particules instanciées lors d'un déplacement classique afin d'accentuer la sensation de dash.")]
     [SerializeField] private ParticleSystem dashParticlesPrefab;
     [Tooltip("Clip joué lorsqu'aucun son spécifique n'est défini sur le personnage pour l'effet de dash.")]
-    [SerializeField] private AudioClip defaultDashSound;
+    [SerializeField] private AudioClipSO defaultDashSound;
 
     // Tag de la caméra de combat à utiliser pour toutes les timelines
     private const string battleCameraTag = "BattleCamera";
 
     // QTE Effect
-    public AudioClip successSFX;
-    public AudioClip failSFX;
+    public AudioClipSO successSFX;
+    public AudioClipSO failSFX;
     // Effets visuels pour indiquer le résultat du QTE
     public GameObject successEffectPrefab;
     public GameObject failEffectPrefab;
@@ -71,7 +71,7 @@ public class RhythmQTEManager : MonoBehaviour
     /// Joue un effet sonore à l'aide d'une source SFX disponible.
     /// </summary>
     /// <param name="clip">Clip audio à jouer</param>
-    private void PlaySfx(AudioClip clip)
+    private void PlaySfx(AudioClipSO clip)
     {
         if (clip == null)
             return;
@@ -582,7 +582,7 @@ public class RhythmQTEManager : MonoBehaviour
 
         // Lecture optionnelle du son associé : priorité au clip personnalisé du personnage,
         // sinon utilisation d'un son par défaut défini dans le manager.
-        AudioClip dashClip = casterData != null && casterData.dashSoundClip != null
+        AudioClipSO dashClip = casterData != null && casterData.dashSoundClip != null
             ? casterData.dashSoundClip
             : defaultDashSound;
         PlaySfx(dashClip);
@@ -1465,7 +1465,7 @@ public class RhythmQTEManager : MonoBehaviour
         return first != null ? first.transform : null;
     }
 
-    private IEnumerator PlayTauntWithDelay(AudioClip clip, float delay)
+    private IEnumerator PlayTauntWithDelay(AudioClipSO clip, float delay)
     {
         yield return new WaitForSeconds(delay);
         AudioManager.Instance?.PlayVoice(clip);

--- a/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SleepStatus.cs
@@ -13,8 +13,8 @@ public class SleepStatus : MonoBehaviour
     [SerializeField] private Vector3 effectOffset = new Vector3(0, 2f, 0);
 
     [Header("Effets sonores")]
-    [SerializeField] private AudioClip sleepClip;
-    [SerializeField] private AudioClip wakeUpClip;
+    [SerializeField] private AudioClipSO sleepClip;
+    [SerializeField] private AudioClipSO wakeUpClip;
 
     private GameObject currentSleepEffect;
 
@@ -30,8 +30,8 @@ public class SleepStatus : MonoBehaviour
 
         isAsleep = true;
 
-        if (sleepClip != null && audioSource != null)
-            audioSource.PlayOneShot(sleepClip);
+        if (sleepClip != null && sleepClip.Clip != null && audioSource != null)
+            audioSource.PlayOneShot(sleepClip.Clip, sleepClip.Volume);
 
         if (sleepPrefab != null && currentSleepEffect == null)
         {
@@ -47,8 +47,8 @@ public class SleepStatus : MonoBehaviour
 
         isAsleep = false;
 
-        if (wakeUpClip != null && audioSource != null)
-            audioSource.PlayOneShot(wakeUpClip);
+        if (wakeUpClip != null && wakeUpClip.Clip != null && audioSource != null)
+            audioSource.PlayOneShot(wakeUpClip.Clip, wakeUpClip.Volume);
 
         if (currentSleepEffect != null)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineManager.cs
@@ -104,7 +104,7 @@ public class TimelineManager : MonoBehaviour
 
     [Header("Audio")]
     [Tooltip("Musique de fond à jouer pendant les timelines.")]
-    [SerializeField] private AudioClip timelineMusicClip;
+    [SerializeField] private AudioClipSO timelineMusicClip;
 
     /// <summary>
     /// Active ou désactive l'ensemble des entrées de la map <c>World</c> pendant

--- a/Assets/Scripts/MonoBehavioursUsed/UnitStateEffects.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/UnitStateEffects.cs
@@ -14,8 +14,8 @@ public class UnitStateEffects : MonoBehaviour
     public AnimationClip exitAnimation;
 
     [Header("Effets sonores")]
-    public AudioClip enterClip;
-    public AudioClip exitClip;
+    public AudioClipSO enterClip;
+    public AudioClipSO exitClip;
 
     [Header("Camera")]
     public OrbitAroundTriggerSO cameraPath;
@@ -32,8 +32,8 @@ public class UnitStateEffects : MonoBehaviour
 
     public void EnterState()
     {
-        if (enterClip != null)
-            audioSource?.PlayOneShot(enterClip);
+        if (enterClip != null && enterClip.Clip != null)
+            audioSource?.PlayOneShot(enterClip.Clip, enterClip.Volume);
         if (enterAnimation != null)
             animator?.Play(enterAnimation.name);
         cameraPath?.StartOrbit();
@@ -43,8 +43,8 @@ public class UnitStateEffects : MonoBehaviour
 
     public void ExitState()
     {
-        if (exitClip != null)
-            audioSource?.PlayOneShot(exitClip);
+        if (exitClip != null && exitClip.Clip != null)
+            audioSource?.PlayOneShot(exitClip.Clip, exitClip.Volume);
         if (exitAnimation != null)
             animator?.Play(exitAnimation.name);
         cameraPath?.StopOrbit();

--- a/Assets/Scripts/UnusedScripts/AreaMusicTrigger.cs
+++ b/Assets/Scripts/UnusedScripts/AreaMusicTrigger.cs
@@ -2,8 +2,8 @@ using UnityEngine;
 
 public class AreaMusicTrigger : MonoBehaviour
 {
-    [Tooltip("Musique jouée dans cette zone d'exploration")]
-    public AudioClip zoneMusic;
+    [Tooltip("Musique jouÃ©e dans cette zone d'exploration")]
+    public AudioClipSO zoneMusic;
 
     private void OnTriggerEnter(Collider other)
     {


### PR DESCRIPTION
## Summary
- introduce an AudioClipSO scriptable object that stores clip, volume, and loop defaults
- migrate character, item, zone and gameplay scripts to reference AudioClipSO assets instead of raw AudioClips
- refactor the AudioManager and related behaviours to honour the new defaults when playing sounds

## Testing
- Not Run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d2f99b08748325bd9f46575eef5be2