### PR TITLE
Ajoute un délai optionnel pour la transition caméra preparing/performing

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -100,6 +100,11 @@ public class ItemData : ScriptableObject
     [Tooltip("Plan cinématique utilisé lors du repli (None = conserver la caméra précédente).")]
     public BattleCameraRole retreatCameraRole = BattleCameraRole.TargetReaction;
 
+    [Header("Transitions de caméra")]
+    [Min(0f)]
+    [Tooltip("Durée (en secondes) durant laquelle la caméra reste sur le cadrage de préparation avant de se déplacer vers celui d'utilisation.")]
+    public float preparingToPerformingCameraDelay = 0f;
+
 #if UNITY_EDITOR
     // ------------------------------------------------------------------
     // Références par défaut

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -151,6 +151,10 @@ public class MusicalMoveSO : ScriptableObject
     public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;
     [Tooltip("Plan cinématique utilisé durant le repli (None = conserver la caméra précédente).")]
     public BattleCameraRole retreatCameraRole = BattleCameraRole.ClosePushCaster;
+    [Header("Transitions de caméra")]
+    [Min(0f)]
+    [Tooltip("Temps (en secondes) durant lequel la caméra conserve le cadrage de préparation avant de basculer sur celui d'exécution.")]
+    public float preparingToPerformingCameraDelay = 0f;
 
 #if UNITY_EDITOR
     // ------------------------------------------------------------------

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -335,6 +335,15 @@ public class RhythmQTEManager : MonoBehaviour
                 caster.transform.forward = dir; // Applique uniquement la rotation horizontale
         }
 
+        if (move.preparingToPerformingCameraDelay > 0f)
+        {
+            // ⏱️ Option de mise en scène : laisse le temps à la caméra de rester sur la préparation
+            //     même si la timeline d'exécution n'a pas encore démarré. Cela permet par exemple
+            //     d'afficher un effet visuel ou un dialogue juste après la préparation tout en
+            //     conservant le cadrage choisi pour cette phase.
+            yield return new WaitForSeconds(move.preparingToPerformingCameraDelay);
+        }
+
         // --- Phase d'exécution ---
         StartTimelinePhase(
             move.performingTimeline,
@@ -499,6 +508,14 @@ public class RhythmQTEManager : MonoBehaviour
             dir = dir.normalized; // Normalisation après suppression de la composante verticale
             if (dir != Vector3.zero)
                 caster.transform.forward = dir; // Applique la rotation uniquement sur le plan horizontal
+        }
+
+        if (item.preparingToPerformingCameraDelay > 0f)
+        {
+            // 🎬 Offre un léger battement entre la fin de la préparation et l'utilisation de l'objet.
+            //     Utile pour créer des respirations ou synchroniser des effets spéciaux sans que
+            //     la caméra ne change immédiatement d'angle.
+            yield return new WaitForSeconds(item.preparingToPerformingCameraDelay);
         }
 
         // --- Phase d'utilisation ---


### PR DESCRIPTION
## Summary
- introduit un délai configurable entre les cadrages de préparation et d'exécution pour les MusicalMoves et Items
- expose le nouveau champ dans les ScriptableObjects concernés pour faciliter le réglage depuis l'éditeur Unity
- applique ce délai dans le RhythmQTEManager afin de conserver le plan de préparation avant de lancer la timeline suivante

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3f75642ac8325badfc129a906d1cd