### PR TITLE
Améliore les transitions vers l'idle en combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -37,6 +37,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     private bool hasLoggedMultipleChildAnimatorsWithController;
     private AwakeState awakeState;
 
+    /// <summary>Hash du state Animator "Idle_Battle" pour accélérer les vérifications de disponibilité.</summary>
+    private static readonly int AnimatorStateIdleBattle = Animator.StringToHash("Idle_Battle");
+    /// <summary>Durée standard (en secondes) appliquée aux fondus d'animations idle.</summary>
+    private const float IdleCrossFadeDurationSeconds = 0.1f;
+
     // Mise en cache des ancres caméra pour éviter de reparcourir toute la hiérarchie à chaque requête.
     private readonly Dictionary<string, Transform> cachedCameraAnchors = new(StringComparer.OrdinalIgnoreCase);
 
@@ -1366,7 +1371,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         if (animator != null)
         {
-            animator.Play("Idle_Battle");
+            const int baseLayerIndex = 0;
+
+            // Afin d'éviter tout changement brutal d'animation, on favorise un CrossFade lorsque l'état existe.
+            if (animator.HasState(baseLayerIndex, AnimatorStateIdleBattle))
+            {
+                animator.CrossFade(AnimatorStateIdleBattle, IdleCrossFadeDurationSeconds, baseLayerIndex, 0f);
+            }
+            else
+            {
+                // En dernier recours, on conserve Play pour les rigs spéciaux n'ayant pas l'état Idle_Battle déclaré.
+                animator.Play("Idle_Battle");
+            }
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1032,7 +1032,9 @@ public class NewBattleManager : MonoBehaviour
 
             Debug.Log($"[BattleTurnManager] Tour de {unit.name} (ATB: {unit.currentATB})");
             OrientAllUnitsTowardClosestOpponent();
-            unit.animator.Play("Idle_Battle");
+            // On tente d'abord une transition douce via CrossFade afin d'éviter tout accroc visuel lors du retour à l'idle.
+            // Le CharacterUnit encapsule désormais la logique (HasState + fallback Play) pour uniformiser les transitions.
+            unit.PlayIdleAnimation();
 
             // Petite pause avant l'exécution du tour, indépendante du timeScale
             yield return new WaitForSecondsRealtime(0.5f);
@@ -1551,7 +1553,10 @@ public class NewBattleManager : MonoBehaviour
 
             // On évite de forcer l'animation d'attente lorsque l'unité est censée dormir ou rester figée.
             if (!skipIdleAnimation)
-                endingUnit.animator.Play("Idle_Battle");
+            {
+                // Idem que pour le début de tour : on délègue au CharacterUnit pour garantir un fondu systématique.
+                endingUnit.PlayIdleAnimation();
+            }
         }
 
         ChangeBattleState(BattleState.EndTurn);


### PR DESCRIPTION
## Résumé
- Harmonise les retours à l'animation Idle des unités en remplaçant les `Play` directs par des appels centralisés.
- Ajoute un fondu contrôlé vers l'état `Idle_Battle` en vérifiant la présence du state avant de l'utiliser.

## Tests
- Non exécutés (environnement Unity indisponible dans ce contexte).

------
https://chatgpt.com/codex/tasks/task_e_68d59362c7488325984cc9d957f6bfd5