### PR TITLE
Fix: corriger les références characterData de la timeline

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUIManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUIManager.cs
@@ -111,18 +111,12 @@ public class BattleTimelineUIManager : MonoBehaviour
     /// </summary>
     private void SortTimelineByATB()
     {
-        if (NewBattleManager.Instance == null)
-            return;
-
         timelineUIObjects.Sort((a, b) =>
         {
-            var unitA = NewBattleManager.Instance.activeCharacterUnits
-                .Find(u => u.Data == a.characterData);
-            var unitB = NewBattleManager.Instance.activeCharacterUnits
-                .Find(u => u.Data == b.characterData);
-
-            float turnsA = EstimateTurnsToReady(unitA);
-            float turnsB = EstimateTurnsToReady(unitB);
+            // Accès direct aux CharacterUnit liés aux vignettes pour éviter
+            // tout couplage supplémentaire avec le NewBattleManager.
+            float turnsA = EstimateTurnsToReady(a.BoundUnit);
+            float turnsB = EstimateTurnsToReady(b.BoundUnit);
             return turnsA.CompareTo(turnsB);
         });
     }
@@ -134,7 +128,9 @@ public class BattleTimelineUIManager : MonoBehaviour
     {
         foreach (var ui in timelineUIObjects)
         {
-            bool isCurrent = activeUnit != null && ui.characterData == activeUnit.Data;
+            // Compare directement les CharacterUnit pour simplifier la logique
+            // et éviter les recherches inutiles dans les collections du manager.
+            bool isCurrent = activeUnit != null && ui.BoundUnit == activeUnit;
             ui.SetHighlight(isCurrent);
         }
     }
@@ -154,7 +150,7 @@ public class BattleTimelineUIManager : MonoBehaviour
         if (activeUnit != null)
         {
             // S'assure que l'unité actuellement active est bien en tête.
-            int index = timelineUIObjects.FindIndex(ui => ui.characterData == activeUnit.Data);
+            int index = timelineUIObjects.FindIndex(ui => ui.BoundUnit == activeUnit);
             if (index > 0)
             {
                 var ui = timelineUIObjects[index];
@@ -195,7 +191,9 @@ public class BattleTimelineUIManager : MonoBehaviour
     /// </summary>
     public void RemoveFromTimeline(CharacterUnit deadUnit)
     {
-        var ui = timelineUIObjects.FirstOrDefault(x => x.characterData == deadUnit.Data);
+        // Recherche directe sur l'unité liée : plus robuste si plusieurs
+        // personnages partagent des données communes.
+        var ui = timelineUIObjects.FirstOrDefault(x => x.BoundUnit == deadUnit);
         if (ui != null)
         {
             timelineUIObjects.Remove(ui);

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineUnit.cs
@@ -169,5 +169,22 @@ public class BattleTimelineUnit : MonoBehaviour
     {
         transform.localScale = Vector3.one * baseScale * highlightMultiplier;
     }
+
+    /// <summary>
+    /// Fournit l'unité actuellement liée à cette vignette de timeline.
+    /// Cette propriété permet d'éviter aux autres gestionnaires de devoir
+    /// maintenir leurs propres références ou de rechercher l'unité via
+    /// <see cref="NewBattleManager"/>.
+    /// </summary>
+    public CharacterUnit BoundUnit => boundUnit;
+
+    /// <summary>
+    /// Expose les données statiques du personnage associé à la vignette.
+    /// L'ancien champ <c>characterData</c> a été remplacé par cette
+    /// propriété afin de conserver la compatibilité avec les systèmes
+    /// existants tout en centralisant la logique d'accès dans
+    /// <see cref="BattleTimelineUnit"/>.
+    /// </summary>
+    public CharacterData characterData => boundUnit != null ? boundUnit.Data : null;
 }
 


### PR DESCRIPTION
## Résumé
- expose l'unité liée et ses données statiques via `BattleTimelineUnit` pour restaurer l'accès attendu à `characterData`
- met à jour `BattleTimelineUIManager` afin d'utiliser directement les `CharacterUnit` liés et ajoute des commentaires explicatifs

## Tests
- Non exécutés (projet Unity non testable automatiquement dans cet environnement)


------
https://chatgpt.com/codex/tasks/task_e_68d8264414448325a3ac788b4432d128