### PR TITLE
Aligne les BattleCameraRole des moves et items sur les ancres partagées

### DIFF
--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -53,7 +53,7 @@ MonoBehaviour:
   performingTimeline: {fileID: 11400000, guid: 65cda8e58c0ff6344b3607c580c09e0a, type: 2}
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 2
-  performingCameraRole: 2
+  performingCameraRole: 8
   retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -58,5 +58,5 @@ MonoBehaviour:
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 5
-  performingCameraRole: 2
+  performingCameraRole: 8
   retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -56,5 +56,5 @@ MonoBehaviour:
   performingTimeline: {fileID: 11400000, guid: 332f64de2f14fea46b6df0d3bc73ee75, type: 2}
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 2
-  performingCameraRole: 2
+  performingCameraRole: 8
   retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -59,6 +59,6 @@ MonoBehaviour:
   performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 2
-  performingCameraRole: 2
+  performingCameraRole: 8
   retreatCameraRole: 8
   preparingToPerformingCameraDelay: 0

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -58,5 +58,5 @@ MonoBehaviour:
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 5
-  performingCameraRole: 2
+  performingCameraRole: 8
   retreatCameraRole: 3

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -93,10 +93,15 @@ public class ItemData : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    [Tooltip("Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle, OverShoulderCasterLookTarget = ancre Camera_Shoulder_Stay, OverShoulderCasterToTarget = ancre Camera_Shoulder_Moving).")]
+    [Tooltip(
+        "Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle, " +
+        "OverShoulderCasterLookTarget = ancre partagée CMVPoint_OverShoulderLookTarget_*, " +
+        "OverShoulderCasterToTarget = ancre portée par l'utilisateur).")]
     public BattleCameraRole preparingCameraRole = BattleCameraRole.MainMenuIdle;
-    [Tooltip("Plan cinématique utilisé pendant l'utilisation (None = conserver la caméra précédente).")]
-    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;
+    [Tooltip(
+        "Plan cinématique utilisé pendant l'utilisation (None = conserver la caméra précédente). " +
+        "Préférez OverShoulderCasterLookTarget pour bénéficier du suivi partagé CMVPoint_OverShoulderLookTarget_*.")]
+    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterLookTarget;
     [Tooltip("Plan cinématique utilisé lors du repli (None = conserver la caméra précédente).")]
     public BattleCameraRole retreatCameraRole = BattleCameraRole.TargetReaction;
 
@@ -124,12 +129,37 @@ public class ItemData : ScriptableObject
             return;
 
         // Applique les valeurs par défaut uniquement si les champs sont vides.
+        bool cameraSettingsUpdated = false;
+
         if (preparingCameraRole == BattleCameraRole.None)
+        {
             preparingCameraRole = reference.preparingCameraRole;
+            cameraSettingsUpdated = true;
+        }
+
         if (performingCameraRole == BattleCameraRole.None)
+        {
             performingCameraRole = reference.performingCameraRole;
+            cameraSettingsUpdated = true;
+        }
+        else if (performingCameraRole == BattleCameraRole.OverShoulderCasterToTarget &&
+                 reference.performingCameraRole == BattleCameraRole.OverShoulderCasterLookTarget)
+        {
+            // Migration automatique des anciens items qui utilisaient la caméra mobile.
+            // On privilégie désormais OverShoulderCasterLookTarget pour aligner les plans
+            // avec les nouvelles ancres partagées.
+            performingCameraRole = BattleCameraRole.OverShoulderCasterLookTarget;
+            cameraSettingsUpdated = true;
+        }
+
         if (retreatCameraRole == BattleCameraRole.None)
+        {
             retreatCameraRole = reference.retreatCameraRole;
+            cameraSettingsUpdated = true;
+        }
+
+        if (cameraSettingsUpdated)
+            EditorUtility.SetDirty(this);
     }
 #endif
 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -145,12 +145,18 @@ public class MusicalMoveSO : ScriptableObject
     public TimelineAsset retreatTimeline;
 
     [Header("Caméras par phase")]
-    [Tooltip("Plan cinématique utilisé durant la préparation (None = conserver la caméra courante, OverShoulderCasterLookTarget = ancre Camera_Shoulder_Stay, OverShoulderCasterToTarget = ancre Camera_Shoulder_Moving).")]
+    [Tooltip(
+        "Plan cinématique utilisé durant la préparation (None = conserver la caméra courante, " +
+        "OverShoulderCasterLookTarget = ancre CMVPoint_OverShoulderLookTarget_* partagée avec le groupe, " +
+        "OverShoulderCasterToTarget = ancre CMVPoint_OverShoulder_CasterToTarget portée par l'unité).")]
     public BattleCameraRole preparingCameraRole = BattleCameraRole.WideEstablish;
     [Tooltip("Temps (en secondes) durant lequel la caméra conserve le cadrage de préparation avant de basculer sur celui d'exécution.")]
     public float preparingToPerformingCameraDelay = 0f;
-    [Tooltip("Plan cinématique utilisé durant l'exécution (None = conserver la caméra précédente).")]
-    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterToTarget;
+    [Tooltip(
+        "Plan cinématique utilisé durant l'exécution (None = conserver la caméra précédente). " +
+        "OverShoulderCasterLookTarget exploite désormais les points partagés CMVPoint_OverShoulderLookTarget_* pour " +
+        "garantir une mise en joue stable vers la cible.")]
+    public BattleCameraRole performingCameraRole = BattleCameraRole.OverShoulderCasterLookTarget;
     [Tooltip("Plan cinématique utilisé durant le repli (None = conserver la caméra précédente).")]
     public BattleCameraRole retreatCameraRole = BattleCameraRole.ClosePushCaster;
 
@@ -197,12 +203,37 @@ public class MusicalMoveSO : ScriptableObject
         // celle de "MusicalMove_Rhapsodie". Les concepteurs peuvent ensuite
         // remplacer ces valeurs manuellement selon les besoins spécifiques
         // du nouveau move.
+        bool cameraSettingsUpdated = false;
+
         if (preparingCameraRole == BattleCameraRole.None)
+        {
             preparingCameraRole = reference.preparingCameraRole;
+            cameraSettingsUpdated = true;
+        }
+
         if (performingCameraRole == BattleCameraRole.None)
+        {
             performingCameraRole = reference.performingCameraRole;
+            cameraSettingsUpdated = true;
+        }
+        else if (performingCameraRole == BattleCameraRole.OverShoulderCasterToTarget &&
+                 reference.performingCameraRole == BattleCameraRole.OverShoulderCasterLookTarget)
+        {
+            // Migration automatique : les anciens assets utilisaient le plan "CasterToTarget".
+            // On les fait désormais pointer vers "OverShoulderCasterLookTarget" qui s'aligne
+            // sur les nouvelles ancres partagées "CMVPoint_OverShoulderLookTarget_*".
+            performingCameraRole = BattleCameraRole.OverShoulderCasterLookTarget;
+            cameraSettingsUpdated = true;
+        }
+
         if (retreatCameraRole == BattleCameraRole.None)
+        {
             retreatCameraRole = reference.retreatCameraRole;
+            cameraSettingsUpdated = true;
+        }
+
+        if (cameraSettingsUpdated)
+            EditorUtility.SetDirty(this);
     }
 #endif
 

--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -284,6 +284,16 @@ public class BattleCameraManager : MonoBehaviour
         if (targetAnchorOverride != null)
             return targetAnchorOverride;
 
+        // Tentative 1 : exploiter les nouveaux points globaux "CMVPoint_OverShoulderLookTarget_*".
+        // Ces points ne sont pas portés par l'unité directement, mais regroupés sous le parent
+        // contenant toute l'escouade (alliée ou ennemie). On commence par interroger la cible,
+        // puis on retente avec le lanceur (utile durant la préparation d'une action sans cible).
+        Transform sharedLookAnchor = ResolveSharedLookTargetAnchor(currentTarget);
+        if (sharedLookAnchor == null)
+            sharedLookAnchor = ResolveSharedLookTargetAnchor(currentCaster);
+        if (sharedLookAnchor != null)
+            return sharedLookAnchor;
+
         if (currentTarget != null)
         {
             Transform reactionPoint = currentTarget.GetCameraAnchor("CMVPoint_TargetReaction");
@@ -291,6 +301,81 @@ public class BattleCameraManager : MonoBehaviour
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Recherche les ancres communes "CMVPoint_OverShoulderLookTarget_*".
+    /// </summary>
+    /// <remarks>
+    /// Ces points sont placés sur le parent contenant l'ensemble des combattants d'un camp.
+    /// Ils permettent d'orienter la caméra épaulière vers un repère stable même lorsque la
+    /// cible se déplace ou disparaît momentanément. Chaque point est suffixé par un indice
+    /// (01 à 03) correspondant à la position de l'unité dans la hiérarchie.
+    /// </remarks>
+    private Transform ResolveSharedLookTargetAnchor(CharacterUnit referenceUnit)
+    {
+        if (referenceUnit == null)
+            return null;
+
+        Transform parent = referenceUnit.transform != null ? referenceUnit.transform.parent : null;
+        if (parent == null)
+            return null;
+
+        bool isPlayer = referenceUnit.Data != null && referenceUnit.Data.isPlayerControlled;
+
+        // On détermine l'indice de l'unité à l'intérieur de son groupe (1..N) afin de sélectionner
+        // l'ancre dédiée. L'ordre est simplement basé sur la hiérarchie des enfants du parent commun.
+        int slotIndex = ResolveUnitSlotIndex(referenceUnit, parent, isPlayer);
+        if (slotIndex <= 0)
+            return null;
+
+        string prefix = isPlayer
+            ? "CMVPoint_OverShoulderLookTarget_Player_"
+            : "CMVPoint_OverShoulderLookTarget_Enemy_";
+        string anchorName = prefix + slotIndex.ToString("00");
+
+        // Les ancres peuvent être nichées à n'importe quel niveau sous le parent : on parcourt
+        // récursivement la hiérarchie en incluant les objets désactivés pour couvrir tous les cas.
+        foreach (var child in parent.GetComponentsInChildren<Transform>(includeInactive: true))
+        {
+            if (child == null)
+                continue;
+
+            if (string.Equals(child.name, anchorName, StringComparison.OrdinalIgnoreCase))
+                return child;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Calcule la position (1..N) de l'unité au sein de son groupe afin de choisir l'ancre adaptée.
+    /// </summary>
+    private static int ResolveUnitSlotIndex(CharacterUnit referenceUnit, Transform groupParent, bool isPlayer)
+    {
+        if (referenceUnit == null || groupParent == null)
+            return -1;
+
+        int index = 0;
+        foreach (Transform child in groupParent)
+        {
+            if (child == null)
+                continue;
+
+            CharacterUnit childUnit = child.GetComponent<CharacterUnit>();
+            if (childUnit == null || childUnit.Data == null)
+                continue;
+
+            if (childUnit.Data.isPlayerControlled != isPlayer)
+                continue; // On ignore les unités appartenant au camp opposé.
+
+            index++;
+
+            if (childUnit == referenceUnit)
+                return index;
+        }
+
+        return -1;
     }
 
     /// <summary>Enregistre l'unité actuellement active (tour en cours).</summary>


### PR DESCRIPTION
## Summary
- met à jour MusicalMoveSO et ItemData pour privilégier le rôle OverShoulderCasterLookTarget et migrer automatiquement les anciens assets
- documente via des tooltips détaillés l’utilisation des nouvelles ancres CMVPoint_OverShoulderLookTarget_*
- aligne les assets de moves et d’items existants sur le nouveau cadrage épaulière partagé

## Testing
- non testé (logiciel Unity hors environnement d’exécution)


------
https://chatgpt.com/codex/tasks/task_e_68d42f4b281883258440840ad4f0bf9e