### PR TITLE
Restreindre les inputs au lancement du combat

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.InputSystem;
 using System.Collections;
+using System.Collections.Generic;
 
 #if UNITY_EDITOR
 // Directives réservées à l'éditeur pour l'inspecteur personnalisé.
@@ -20,6 +21,20 @@ public class InputsManager : MonoBehaviour
     private Coroutine passRoutine;
 
     private InputActionMap[] allMaps;
+
+    /// <summary>
+    /// Liste temporaire des actions du mapping Battle mises en pause pendant
+    /// l'introduction du combat. Elle permet de restaurer précisément l'état
+    /// des contrôles une fois la cinématique terminée.
+    /// </summary>
+    private readonly List<InputAction> battleActionsDisabledDuringIntro = new();
+
+    /// <summary>
+    /// Indique si la restriction "Confirm uniquement" est active. Ce drapeau
+    /// évite d'empiler plusieurs appels successifs et garantit une remise à
+    /// zéro propre lorsque les menus sont à nouveau disponibles.
+    /// </summary>
+    private bool battleIntroRestrictionActive = false;
 
 
     /// <summary>
@@ -156,6 +171,92 @@ public class InputsManager : MonoBehaviour
         // 2) on ré-active le sous-ensemble voulu
         foreach (var m in mapsToEnable)
             m.Enable();
+    }
+
+    /// <summary>
+    /// Restreint temporairement les contrôles au seul bouton "Confirm" du mapping Battle.
+    /// Cette méthode est invoquée au début d'un combat pour éviter toute interaction
+    /// prématurée avec les menus tant que les unités terminent leurs animations
+    /// d'introduction.
+    /// </summary>
+    public void RestrictInputsToBattleConfirm()
+    {
+        if (playerInputs == null)
+            return;
+
+        if (battleIntroRestrictionActive)
+            return;
+
+        battleIntroRestrictionActive = true;
+
+        // On s'assure que seul le mapping Battle est actif afin de bloquer immédiatement
+        // les contrôles d'exploration ou des menus annexes.
+        ActivateOnly(playerInputs.Battle.Get());
+
+        var confirmAction = playerInputs.Battle.Confirm;
+        var battleMap = playerInputs.Battle.Get();
+
+        if (battleMap == null)
+        {
+            battleIntroRestrictionActive = false;
+            return;
+        }
+
+        // Dans le doute, on garantit que Confirm est bien opérationnel pour permettre
+        // au joueur de valider les messages affichés pendant la transition (ex : écran Versus).
+        if (confirmAction != null && !confirmAction.enabled)
+            confirmAction.Enable();
+
+        battleActionsDisabledDuringIntro.Clear();
+
+        // Chaque action du mapping, à l'exception de Confirm, est désactivée jusqu'à la fin
+        // de l'introduction. On mémorise la liste pour pouvoir la restaurer fidèlement.
+        foreach (var action in battleMap.actions)
+        {
+            if (action == null || action == confirmAction)
+                continue;
+
+            if (action.enabled)
+            {
+                action.Disable();
+                battleActionsDisabledDuringIntro.Add(action);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Restaure l'intégralité du mapping Battle après la cinématique d'introduction.
+    /// Les actions précédemment suspendues sont réactivées une par une pour retrouver
+    /// un contrôle complet des menus de combat.
+    /// </summary>
+    public void RestoreBattleInputsAfterIntro()
+    {
+        if (playerInputs == null)
+            return;
+
+        if (!battleIntroRestrictionActive)
+            return;
+
+        var battleMap = playerInputs.Battle.Get();
+        if (battleMap == null)
+        {
+            battleIntroRestrictionActive = false;
+            battleActionsDisabledDuringIntro.Clear();
+            return;
+        }
+
+        // On conserve l'exclusivité du mapping Battle afin de respecter le cahier des charges.
+        ActivateOnly(battleMap);
+
+        // Réactive chaque action mise en pause pendant la cinématique.
+        foreach (var action in battleActionsDisabledDuringIntro)
+        {
+            if (action != null && !action.enabled)
+                action.Enable();
+        }
+
+        battleActionsDisabledDuringIntro.Clear();
+        battleIntroRestrictionActive = false;
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -729,6 +729,11 @@ public class NewBattleManager : MonoBehaviour
     {
         Debug.Log("[BattleTurnManager] Démarrage du combat");
 
+        // 🎮 Au lancement du combat, on limite les entrées au seul bouton de validation.
+        //     Les menus resteront donc parfaitement figés pendant les animations
+        //     d'introduction des unités, conformément à la demande de game design.
+        InputsManager.Instance?.RestrictInputsToBattleConfirm();
+
         // 🛡️ Assure que les filtres d'écran sont totalement invisibles au lancement du combat.
         //    Sans cette étape, un résidu de fondu noir ou blanc pourrait persister d'une timeline précédente.
         var fader = FadeChildrenOpacity.Instance;
@@ -790,6 +795,10 @@ public class NewBattleManager : MonoBehaviour
         yield return PlayIntroCameraSequence();
         // Les introductions sont terminées : les menus peuvent à présent accepter les entrées.
         battleIntroMenusLocked = false;
+
+        // ✅ Les actions de combat redeviennent disponibles une fois la cinématique bouclée.
+        //    Cette remise à zéro intervient immédiatement après le déverrouillage logique des menus.
+        InputsManager.Instance?.RestoreBattleInputsAfterIntro();
 
         //7 Démarre la boucle de tours
         StartCoroutine(TurnLoop());
@@ -3838,6 +3847,10 @@ public class NewBattleManager : MonoBehaviour
 
         // Supprime toute trace d'un éventuel verrou d'introduction pour la prochaine rencontre.
         battleIntroMenusLocked = false;
+
+        // 🧹 Si la restriction d'entrées est encore active (ex : interruption prématurée),
+        //     on s'assure de rétablir le mapping complet avant de quitter le combat.
+        InputsManager.Instance?.RestoreBattleInputsAfterIntro();
 
         // Nettoie les références
         currentCharacterUnit = null;


### PR DESCRIPTION
## Summary
- restreindre temporairement les contrôles au seul bouton Battle.Confirm pendant l'introduction du combat
- restaurer automatiquement le mapping Battle complet dès que les animations d'ouverture sont terminées ou qu'un reset de combat survient

## Testing
- not run (non disponible dans cet environnement)


------
https://chatgpt.com/codex/tasks/task_e_68d804eb90288325ab5e4929fb897fe4