### PR TITLE
Amélioration de la BattleCamera pour exploiter les nouveaux CMVPoint

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -75,6 +75,48 @@ public class BattleCameraManager : MonoBehaviour
     /// <summary>Rôle logique actuellement prioritaire.</summary>
     private BattleCameraRole currentRole = BattleCameraRole.None;
 
+    /// <summary>Suffixe historique associé au plan épaule regardant la cible.</summary>
+    private const string OverShoulderLookTargetSuffix = "OverShoulder_CasterLookTarget";
+
+    /// <summary>Préfixe commun des ancres d'épaule dédiées aux alliés.</summary>
+    private const string PlayerOverShoulderAnchorPrefix = "CMVPoint_OverShoulderLookTarget_Player";
+
+    /// <summary>Préfixe commun des ancres d'épaule dédiées aux ennemis.</summary>
+    private const string EnemyOverShoulderAnchorPrefix = "CMVPoint_OverShoulderLookTarget_Enemy";
+
+    /// <summary>
+    /// Liste triée des ancres de travelling côté joueur. Le tri permet de garantir
+    /// un ordre reproductible lorsque la caméra parcourt les différents points.
+    /// </summary>
+    private readonly List<Transform> playerOverShoulderAnchors = new();
+
+    /// <summary>Mêmes ancres mais pour le côté adverse.</summary>
+    private readonly List<Transform> enemyOverShoulderAnchors = new();
+
+    /// <summary>Référence de l'ancre actuellement utilisée chez les alliés.</summary>
+    private Transform currentPlayerOverShoulderAnchor;
+
+    /// <summary>Référence de l'ancre actuellement utilisée chez les ennemis.</summary>
+    private Transform currentEnemyOverShoulderAnchor;
+
+    /// <summary>Index du prochain point allié à utiliser dans la séquence.</summary>
+    private int playerOverShoulderCursor = -1;
+
+    /// <summary>Index du prochain point ennemi à utiliser dans la séquence.</summary>
+    private int enemyOverShoulderCursor = -1;
+
+    /// <summary>
+    /// Indique si les ancres globales du champ de bataille ont déjà été collectées
+    /// pour éviter de relancer une recherche coûteuse chaque frame.
+    /// </summary>
+    private bool battlefieldAnchorsCached;
+
+    /// <summary>
+    /// Empêche de répéter les avertissements lorsque la scène ne fournit aucune
+    /// ancre « CMVPoint_OverShoulderLookTarget_* » exploitable.
+    /// </summary>
+    private bool hasLoggedMissingOverShoulderAnchors;
+
     /// <summary>Modes d'association entre une caméra Cinemachine et un CharacterUnit.</summary>
     private enum CameraAnchorOwner
     {
@@ -146,6 +188,11 @@ public class BattleCameraManager : MonoBehaviour
         }
         Instance = this;
 
+        // On invalide immédiatement les caches dédiés aux ancres globales afin
+        // de repartir d'une base saine, quel que soit l'ordre d'initialisation
+        // des autres éléments de la scène (Battlefield, unités, etc.).
+        InvalidateBattlefieldAnchorCache();
+
         blendSwitcher = FindFirstObjectByType<CinemachineBlendSwitcher>();
         if (!blendSwitcher)
             Debug.LogWarning("[BattleCameraManager] Aucun CinemachineBlendSwitcher trouvé dans la scène.");
@@ -179,6 +226,11 @@ public class BattleCameraManager : MonoBehaviour
     /// <summary>Réactualise le cache des CinemachineCamera disponibles.</summary>
     private void RefreshCameraCache()
     {
+        // Un changement dans les Cinemachine disponibles signifie souvent que le
+        // décor vient d'être rechargé : on invalide donc également les caches des
+        // ancres globales pour éviter toute référence périmée.
+        InvalidateBattlefieldAnchorCache();
+
         cameraByName.Clear();
         availableCameras.Clear();
 
@@ -195,6 +247,231 @@ public class BattleCameraManager : MonoBehaviour
         }
 
         CacheIntroCameraReference();
+    }
+
+    /// <summary>
+    /// Réinitialise tous les caches liés aux points « CMVPoint_OverShoulderLookTarget_* ».
+    /// Cette méthode est appelée dès que la scène est susceptible d'avoir changé afin
+    /// d'éviter que la caméra reste ancrée sur des Transforms détruits.
+    /// </summary>
+    private void InvalidateBattlefieldAnchorCache()
+    {
+        battlefieldAnchorsCached = false;
+        playerOverShoulderAnchors.Clear();
+        enemyOverShoulderAnchors.Clear();
+        currentPlayerOverShoulderAnchor = null;
+        currentEnemyOverShoulderAnchor = null;
+        playerOverShoulderCursor = -1;
+        enemyOverShoulderCursor = -1;
+    }
+
+    /// <summary>
+    /// Supprime les entrées nulles (ancres détruites) d'une liste puis recale le
+    /// pointeur courant pour que la prochaine sélection reste cohérente.
+    /// </summary>
+    private static bool RemoveNullAnchors(List<Transform> anchors, ref Transform current, ref int cursor)
+    {
+        bool removed = false;
+        for (int i = anchors.Count - 1; i >= 0; --i)
+        {
+            if (anchors[i] == null)
+            {
+                anchors.RemoveAt(i);
+                removed = true;
+            }
+        }
+
+        if (!removed)
+            return false;
+
+        if (anchors.Count == 0)
+        {
+            current = null;
+            cursor = -1;
+            return true;
+        }
+
+        if (current != null)
+        {
+            int existingIndex = anchors.IndexOf(current);
+            if (existingIndex >= 0)
+            {
+                cursor = existingIndex;
+            }
+            else
+            {
+                current = null;
+                cursor = Mathf.Clamp(cursor, -1, anchors.Count - 1);
+            }
+        }
+        else
+        {
+            cursor = Mathf.Clamp(cursor, -1, anchors.Count - 1);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Nettoie les caches existants des ancres globales puis tente de récupérer
+    /// tous les <see cref="LookAtBattleTarget"/> présents dans la scène afin de
+    /// constituer les séquences côté joueurs et ennemis.
+    /// </summary>
+    private void CacheBattlefieldAnchors()
+    {
+        Transform previousPlayerAnchor = currentPlayerOverShoulderAnchor;
+        Transform previousEnemyAnchor = currentEnemyOverShoulderAnchor;
+
+        playerOverShoulderAnchors.Clear();
+        enemyOverShoulderAnchors.Clear();
+
+        foreach (var anchor in FindObjectsOfType<LookAtBattleTarget>(includeInactive: true))
+        {
+            Transform anchorTransform = anchor ? anchor.transform : null;
+            if (anchorTransform == null)
+                continue;
+
+            string anchorName = anchorTransform.name;
+            if (anchorName.StartsWith(PlayerOverShoulderAnchorPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                playerOverShoulderAnchors.Add(anchorTransform);
+            }
+            else if (anchorName.StartsWith(EnemyOverShoulderAnchorPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                enemyOverShoulderAnchors.Add(anchorTransform);
+            }
+        }
+
+        playerOverShoulderAnchors.Sort((a, b) => string.Compare(a.name, b.name, StringComparison.OrdinalIgnoreCase));
+        enemyOverShoulderAnchors.Sort((a, b) => string.Compare(a.name, b.name, StringComparison.OrdinalIgnoreCase));
+
+        battlefieldAnchorsCached = playerOverShoulderAnchors.Count > 0 || enemyOverShoulderAnchors.Count > 0;
+        if (!battlefieldAnchorsCached)
+        {
+            currentPlayerOverShoulderAnchor = null;
+            currentEnemyOverShoulderAnchor = null;
+            playerOverShoulderCursor = -1;
+            enemyOverShoulderCursor = -1;
+
+            if (!hasLoggedMissingOverShoulderAnchors)
+            {
+                Debug.LogWarning("[BattleCameraManager] Aucun point 'CMVPoint_OverShoulderLookTarget_*' détecté dans la scène.");
+                hasLoggedMissingOverShoulderAnchors = true;
+            }
+
+            return;
+        }
+
+        hasLoggedMissingOverShoulderAnchors = false;
+
+        if (previousPlayerAnchor != null)
+        {
+            int index = playerOverShoulderAnchors.IndexOf(previousPlayerAnchor);
+            if (index >= 0)
+            {
+                currentPlayerOverShoulderAnchor = previousPlayerAnchor;
+                playerOverShoulderCursor = index;
+            }
+            else
+            {
+                currentPlayerOverShoulderAnchor = null;
+                playerOverShoulderCursor = -1;
+            }
+        }
+        else
+        {
+            currentPlayerOverShoulderAnchor = null;
+            playerOverShoulderCursor = Mathf.Clamp(playerOverShoulderCursor, -1, playerOverShoulderAnchors.Count - 1);
+        }
+
+        if (previousEnemyAnchor != null)
+        {
+            int index = enemyOverShoulderAnchors.IndexOf(previousEnemyAnchor);
+            if (index >= 0)
+            {
+                currentEnemyOverShoulderAnchor = previousEnemyAnchor;
+                enemyOverShoulderCursor = index;
+            }
+            else
+            {
+                currentEnemyOverShoulderAnchor = null;
+                enemyOverShoulderCursor = -1;
+            }
+        }
+        else
+        {
+            currentEnemyOverShoulderAnchor = null;
+            enemyOverShoulderCursor = Mathf.Clamp(enemyOverShoulderCursor, -1, enemyOverShoulderAnchors.Count - 1);
+        }
+    }
+
+    /// <summary>
+    /// Vérifie que les ancres collectées n'ont pas été détruites puis relance un
+    /// scan si nécessaire pour intégrer les nouveaux points ajoutés à la scène.
+    /// </summary>
+    private void RemoveDestroyedBattlefieldAnchors()
+    {
+        bool removedPlayer = RemoveNullAnchors(playerOverShoulderAnchors, ref currentPlayerOverShoulderAnchor, ref playerOverShoulderCursor);
+        bool removedEnemy = RemoveNullAnchors(enemyOverShoulderAnchors, ref currentEnemyOverShoulderAnchor, ref enemyOverShoulderCursor);
+
+        if (removedPlayer || removedEnemy)
+            battlefieldAnchorsCached = false;
+    }
+
+    /// <summary>
+    /// Sélectionne l'ancre suivante (ou actuelle) pour le plan épaule associé à
+    /// une unité. Le paramètre <paramref name="advance"/> permet de progresser
+    /// dans la séquence pour varier les cadrages d'une invocation à l'autre.
+    /// </summary>
+    private Transform GetBattlefieldOverShoulderAnchor(CharacterUnit unit, bool advance)
+    {
+        if (unit == null)
+            return null;
+
+        RemoveDestroyedBattlefieldAnchors();
+
+        if (!battlefieldAnchorsCached)
+            CacheBattlefieldAnchors();
+
+        bool isEnemyUnit = unit.Data != null && unit.Data.characterType == CharacterType.EnemyUnit;
+        return isEnemyUnit
+            ? SelectOverShoulderAnchor(enemyOverShoulderAnchors, ref enemyOverShoulderCursor, ref currentEnemyOverShoulderAnchor, advance)
+            : SelectOverShoulderAnchor(playerOverShoulderAnchors, ref playerOverShoulderCursor, ref currentPlayerOverShoulderAnchor, advance);
+    }
+
+    /// <summary>
+    /// Implémente la logique de sélection circulaire sur une liste d'ancres
+    /// donnée. Le curseur est stocké par référence pour suivre l'avancement.
+    /// </summary>
+    private Transform SelectOverShoulderAnchor(
+        List<Transform> anchors,
+        ref int cursor,
+        ref Transform current,
+        bool advance)
+    {
+        if (anchors == null || anchors.Count == 0)
+            return null;
+
+        if (current != null)
+        {
+            int existingIndex = anchors.IndexOf(current);
+            if (existingIndex >= 0)
+            {
+                cursor = existingIndex;
+            }
+            else
+            {
+                current = null;
+            }
+        }
+
+        if (advance || current == null)
+        {
+            cursor = (cursor + 1) % anchors.Count;
+            current = anchors[cursor];
+        }
+
+        return current;
     }
 
     /// <summary>Replace toutes les caméras "CMV_" sur leurs points d'ancrage respectifs.</summary>
@@ -269,6 +546,18 @@ public class BattleCameraManager : MonoBehaviour
 
         if (anchorOverride != null)
             return anchorOverride;
+
+        if (string.Equals(config.Suffix, OverShoulderLookTargetSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            // Les plans épaule peuvent désormais s'appuyer sur les ancres globales
+            // « CMVPoint_OverShoulderLookTarget_* » afin d'offrir davantage de
+            // variété sans dupliquer les Cinemachine. On tente donc de récupérer
+            // l'un de ces points avant de revenir au fallback historique sur
+            // l'unité elle-même.
+            Transform battlefieldAnchor = GetBattlefieldOverShoulderAnchor(unit, advance: false);
+            if (battlefieldAnchor != null)
+                return battlefieldAnchor;
+        }
 
         string pointName = $"CMVPoint_{config.Suffix}";
         Transform anchor = unit.GetCameraAnchor(pointName);
@@ -378,9 +667,20 @@ public class BattleCameraManager : MonoBehaviour
             return;
         }
 
-        RefreshCameraPlacement(cameraName, CameraBindings.TryGetValue(cameraName, out var config)
-            ? config
-            : new CameraBindingConfig(CameraAnchorOwner.Caster, cameraName.Replace("CMV_", string.Empty), false));
+        CameraBindingConfig config = CameraBindings.TryGetValue(cameraName, out var binding)
+            ? binding
+            : new CameraBindingConfig(CameraAnchorOwner.Caster, cameraName.Replace("CMV_", string.Empty), false);
+
+        if (string.Equals(config.Suffix, OverShoulderLookTargetSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            // On avance dans la séquence uniquement lorsqu'une caméra d'épaule est
+            // demandée. Ainsi la prochaine apparition de ce plan proposera un
+            // point de vue différent parmi les CMVPoint_OverShoulderLookTarget_*.
+            CharacterUnit ownerUnit = ResolveAnchorOwner(config.Owner);
+            GetBattlefieldOverShoulderAnchor(ownerUnit, advance: true);
+        }
+
+        RefreshCameraPlacement(cameraName, config);
 
         currentCameraName = cameraName;
         DisplayCameraWithBlend(cameraName, blendTime, overrideStyle);


### PR DESCRIPTION
## Summary
- prise en charge des ancres CMVPoint_OverShoulderLookTarget_Player_* et Enemy_* directement dans le BattleCameraManager
- mise en cache, nettoyage et sélection cyclique des nouveaux points pour faire voyager la BattleCamera sans multiplier les Cinemachine
- commentaires détaillés sur le fonctionnement et les nouvelles étapes de sélection

## Testing
- not run (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68d41a5a50a8832584294c890f29b6d1