### PR TITLE
Expose audio clip length on AudioClipSO

### DIFF
--- a/Assets/Scripts/Classes/AudioClipSO.cs
+++ b/Assets/Scripts/Classes/AudioClipSO.cs
@@ -33,4 +33,11 @@ public class AudioClipSO : ScriptableObject
     /// Indique si le clip doit boucler par défaut.
     /// </summary>
     public bool Loop => loop;
+
+    /// <summary>
+    /// Durée du clip en secondes (0 si aucun clip n'est assigné).
+    /// Cette propriété est utilisée pour synchroniser les temps d'attente
+    /// avec les indices sonores dans les différents systèmes de combat.
+    /// </summary>
+    public float Length => audioClip != null ? audioClip.length : 0f;
 }

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1014,7 +1014,9 @@ public class NewBattleManager : MonoBehaviour
             // Les indices sonores sont joués via la nouvelle source dédiée
             AudioManager.Instance?.PlayWarningClip(move.warningClip);
             // On attend au moins la durée du clip pour conserver la cohérence musicale
-            delay = Mathf.Max(delay, move.warningClip.length);
+            // Utilise la propriété Length du ScriptableObject afin d'éviter les accès
+            // directs au composant AudioClip et de centraliser la gestion des durées.
+            delay = Mathf.Max(delay, move.warningClip.Length);
         }
 
         // Laisse un délai pour que le joueur prenne connaissance de l'action
@@ -1088,7 +1090,8 @@ public class NewBattleManager : MonoBehaviour
             // Les indices sonores sont joués via la nouvelle source dédiée
             AudioManager.Instance?.PlayWarningClip(move.warningClip);
             // On attend la fin du clip pour conserver la cohérence musicale
-            yield return new WaitForSecondsRealtime(move.warningClip.length);
+            // La propriété Length garantit un retour de durée valide même si aucun clip n'est assigné.
+            yield return new WaitForSecondsRealtime(move.warningClip.Length);
         }
 
         yield return RhythmQTEManager.Instance.MusicalMoveRoutine(move, caster, target);


### PR DESCRIPTION
## Summary
- ajouter une propriété Length sur AudioClipSO afin d'exposer la durée du clip encapsulé
- utiliser cette durée centralisée pour calculer les temps d'attente dans NewBattleManager et documenter le comportement

## Testing
- not run (non applicable dans l'environnement CI)


------
https://chatgpt.com/codex/tasks/task_e_68d3915c87f48325bb350286bfb2be82