### PR TITLE
Ensure CMV over-shoulder camera follows parent anchor

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -487,11 +487,66 @@ public class BattleCameraManager : MonoBehaviour
             return anchorOverride;
 
         string pointName = $"CMVPoint_{config.Suffix}";
-        Transform anchor = unit.GetCameraAnchor(pointName);
+        Transform anchor = null;
+
+        // 🎯 Cas particulier : la caméra "CMV_OverShoulder_CasterLookTarget" doit se caler sur
+        // le point généré directement sous le parent du CharacterUnit (PlayerPosition_X / EnemyPosition_X).
+        // Les artistes ajustent ce repère pour garantir une composition identique quel que soit le
+        // modèle instancié ; on force donc cette recherche avant de retomber sur la logique standard.
+        if (ShouldUseParentCasterLookTarget(config))
+            anchor = ResolveParentCasterLookTargetAnchor(unit);
+
+        // 🧭 Si aucune ancre spécifique au parent n'a été trouvée, on revient au comportement par défaut
+        // en interrogeant les points « CMVPoint_… » directement disponibles sur l'unité.
+        anchor ??= unit.GetCameraAnchor(pointName);
         if (anchor == null && missingAnchorWarnings.Add(pointName))
             Debug.LogWarning($"[BattleCameraManager] Point '{pointName}' introuvable sur '{unit.name}'.");
 
         return anchor;
+    }
+
+    /// <summary>
+    /// Détermine si la configuration de caméra doit privilégier le point placé sur le parent
+    /// du CharacterUnit plutôt que sur l'unité elle-même.
+    /// </summary>
+    private static bool ShouldUseParentCasterLookTarget(CameraBindingConfig config)
+    {
+        return config.Owner == CameraAnchorOwner.Caster
+            && !string.IsNullOrEmpty(config.Suffix)
+            && string.Equals(config.Suffix, "OverShoulder_CasterLookTarget", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Recherche le point « CMVPoint_OverShoulder_CasterLookTarget » placé sur le parent du personnage.
+    /// </summary>
+    private static Transform ResolveParentCasterLookTargetAnchor(CharacterUnit unit)
+    {
+        if (unit == null)
+            return null;
+
+        const string anchorName = "CMVPoint_OverShoulder_CasterLookTarget";
+
+        Transform parent = unit.transform.parent;
+        if (parent == null)
+            return null;
+
+        // 🎬 Priorité au child direct : c'est la configuration privilégiée par le BattleManager.
+        Transform directChild = parent.Find(anchorName);
+        if (directChild != null)
+            return directChild;
+
+        // 🔄 Certains environnements peuvent regrouper le point dans une sous-hiérarchie.
+        // On balaie donc l'ensemble des enfants du parent (hors unité actuelle) pour couvrir ces variantes.
+        foreach (Transform sibling in parent.GetComponentsInChildren<Transform>(includeInactive: true))
+        {
+            if (sibling == null || sibling == unit.transform)
+                continue;
+
+            if (string.Equals(sibling.name, anchorName, StringComparison.OrdinalIgnoreCase))
+                return sibling;
+        }
+
+        return null;
     }
 
     /// <summary>Détermine le Transform à regarder lorsque la caméra doit suivre la cible.</summary>

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -571,11 +571,8 @@ public class NewBattleManager : MonoBehaviour
 
         if (existingAnchor != null)
         {
-            // Met à jour l'offset du script si le point a été préparé à la main dans la scène.
-            LookAtBattleTarget existingLookAt = existingAnchor.GetComponent<LookAtBattleTarget>();
-            if (existingLookAt != null)
-                existingLookAt.offset = overShoulderCasterLookOffset;
-
+            // Met à jour/ajoute le composant responsable d'orienter l'ancre vers la cible courante.
+            EnsureLookAtComponent(existingAnchor);
             return existingAnchor;
         }
 
@@ -585,8 +582,9 @@ public class NewBattleManager : MonoBehaviour
         anchorGO.transform.localPosition = overShoulderCasterLookPointPosition_SquadUnit;
         anchorGO.transform.localRotation = Quaternion.identity;
 
-        LookAtBattleTarget lookAt = anchorGO.AddComponent<LookAtBattleTarget>();
-        lookAt.offset = overShoulderCasterLookOffset;
+        // Lie systématiquement l'ancre à la cible actuelle afin que les caméras épaulières cadrent
+        // correctement la scène, quel que soit le modèle visuel du personnage.
+        EnsureLookAtComponent(anchorGO.transform);
 
         return anchorGO.transform;
     }
@@ -613,11 +611,9 @@ public class NewBattleManager : MonoBehaviour
 
         if (existingAnchor != null)
         {
-            // Met à jour l'offset du script si le point a été préparé à la main dans la scène.
-            LookAtBattleTarget existingLookAt = existingAnchor.GetComponent<LookAtBattleTarget>();
-            if (existingLookAt != null)
-                existingLookAt.offset = overShoulderCasterLookOffset;
-
+            // Garantit que le point continue d'orienter la caméra vers la cible active, même
+            // lorsqu'il a été placé manuellement dans la scène.
+            EnsureLookAtComponent(existingAnchor);
             return existingAnchor;
         }
 
@@ -627,10 +623,27 @@ public class NewBattleManager : MonoBehaviour
         anchorGO.transform.localPosition = overShoulderCasterLookPointPosition_EnemyUnit;
         anchorGO.transform.localRotation = Quaternion.identity;
 
-        LookAtBattleTarget lookAt = anchorGO.AddComponent<LookAtBattleTarget>();
-        lookAt.offset = overShoulderCasterLookOffset;
+        EnsureLookAtComponent(anchorGO.transform);
 
         return anchorGO.transform;
+    }
+
+    /// <summary>
+    /// S'assure qu'un composant <see cref="LookAtBattleTarget"/> est présent et configuré sur l'ancre donnée.
+    /// </summary>
+    /// <param name="anchor">Transform de l'ancre à valider.</param>
+    private void EnsureLookAtComponent(Transform anchor)
+    {
+        if (anchor == null)
+            return;
+
+        // 🔄 Réutilise le composant existant lorsqu'il est déjà en place pour préserver les réglages
+        // manuels éventuels, tout en rafraîchissant l'offset commun à toutes les ancres générées.
+        LookAtBattleTarget lookAt = anchor.GetComponent<LookAtBattleTarget>();
+        if (lookAt == null)
+            lookAt = anchor.gameObject.AddComponent<LookAtBattleTarget>();
+
+        lookAt.offset = overShoulderCasterLookOffset;
     }
 
     #region Mise en scène de la scène de bataille


### PR DESCRIPTION
## Summary
- force CMV_OverShoulder_CasterLookTarget to attach to the parent-level CMVPoint_OverShoulder_CasterLookTarget
- ensure generated or preplaced CMVPoint_OverShoulder_CasterLookTarget anchors always include LookAtBattleTarget
- keep camera anchors refreshed for consistent framing regardless of character model

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d82a718c50832585e8084fd045cdc4