### PR TITLE
Harmonise les ancres caméra pour les ennemis et l'escouade

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -216,7 +216,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// Vrai pour parcourir également les objets désactivés (utile lorsque certains repères sont masqués dans l'éditeur).
     /// </param>
     /// <returns>La transform correspondant à l'ancre ou <c>null</c> si elle est introuvable.</returns>
-    public Transform GetCameraAnchor(string anchorName, bool includeInactive = true)
+    public Transform GetCameraAnchor(string anchorName, bool includeInactive = true, bool logWarning = true)
     {
         if (string.IsNullOrEmpty(anchorName))
             return null;
@@ -234,12 +234,77 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         Transform located = LocateCameraAnchor(anchorName, includeInactive);
         cachedCameraAnchors[anchorName] = located;
 
-        if (located == null)
+        if (located == null && logWarning)
         {
             Debug.LogWarning($"[CharacterUnit] Ancre caméra '{anchorName}' introuvable sur '{name}'.");
         }
 
         return located;
+    }
+
+    /// <summary>
+    /// Rôle principal associé au point caméra recherché lorsqu'on souhaite
+    /// fournir un override explicite au <see cref="BattleCameraManager"/>.
+    /// </summary>
+    public enum CameraAnchorPurpose
+    {
+        /// <summary>L'ancre doit suivre le lanceur de l'action.</summary>
+        Caster,
+        /// <summary>L'ancre doit suivre la cible de l'action.</summary>
+        Target
+    }
+
+    /// <summary>
+    /// Détermine un point caméra pertinent pour l'unité selon le rôle
+    /// souhaité (lanceur ou cible). Les ancres déclarées via les GameObjects
+    /// « CMVPoint_… » sont privilégiées afin de reproduire les cadrages
+    /// définis par les artistes, puis un repli progressif est appliqué vers
+    /// l'Animator de binding et, en dernier recours, vers le transform racine.
+    /// </summary>
+    /// <param name="purpose">Indique si l'on cherche un point côté lanceur ou côté cible.</param>
+    /// <param name="includeInactive">
+    /// Vrai pour considérer également les ancres désactivées dans la hiérarchie.
+    /// </param>
+    /// <returns>
+    /// Le transform de l'ancre dédiée, celui de l'Animator utilisé pour les bindings,
+    /// ou, à défaut, le transform racine de l'unité.
+    /// </returns>
+    public Transform GetDefaultCameraAnchor(CameraAnchorPurpose purpose, bool includeInactive = true)
+    {
+        // ⚖️ Liste de priorité différente selon le rôle recherché :
+        //     * côté lanceur -> on privilégie les points « OverShoulder » pour cadrer l'action.
+        //     * côté cible   -> on vise d'abord la réaction puis les autres plans utiles.
+        string[] preferredAnchors = purpose == CameraAnchorPurpose.Caster
+            ? new[]
+            {
+                "CMVPoint_OverShoulder_CasterToTarget",
+                "CMVPoint_OverShoulder_CasterLookTarget",
+                "CMVPoint_TargetReaction",
+                "CMVPoint_OrbitAroundUnit"
+            }
+            : new[]
+            {
+                "CMVPoint_TargetReaction",
+                "CMVPoint_OverShoulder_CasterLookTarget",
+                "CMVPoint_OverShoulder_CasterToTarget",
+                "CMVPoint_OrbitAroundUnit"
+            };
+
+        foreach (string anchorName in preferredAnchors)
+        {
+            Transform anchor = GetCameraAnchor(anchorName, includeInactive, logWarning: false);
+            if (anchor != null)
+                return anchor;
+        }
+
+        // 🎭 Aucun point spécifique n'est présent : on retombe sur l'Animator qui
+        // sert déjà aux timelines, garantissant un pivot cohérent pour la caméra.
+        Animator bindingAnimator = GetCasterAnimator();
+        if (bindingAnimator != null)
+            return bindingAnimator.transform;
+
+        // 🔚 Dernier recours : le transform racine pour ne jamais renvoyer null.
+        return transform;
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2647,12 +2647,9 @@ public class NewBattleManager : MonoBehaviour
         }
 
         // Confie la priorité caméra à la Cinemachine dédiée à l'attente d'objet.
-        Transform casterCameraAnchor = null;
-        if (currentCharacterUnit != null)
-        {
-            GameObject casterBinding = currentCharacterUnit.GetCasterBindingTarget();
-            casterCameraAnchor = casterBinding != null ? casterBinding.transform : null;
-        }
+        Transform casterCameraAnchor = currentCharacterUnit != null
+            ? currentCharacterUnit.GetDefaultCameraAnchor(CharacterUnit.CameraAnchorPurpose.Caster)
+            : null;
 
         BattleCameraManager.Instance?.ConfigureActionTargets(
             currentCharacterUnit,

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -370,26 +370,36 @@ public class RhythmQTEManager : MonoBehaviour
             }
         }
         GameObject casterAnimatorGO = caster.GetCasterBindingTarget();
-        // 🎯 La caméra se centre désormais directement sur l'unité ciblée du mouvement.
-        // Si aucune cible n'est définie (attaque de zone, soin personnel, etc.),
-        // on utilise l'Animator du lanceur pour conserver un ancrage valable.
-        // 🧭 Préparation des points d'ancrage pour la caméra de combat.
-        // - L'exécution doit suivre la cible directe du sort.
-        // - Les phases de préparation et de repli se recentrent sur le lanceur
-        //   pour garder une mise en scène cohérente.
+
+        // 🎯 Préparation des points d'ancrage caméra : on privilégie toujours
+        //     les « CMVPoint_… » dédiés pour éviter que la caméra ne retombe sur
+        //     les pieds de l'unité lorsque seul l'Animator racine est disponible
+        //     (cas fréquent sur certains ennemis comme CryingAngel).
+        Transform casterCameraAnchor = caster != null
+            ? caster.GetDefaultCameraAnchor(CharacterUnit.CameraAnchorPurpose.Caster)
+            : null;
+        GameObject casterCameraTarget = casterCameraAnchor != null
+            ? casterCameraAnchor.gameObject
+            : (casterAnimatorGO ?? (caster != null ? caster.gameObject : null));
+
+        Transform performingCameraAnchor = null;
         GameObject performingCameraTarget = null;
         if (target != null)
         {
-            // On privilégie l'ancre animée de la cible pour obtenir un cadrage stable.
-            performingCameraTarget = target.GetCasterBindingTarget();
-            if (performingCameraTarget == null)
-                performingCameraTarget = target.gameObject;
+            performingCameraAnchor = target.GetDefaultCameraAnchor(CharacterUnit.CameraAnchorPurpose.Target);
+            performingCameraTarget = performingCameraAnchor != null
+                ? performingCameraAnchor.gameObject
+                : (target.GetCasterBindingTarget() ?? target.gameObject);
+            if (performingCameraTarget != null && performingCameraAnchor == null)
+                performingCameraAnchor = performingCameraTarget.transform; // Garantit un transform valide pour l'override.
         }
         else
         {
-            performingCameraTarget = casterAnimatorGO; // 🔁 Retombe sur le lanceur si aucune cible
+            performingCameraAnchor = casterCameraAnchor ?? (casterAnimatorGO != null
+                ? casterAnimatorGO.transform
+                : (caster != null ? caster.transform : null));
+            performingCameraTarget = performingCameraAnchor != null ? performingCameraAnchor.gameObject : null;
         }
-        GameObject casterCameraTarget = casterAnimatorGO; // 📌 Ancre sur le lanceur pour préparation et repli
         // Détermine si une timeline caméra couvrant toute l'action est disponible.
         // Ce système est remplacé par l'utilisation de caméras Cinemachine dédiées.
         bool useOverlay = false;
@@ -399,8 +409,8 @@ public class RhythmQTEManager : MonoBehaviour
             caster,
             target,
             null,
-            casterCameraTarget != null ? casterCameraTarget.transform : null,
-            performingCameraTarget != null ? performingCameraTarget.transform : null);
+            casterCameraAnchor,
+            performingCameraAnchor);
 
         // Éventuel délai de pré-animation.
         // 🔄 Cette attente se produit désormais AVANT toute timeline
@@ -564,24 +574,32 @@ public class RhythmQTEManager : MonoBehaviour
         
         Animator animator = caster.GetCasterAnimator();
         GameObject casterAnimatorGO = animator != null ? animator.gameObject : null;
-        // 🎯 La caméra se positionne directement sur l'unité ciblée par l'objet.
-        // En l'absence de cible (consommable global, soin personnel...),
-        // on conserve le lanceur comme ancre pour éviter un décalage brusque.
-        // 🧭 Détermination des cibles de caméra pour les différentes phases :
-        //   * exécution -> focus sur la cible de l'objet si elle existe ;
-        //   * préparation et repli -> recentrage sur le lanceur.
+
+        // 🎯 Même logique que pour les MusicalMoves : on favorise les ancres
+        //     déclarées pour garantir un cadrage cohérent entre Squads et Ennemis.
+        Transform casterCameraAnchor = caster.GetDefaultCameraAnchor(CharacterUnit.CameraAnchorPurpose.Caster);
+        GameObject casterCameraTarget = casterCameraAnchor != null
+            ? casterCameraAnchor.gameObject
+            : (casterAnimatorGO ?? caster.gameObject);
+
+        Transform performingCameraAnchor = null;
         GameObject performingCameraTarget = null;
         if (target != null)
         {
-            performingCameraTarget = target.GetCasterBindingTarget();
-            if (performingCameraTarget == null)
-                performingCameraTarget = target.gameObject;
+            performingCameraAnchor = target.GetDefaultCameraAnchor(CharacterUnit.CameraAnchorPurpose.Target);
+            performingCameraTarget = performingCameraAnchor != null
+                ? performingCameraAnchor.gameObject
+                : (target.GetCasterBindingTarget() ?? target.gameObject);
+            if (performingCameraTarget != null && performingCameraAnchor == null)
+                performingCameraAnchor = performingCameraTarget.transform;
         }
         else
         {
-            performingCameraTarget = casterAnimatorGO; // 🔁 Retombe sur le lanceur en absence de cible
+            performingCameraAnchor = casterCameraAnchor ?? (casterAnimatorGO != null
+                ? casterAnimatorGO.transform
+                : caster.transform);
+            performingCameraTarget = performingCameraAnchor != null ? performingCameraAnchor.gameObject : null;
         }
-        GameObject casterCameraTarget = casterAnimatorGO; // 📌 Référence fixe sur le lanceur
 
         // L'ancien système de timeline caméra est remplacé par les caméras Cinemachine.
         bool useOverlay = false;
@@ -591,8 +609,8 @@ public class RhythmQTEManager : MonoBehaviour
             caster,
             target,
             null,
-            casterCameraTarget != null ? casterCameraTarget.transform : null,
-            performingCameraTarget != null ? performingCameraTarget.transform : null);
+            casterCameraAnchor,
+            performingCameraAnchor);
 
         // --- Phase de préparation ---
         StartTimelinePhase(


### PR DESCRIPTION
## Résumé
- ajoute une méthode utilitaire sur CharacterUnit pour déterminer une ancre caméra par défaut selon le rôle
- met à jour RhythmQTEManager afin que les MusicalMoves et Items utilisent les ancres CMVPoint si disponibles avant de retomber sur les fallback
- aligne NewBattleManager sur cette nouvelle logique pour l'ouverture du menu d'objets

## Tests
- non effectués (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68d7d637999083258836453f619840f2