### PR TITLE
Refactoriser la synchronisation des barres de vie

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
@@ -19,8 +19,6 @@ public class BattleTimelineUnit : MonoBehaviour
     [SerializeField] private Color highlightColor = Color.yellow;
     [SerializeField] private Color deadColor = Color.red;
 
-    [HideInInspector] public CharacterData characterData;
-
     [SerializeField] private CanvasGroup canvasGroup;
 
     /// <summary>Référence directe vers l'unité affichée pour faciliter l'accès aux stats dynamiques.</summary>
@@ -49,12 +47,11 @@ public class BattleTimelineUnit : MonoBehaviour
             return;
         }
 
-        characterData = unit.Data;
         boundUnit = unit;
 
         // Portrait et nom
-        if (portraitImage) portraitImage.sprite = characterData.portrait;
-        if (nameText) nameText.text = characterData.characterName;
+        if (portraitImage) portraitImage.sprite = boundUnit.Data.portrait;
+        if (nameText) nameText.text = boundUnit.Data.characterName;
 
         // HP : on crée/initialise l'adaptateur qui mettra à jour la jauge timeline
         if (timelineHPBarAdapter == null)
@@ -64,25 +61,21 @@ public class BattleTimelineUnit : MonoBehaviour
             timelineHPBarAdapter = gameObject.AddComponent<TimelineHPBarAdapter>();
 
         Color aliveColor = hpBarImage != null ? hpBarImage.color : Color.white;
-        timelineHPBarAdapter.Setup(unit, hpBarImage, hpText, aliveColor, deadColor);
-
-        float maxHP = unit != null
-            ? unit.Data.baseHP + unit.currentVitality
-            : characterData.baseHP + characterData.currentVitality;
-        timelineHPBarAdapter.SetMaxValue(maxHP);
-        timelineHPBarAdapter.SetValue(unit != null ? unit.currentHP : characterData.currentHP);
+        timelineHPBarAdapter.Setup(boundUnit, hpBarImage, hpText, aliveColor, deadColor);
+        // Appel explicite pour synchroniser immédiatement l'affichage avant le prochain événement de PV.
+        timelineHPBarAdapter.SyncWithOwner();
 
         // Custom bar (Rage/Fatigue/Concentration)
         if (customBar != null)
         {
-            if (characterData.gameplayType == GameplayType.Rage)
+            if (boundUnit.Data.gameplayType == GameplayType.Rage)
             {
-                customBar.SetMaxValue(characterData.maxRage);
+                customBar.SetMaxValue(boundUnit.Data.maxRage);
                 customBar.SetValue(unit.currentRage);
             }
-            else if (characterData.gameplayType == GameplayType.Fatigue)
+            else if (boundUnit.Data.gameplayType == GameplayType.Fatigue)
             {
-                customBar.SetMaxValue(characterData.maxFatigue);
+                customBar.SetMaxValue(boundUnit.Data.maxFatigue);
                 customBar.SetValue(unit.currentFatigue);
             }
             else if (unit.TryGetComponent<ConcentrationSystem>(out var c))
@@ -111,32 +104,29 @@ public class BattleTimelineUnit : MonoBehaviour
 
     public void UpdateATBGauge()
     {
-        var unit = NewBattleManager.Instance.activeCharacterUnits
-            .Find(u => u.Data == characterData);
+        if (boundUnit == null || atbSlider == null)
+            return;
 
-        if (unit != null && atbSlider != null)
-        {
-            atbSlider.value = unit.currentATB;
-        }
+        // Plus besoin de rechercher l'unité dans le NewBattleManager : on lit directement la valeur courante.
+        atbSlider.value = boundUnit.currentATB;
     }
 
     public void UpdateCustomBar()
     {
-        var unit = NewBattleManager.Instance.activeCharacterUnits
-            .Find(u => u.Data == characterData);
-
-        if (unit == null || customBar == null)
+        if (boundUnit == null || customBar == null)
             return;
 
-        if (characterData.gameplayType == GameplayType.Rage)
+        // La barre personnalisée dépend du gameplayType de la fiche personnage : on récupère donc
+        // l'information directement depuis les données de l'unité liée.
+        if (boundUnit.Data.gameplayType == GameplayType.Rage)
         {
-            customBar.SetValue(unit.currentRage);
+            customBar.SetValue(boundUnit.currentRage);
         }
-        else if (characterData.gameplayType == GameplayType.Fatigue)
+        else if (boundUnit.Data.gameplayType == GameplayType.Fatigue)
         {
-            customBar.SetValue(unit.currentFatigue);
+            customBar.SetValue(boundUnit.currentFatigue);
         }
-        else if (unit.TryGetComponent<ConcentrationSystem>(out var c))
+        else if (boundUnit.TryGetComponent<ConcentrationSystem>(out var c))
         {
             customBar.SetValue(c.currentConcentration);
         }
@@ -144,31 +134,17 @@ public class BattleTimelineUnit : MonoBehaviour
 
     public void UpdateHarmonicsDisplay()
     {
-        var unit = NewBattleManager.Instance.activeCharacterUnits
-            .Find(u => u.Data == characterData);
-
-        if (unit == null || harmonicsText == null)
+        if (boundUnit == null || harmonicsText == null)
             return;
 
-        int count = unit.GetHarmonicCount(unit.Data.harmonicType);
+        // Affiche en permanence la réserve d'harmoniques du type principal du personnage.
+        int count = boundUnit.GetHarmonicCount(boundUnit.Data.harmonicType);
         harmonicsText.text = count.ToString();
     }
 
     public void UpdateHPBar()
     {
-        if (timelineHPBarAdapter == null)
-            return;
-
-        if (boundUnit != null && boundUnit.Data != null)
-        {
-            float maxHP = boundUnit.Data.baseHP + boundUnit.currentVitality;
-            timelineHPBarAdapter.UpdateInstant(boundUnit.currentHP, maxHP);
-        }
-        else if (characterData != null)
-        {
-            float maxHP = characterData.baseHP + characterData.currentVitality;
-            timelineHPBarAdapter.UpdateInstant(characterData.currentHP, maxHP);
-        }
+        timelineHPBarAdapter?.SyncWithOwner();
     }
 
     public void SetHighlight(bool active)

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -20,6 +20,11 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public CharacterData Data;
 
     [Header("UI Components")]
+    /// <summary>
+    /// Barre de vie principale de l'unité (souvent affichée en monde ou via des widgets dédiés).
+    /// Les TimelineUnits s'y abonnent désormais via <see cref="OnHealthChanged"/> pour éviter
+    /// les manipulations directes de cette référence.
+    /// </summary>
     public HPBar hpBar;
     public CustomBar customBar;
 
@@ -402,9 +407,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         set
         {
             bool wasDead = _currentHP <= 0f;
-            _currentHP = value;
+
+            // On s'assure que la valeur stockée reste positive et ne dépasse pas le maximum connu.
+            float maxHP = MaxHP;
+            float clampedValue = maxHP > 0f ? Mathf.Clamp(value, 0f, maxHP) : Mathf.Max(0f, value);
+
+            _currentHP = clampedValue;
+
             if (Data != null)
-                Data.currentHP = value;
+                Data.currentHP = clampedValue;
+
+            // Préviens immédiatement toutes les interfaces (dont la timeline) que les PV ont changé.
+            NotifyHealthChanged();
 
             if (wasDead && _currentHP > 0f && Data != null && Data.characterName == "Lucian")
             {
@@ -422,7 +436,16 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentMobility { get => Data.currentMobility; set => Data.currentMobility = value; }
     public float currentPower { get => Data.currentPower; set => Data.currentPower = value; }
     public float currentStability { get => Data.currentStability; set => Data.currentStability = value; }
-    public float currentVitality { get => Data.currentVitality; set => Data.currentVitality = value; }
+    public float currentVitality
+    {
+        get => Data.currentVitality;
+        set
+        {
+            Data.currentVitality = value;
+            // La vitalité influence directement les PV max : on rafraîchit l'affichage et l'événement.
+            NotifyHealthChanged(refreshMax: true);
+        }
+    }
     public float currentSagacity { get => Data.currentSagacity; set => Data.currentSagacity = value; }
 
     public float currentMusicalGauge;
@@ -440,6 +463,45 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public float currentATB = 0f;
     public float ATBMax = 100f;
     public bool IsReady => currentATB >= ATBMax && currentHP > 0;
+
+    /// <summary>
+    /// Evénement déclenché à chaque modification des points de vie de l'unité.
+    /// Les deux valeurs flottantes correspondent respectivement aux PV actuels et aux PV max
+    /// afin de simplifier le binding côté UI.
+    /// </summary>
+    public event Action<CharacterUnit, float, float> OnHealthChanged;
+
+    /// <summary>
+    /// Renvoie les points de vie maximums actuels en tenant compte des bonus/malus de vitalité.
+    /// </summary>
+    public float MaxHP => Data != null ? Data.baseHP + Data.currentVitality : Mathf.Max(_currentHP, 0f);
+
+    /// <summary>
+    /// Force un rafraîchissement manuel de la barre de vie ainsi que des abonnés à <see cref="OnHealthChanged"/>.
+    /// Utile si un autre système manipule directement les statistiques sans passer par les propriétés publiques.
+    /// </summary>
+    /// <param name="refreshMax">Indique si la valeur max doit être réappliquée à la barre.</param>
+    public void RefreshHealthDisplay(bool refreshMax = false) => NotifyHealthChanged(refreshMax);
+
+    /// <summary>
+    /// Centralise la notification des variations de PV afin de tenir à jour la barre monde et les UI associées.
+    /// </summary>
+    /// <param name="refreshMax">Forcer la réapplication de la valeur maximale sur la barre.</param>
+    private void NotifyHealthChanged(bool refreshMax = false)
+    {
+        float maxHP = MaxHP;
+        float clampedValue = maxHP > 0f ? Mathf.Clamp(_currentHP, 0f, maxHP) : Mathf.Max(_currentHP, 0f);
+
+        if (hpBar != null)
+        {
+            if (refreshMax)
+                hpBar.SetMaxValue(maxHP);
+
+            hpBar.SetValue(clampedValue);
+        }
+
+        OnHealthChanged?.Invoke(this, clampedValue, maxHP);
+    }
 
     private bool deathTriggered;
     /// <summary>
@@ -498,12 +560,9 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (spriteRenderer != null && Data.portrait != null)
             spriteRenderer.sprite = Data.portrait;
 
-        // UI HP
-        if (hpBar != null)
-        {
-            hpBar.SetMaxValue(Data.baseHP + currentVitality);
-            hpBar.SetValue(currentHP);
-        }
+        // UI HP : un rafraîchissement explicite garantit que les valeurs max et courantes
+        // sont cohérentes sur toutes les interfaces (monde + timeline) immédiatement après l'init.
+        NotifyHealthChanged(refreshMax: true);
 
         if (customBar != null)
         {
@@ -871,7 +930,6 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         }
 
         currentHP = Mathf.Max(currentHP - amount, 0);
-        if (hpBar != null) hpBar.SetValue(currentHP);
 
         // Calcul de la gravité du coup pour déterminer le son et le message
         float maxHP = Data.baseHP + currentVitality;
@@ -1010,7 +1068,6 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public void Heal(float amount)
     {
         currentHP = Mathf.Min(currentHP + amount, Data.baseHP + currentVitality);
-        if (hpBar != null) hpBar.SetValue(currentHP);
     }
 
     public void ApplyBuff(float value)

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineHPBarAdapter.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineHPBarAdapter.cs
@@ -4,8 +4,9 @@ using UnityEngine.UI;
 
 /// <summary>
 /// Adapte l'affichage de la timeline de combat au système standard de <see cref="HPBar"/>.
-/// Cette passerelle permet d'affecter dynamiquement la barre de vie timeline à un
-/// <see cref="CharacterUnit"/> sans perdre l'éventuelle barre déjà configurée sur l'unité.
+/// Cette passerelle écoute les événements d'un <see cref="CharacterUnit"/> pour refléter
+/// instantanément l'état de ses points de vie dans la timeline sans perturber les barres
+/// monde éventuellement associées à l'unité.
 /// </summary>
 [RequireComponent(typeof(BattleTimelineUnit))]
 public class TimelineHPBarAdapter : HPBar
@@ -20,12 +21,8 @@ public class TimelineHPBarAdapter : HPBar
     [SerializeField] private Color midHealthColor = Color.yellow; // Couleur d'avertissement pour une santé moyenne.
     [SerializeField] private Color lowHealthColor = new Color(0.75f, 0f, 0f); // Rouge légèrement assombri pour distinguer l'état critique.
 
-    /// <summary>Barre éventuellement déjà assignée sur l'unité (ex : interface 3D).</summary>
-    private HPBar fallbackBar;
     /// <summary>Référence vers l'unité dont on suit les points de vie.</summary>
     private CharacterUnit owner;
-    /// <summary>Indique si la barre de secours a déjà été mémorisée.</summary>
-    private bool fallbackCaptured;
     /// <summary>Valeur maximale actuelle utilisée pour le calcul du ratio.</summary>
     private float cachedMaxValue = 1f;
     /// <summary>Valeur courante retenue pour l'affichage.</summary>
@@ -41,6 +38,9 @@ public class TimelineHPBarAdapter : HPBar
     /// <param name="dead">Couleur utilisée lorsque l'unité est vaincue.</param>
     public void Setup(CharacterUnit target, Image fill, TextMeshProUGUI hpLabel, Color alive, Color dead)
     {
+        if (owner != null)
+            owner.OnHealthChanged -= HandleOwnerHealthChanged;
+
         owner = target;
         timelineFillImage = fill != null ? fill : timelineFillImage;
         timelineHPText = hpLabel != null ? hpLabel : timelineHPText;
@@ -72,23 +72,14 @@ public class TimelineHPBarAdapter : HPBar
         if (owner == null)
             return;
 
-        // Mémorise la barre existante avant de prendre la main afin de la restaurer plus tard.
-        if (!fallbackCaptured && owner.hpBar != null && owner.hpBar != this)
-        {
-            fallbackBar = owner.hpBar;
-            fallbackCaptured = true;
-        }
-
-        // Affecte cette barre comme référence principale pour les prochains dégâts/soins.
-        owner.hpBar = this;
+        owner.OnHealthChanged += HandleOwnerHealthChanged;
     }
 
     /// <inheritdoc />
     public override void SetMaxValue(float max)
     {
         cachedMaxValue = Mathf.Max(0f, max);
-        // Propage la nouvelle limite vers l'ancienne barre si elle existe encore.
-        fallbackBar?.SetMaxValue(max);
+        base.SetMaxValue(cachedMaxValue);
 
         // Utilise la valeur courante connue de l'unité pour maintenir la cohérence visuelle.
         float current = owner != null ? owner.currentHP : cachedCurrentValue;
@@ -99,21 +90,36 @@ public class TimelineHPBarAdapter : HPBar
     public override void SetValue(float current)
     {
         cachedCurrentValue = Mathf.Clamp(current, 0f, cachedMaxValue > 0f ? cachedMaxValue : current);
-        fallbackBar?.SetValue(cachedCurrentValue);
+        base.SetValue(cachedCurrentValue);
         UpdateVisuals(cachedCurrentValue);
     }
 
     /// <summary>
-    /// Met à jour l'affichage immédiatement sans toucher aux barres fallback.
-    /// Utile lors de la phase d'initialisation de la timeline.
+    /// Synchronise immédiatement la jauge avec l'unité liée sans attendre un nouvel événement.
     /// </summary>
-    /// <param name="current">Valeur actuelle des PV.</param>
-    /// <param name="max">Valeur maximale des PV.</param>
-    public void UpdateInstant(float current, float max)
+    public void SyncWithOwner()
     {
-        cachedMaxValue = Mathf.Max(0f, max);
-        cachedCurrentValue = Mathf.Clamp(current, 0f, cachedMaxValue > 0f ? cachedMaxValue : current);
-        UpdateVisuals(cachedCurrentValue);
+        if (owner == null)
+            return;
+
+        HandleOwnerHealthChanged(owner, owner.currentHP, owner.MaxHP);
+    }
+
+    private void OnEnable()
+    {
+        if (owner == null)
+            return;
+
+        // Sécurise la souscription lors d'un ré-activation (ex : pool UI) et force un rafraîchissement instantané.
+        owner.OnHealthChanged -= HandleOwnerHealthChanged;
+        owner.OnHealthChanged += HandleOwnerHealthChanged;
+        SyncWithOwner();
+    }
+
+    private void OnDisable()
+    {
+        if (owner != null)
+            owner.OnHealthChanged -= HandleOwnerHealthChanged;
     }
 
     /// <summary>
@@ -173,18 +179,23 @@ public class TimelineHPBarAdapter : HPBar
 
     private void OnDestroy()
     {
-        // Lorsque la timeline est détruite, on restitue la barre précédente pour éviter
-        // de laisser l'unité sans référence valide (cas d'une nouvelle scène de combat).
-        if (owner != null && owner.hpBar == this)
-        {
-            owner.hpBar = fallbackBar;
+        if (owner != null)
+            owner.OnHealthChanged -= HandleOwnerHealthChanged;
+    }
 
-            if (fallbackBar != null)
-            {
-                // Synchronise la barre restaurée avec les valeurs les plus récentes.
-                fallbackBar.SetMaxValue(cachedMaxValue);
-                fallbackBar.SetValue(cachedCurrentValue);
-            }
-        }
+    /// <summary>
+    /// Réagit aux variations de PV signalées par le <see cref="CharacterUnit"/> pour mettre à jour la jauge timeline.
+    /// </summary>
+    private void HandleOwnerHealthChanged(CharacterUnit unit, float current, float max)
+    {
+        if (owner == null || unit != owner)
+            return;
+
+        cachedMaxValue = Mathf.Max(0f, max);
+        cachedCurrentValue = Mathf.Clamp(current, 0f, cachedMaxValue > 0f ? cachedMaxValue : current);
+
+        base.SetMaxValue(cachedMaxValue);
+        base.SetValue(cachedCurrentValue);
+        UpdateVisuals(cachedCurrentValue);
     }
 }


### PR DESCRIPTION
## Résumé
- exposer un événement de points de vie et un utilitaire de rafraîchissement sur `CharacterUnit`
- relier directement `BattleTimelineUnit` au `CharacterUnit` pour mettre à jour ATB, jauges et harmoniques sans rechercher via `NewBattleManager`
- faire écouter `TimelineHPBarAdapter` aux événements de vie afin de synchroniser l’UI timeline sans écraser la barre principale de l’unité

## Tests
- non exécuté (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68d823716d208325ab6aff1b842747a3