### PR TITLE
Retarder l'animation défensive pendant la timeline de préparation

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1138,10 +1138,18 @@ public class NewBattleManager : MonoBehaviour
         currentMove = move;
         var target = enemy.SelectTargetFromSquad();
 
+        // Anticipe le comportement d'animation de la cible : si le move
+        // dispose d'une timeline de préparation, on retarde sa posture
+        // défensive jusqu'à la fin de ladite timeline pour éviter un doublon.
+        RhythmQTEManager.Instance?.PrimeTargetPreparationAnimation(move);
+
         currentTargetCharacter = target;
 
         if (move == null || target == null)
         {
+            // Sans move ou cible valide on réinitialise immédiatement le drapeau
+            // pour ne pas bloquer les prochaines animations défensives.
+            RhythmQTEManager.Instance?.PrimeTargetPreparationAnimation(null);
             Debug.LogWarning("[EnemyTurn] Aucune attaque ou cible valide !");
             yield break;
         }

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -293,6 +293,22 @@ public class RhythmQTEManager : MonoBehaviour
     public bool ShouldDelayTargetPreparationAnimation => delayTargetPreparationAnimationForCurrentMove;
 
     /// <summary>
+    /// Prépare le comportement d'animation défensive de la cible avant même
+    /// que la routine principale du <see cref="MusicalMoveSO"/> ne débute.
+    /// </summary>
+    /// <param name="upcomingMove">Move qui va être exécuté (peut être nul).</param>
+    public void PrimeTargetPreparationAnimation(MusicalMoveSO upcomingMove)
+    {
+        // On mémorise si l'animation « PrepareToUndergo » doit patienter
+        // jusqu'à la fin de la timeline de préparation du lanceur. Sans
+        // cette anticipation, la cible jouerait sa posture défensive dès
+        // l'assignation par le BattleManager, puis une seconde fois à la fin
+        // de ladite timeline, créant un doublon visuel.
+        bool shouldDelay = upcomingMove != null && upcomingMove.preparingTimeline != null;
+        delayTargetPreparationAnimationForCurrentMove = shouldDelay;
+    }
+
+    /// <summary>
     /// Drapeau interne mémorisant l'état du retard à appliquer à l'animation
     /// de préparation de la cible. En évitant une variable locale, on rend
     /// l'information consultable par d'autres systèmes durant toute la routine.


### PR DESCRIPTION
## Summary
- ajoute une méthode centralisée pour préparer le report de l'animation défensive en fonction de la timeline du move
- utilise cette configuration lors du tour ennemi et la réinitialise immédiatement lorsque le move n'est pas valide afin d'éviter les doublons visuels

## Testing
- Non testé (environnement Unity indisponible dans le conteneur)


------
https://chatgpt.com/codex/tasks/task_e_68d5a145b5808325ae82c326e12e51e7