### PR TITLE
Synchroniser l'animation defensive avec la timeline de preparation

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -273,7 +273,21 @@ public class NewBattleManager : MonoBehaviour
             // le joueur, notamment lorsque plusieurs actions consécutives visent la même cible.
             if (_currentTargetCharacter != null)
             {
-                _currentTargetCharacter.PlayPrepareToUndergoAnimation();
+                // 🎯 Pendant les phases de sélection on relance toujours l'animation
+                // de préparation pour souligner la menace immédiate. En revanche,
+                // lorsque la séquence du MusicalMove est en cours et que la
+                // timeline de préparation du lanceur doit garder la priorité,
+                // on s'abstient de relancer l'animation pour éviter un doublon
+                // avant que RhythmQTEManager ne le fasse lui-même à la fin de
+                // ladite timeline.
+                bool isSelectionState = IsTargetSelectionState(currentBattleState);
+                bool shouldDelayDueToMove = RhythmQTEManager.Instance != null
+                    && RhythmQTEManager.Instance.ShouldDelayTargetPreparationAnimation;
+
+                if (isSelectionState || !shouldDelayDueToMove)
+                {
+                    _currentTargetCharacter.PlayPrepareToUndergoAnimation();
+                }
             }
         }
     }

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -285,6 +285,21 @@ public class RhythmQTEManager : MonoBehaviour
 
     // Séquence du Musicalmove - Ajouter autant de méthodes que d'effets durant le move
     /// <summary>
+    /// Indique si l'animation « PrepareToUndergo » doit être retardée pour la cible
+    /// tant que la timeline de préparation du lanceur n'est pas terminée.
+    /// Cette information est exposée afin que les autres gestionnaires (comme
+    /// le NewBattleManager) puissent synchroniser leurs propres feedbacks visuels.
+    /// </summary>
+    public bool ShouldDelayTargetPreparationAnimation => delayTargetPreparationAnimationForCurrentMove;
+
+    /// <summary>
+    /// Drapeau interne mémorisant l'état du retard à appliquer à l'animation
+    /// de préparation de la cible. En évitant une variable locale, on rend
+    /// l'information consultable par d'autres systèmes durant toute la routine.
+    /// </summary>
+    private bool delayTargetPreparationAnimationForCurrentMove = false;
+
+    /// <summary>
     /// Orchestration complète d'un MusicalMove du déplacement à la résolution.
     /// </summary>
     public IEnumerator MusicalMoveRoutine(MusicalMoveSO move, CharacterUnit caster, CharacterUnit target)
@@ -321,7 +336,10 @@ public class RhythmQTEManager : MonoBehaviour
                 tauntPlayed = true;
             }
         };
+        // Lorsque l'on dispose d'une timeline de préparation, on retarde la posture
+        // défensive de la cible afin de ne pas parasiter la mise en scène du lanceur.
         bool delayTargetPreparationAnimation = move != null && move.preparingTimeline != null;
+        delayTargetPreparationAnimationForCurrentMove = delayTargetPreparationAnimation;
         if (target != null)
         {
             target.OnDeath += deathHandler;
@@ -480,6 +498,7 @@ public class RhythmQTEManager : MonoBehaviour
         currentMove = null;
         currentCaster = null;
         currentTarget = null;
+        delayTargetPreparationAnimationForCurrentMove = false; // ✅ Réinitialisation du drapeau de report
 
         // Restaure la caméra par défaut en fin de move.
         // Avant de restaurer la caméra par défaut, on s'assure qu'aucun délai


### PR DESCRIPTION
## Résumé
- expose dans le RhythmQTEManager un indicateur public indiquant si l'animation défensive de la cible doit être retardée jusqu’à la fin de la timeline de préparation
- réinitialise systématiquement ce drapeau en fin de routine pour éviter tout état persistant indésirable
- adapte le NewBattleManager pour ne déclencher l’animation « PrepareToUndergo » qu’en l’absence de délai ou durant les phases de sélection, supprimant ainsi le double déclenchement autour de la timeline de préparation

## Tests
- Aucun test automatique disponible dans l’environnement

------
https://chatgpt.com/codex/tasks/task_e_68d58d9a37f8832593d74add600152fb