### PR TITLE
Ajoute une zone caméra 2D configurable

### DIFF
--- a/Assets/Prefabs/Camera2DZone.prefab
+++ b/Assets/Prefabs/Camera2DZone.prefab
@@ -1,0 +1,165 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4379047365140272635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4379047365140272636}
+  - component: {fileID: 4379047365140272637}
+  - component: {fileID: 4379047365140272638}
+  m_Layer: 0
+  m_Name: Camera2DZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4379047365140272636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379047365140272635}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1752938476501384922}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4379047365140272637
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379047365140272635}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 10, y: 4, z: 10}
+  m_Center: {x: 0, y: 2, z: 0}
+--- !u!114 &4379047365140272638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4379047365140272635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74ab8ef5aeb14e2a82cfe37001b847f9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  targetCamera: {fileID: 0}
+  playerTag: Player
+  baseSettings:
+    plane: 1
+    customPlaneNormal: {x: 0, y: 1, z: 0}
+    distance: 8
+    fieldOfView: 55
+    keepCameraFixed: 0
+    fixedCameraAnchor: {fileID: 0}
+    followPlayerByDefault: 1
+    explicitFollowTarget: {fileID: 0}
+    followOffset: {x: 0, y: 1.6, z: 0}
+    cameraOffset: {x: 0, y: 0, z: 0}
+    rotationOffset: {x: 0, y: 0, z: 0}
+    smoothPosition: 1
+    positionSmoothTime: 0.3
+    smoothRotation: 1
+    rotationSmoothSpeed: 6
+    fovSmoothTime: 0.25
+--- !u!1 &1752938476501384921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1752938476501384922}
+  - component: {fileID: 1752938476501384923}
+  - component: {fileID: 1752938476501384924}
+  m_Layer: 0
+  m_Name: SubZoneExample
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1752938476501384922
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752938476501384921}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4379047365140272636}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &1752938476501384923
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752938476501384921}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 6, y: 4, z: 6}
+  m_Center: {x: 0, y: 2, z: 0}
+--- !u!114 &1752938476501384924
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1752938476501384921}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 106d096e0c1c460584a2d93f3eee553a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  parentZone: {fileID: 4379047365140272638}
+  overrideDistance: 0
+  distance: 6
+  overrideFieldOfView: 1
+  fieldOfView: 45
+  overrideFollowOffset: 0
+  followOffset: {x: 0, y: 1.6, z: 0}
+  overrideCameraOffset: 0
+  cameraOffset: {x: 0, y: 0, z: 0}
+  overrideRotationOffset: 0
+  rotationOffset: {x: 0, y: 0, z: 0}
+  overridePositionSmoothing: 0
+  smoothPosition: 1
+  positionSmoothTime: 0.3
+  overrideRotationSmoothing: 0
+  smoothRotation: 1
+  rotationSmoothSpeed: 6
+  overrideFovSmoothTime: 0
+  fovSmoothTime: 0.25
+  overridePlane: 0
+  plane: 1
+  customPlaneNormal: {x: 0, y: 1, z: 0}
+  overrideFixedBehaviour: 0
+  keepCameraFixed: 0
+  fixedCameraAnchor: {fileID: 0}
+  overrideFollowTarget: 0
+  followTargetOverride: {fileID: 0}

--- a/Assets/Prefabs/Camera2DZone.prefab.meta
+++ b/Assets/Prefabs/Camera2DZone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c53960babc074cce8cf55e81d5427271
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/TwoDZone.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TwoDZone.cs
@@ -1,0 +1,460 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Zone de caméra dédiée aux séquences « en 2D » de Symphonie.
+/// Lorsqu'un joueur entre dans le volume de déclenchement, la caméra
+/// est repositionnée pour ne se déplacer que sur un plan 2D défini par la zone.
+/// Cette classe offre un ensemble complet d'options : choix du plan, distance,
+/// champ de vision, comportement fixe ou en suivi, offsets et lissage.
+/// 
+/// L'objectif est de faciliter les transitions entre phases 3D et phases plus
+/// cinématiques tout en respectant la narration du jeu.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+[AddComponentMenu("Camera/2D Zone")]
+public class TwoDZone : MonoBehaviour
+{
+    /// <summary>
+    /// Plan dans lequel la caméra doit se déplacer.
+    /// </summary>
+    public enum CameraPlane
+    {
+        XY,        // Plan horizontal (vue de côté – normal = forward)
+        XZ,        // Plan classique « sol » (normal = up)
+        YZ,        // Plan vertical (normal = right)
+        Custom     // Plan défini par un vecteur personnalisé
+    }
+
+    /// <summary>
+    /// Paramètres principaux de la zone. Cette classe est sérialisée pour
+    /// faciliter la configuration dans l'inspecteur et permettre aux sous-zones
+    /// de créer des overrides temporaires.
+    /// </summary>
+    [System.Serializable]
+    public class ZoneSettings
+    {
+        [Header("Plan de déplacement")]
+        [Tooltip("Plan sur lequel la caméra pourra se déplacer.")]
+        public CameraPlane plane = CameraPlane.XZ;
+
+        [Tooltip("Normal personnalisée lorsque le plan est défini sur Custom.")]
+        public Vector3 customPlaneNormal = Vector3.up;
+
+        [Header("Placement de la caméra")]
+        [Tooltip("Distance de la caméra par rapport au point suivi, le long de la normale du plan.")]
+        public float distance = 8f;
+
+        [Tooltip("Champ de vision appliqué lors de l'entrée dans la zone.")]
+        public float fieldOfView = 55f;
+
+        [Tooltip("La caméra reste-t-elle fixe (ancrée sur un transform) ?")]
+        public bool keepCameraFixed = false;
+
+        [Tooltip("Point d'ancrage utilisé si la caméra reste fixe.")]
+        public Transform fixedCameraAnchor;
+
+        [Header("Suivi d'une cible")]
+        [Tooltip("Par défaut, suivre automatiquement le joueur qui entre dans la zone.")]
+        public bool followPlayerByDefault = true;
+
+        [Tooltip("Cible explicite à suivre. Si renseignée, remplace le suivi automatique du joueur.")]
+        public Transform explicitFollowTarget;
+
+        [Tooltip("Décalage appliqué au point de suivi (par exemple pour viser la tête du personnage).")]
+        public Vector3 followOffset = new Vector3(0f, 1.6f, 0f);
+
+        [Tooltip("Offset supplémentaire appliqué à la position finale de la caméra.")]
+        public Vector3 cameraOffset = Vector3.zero;
+
+        [Tooltip("Décalage en Euler appliqué à la rotation finale.")]
+        public Vector3 rotationOffset = Vector3.zero;
+
+        [Header("Lissage des mouvements")]
+        [Tooltip("Activer le lissage de la position.")]
+        public bool smoothPosition = true;
+
+        [Tooltip("Temps de lissage (SmoothDamp) pour la position.")]
+        public float positionSmoothTime = 0.3f;
+
+        [Tooltip("Activer un lissage de rotation (Slerp).")]
+        public bool smoothRotation = true;
+
+        [Tooltip("Vitesse du Slerp de rotation.")]
+        public float rotationSmoothSpeed = 6f;
+
+        [Tooltip("Temps de lissage appliqué au champ de vision.")]
+        public float fovSmoothTime = 0.25f;
+    }
+
+    /// <summary>
+    /// Structure runtime permettant de manipuler les paramètres actifs
+    /// sans modifier l'instance sérialisée.
+    /// </summary>
+    public struct ResolvedSettings
+    {
+        public Vector3 planeNormal;
+        public float distance;
+        public float fieldOfView;
+        public bool keepCameraFixed;
+        public Transform fixedCameraAnchor;
+        public Transform followTarget;
+        public Vector3 followOffset;
+        public Vector3 cameraOffset;
+        public Vector3 rotationOffset;
+        public bool smoothPosition;
+        public float positionSmoothTime;
+        public bool smoothRotation;
+        public float rotationSmoothSpeed;
+        public float fovSmoothTime;
+
+        public ResolvedSettings(ZoneSettings source, Transform follow)
+        {
+            planeNormal = ResolvePlaneNormal(source.plane, source.customPlaneNormal);
+            distance = Mathf.Max(0f, source.distance);
+            fieldOfView = Mathf.Clamp(source.fieldOfView, 1f, 179f);
+            keepCameraFixed = source.keepCameraFixed;
+            fixedCameraAnchor = source.fixedCameraAnchor;
+            followTarget = follow;
+            followOffset = source.followOffset;
+            cameraOffset = source.cameraOffset;
+            rotationOffset = source.rotationOffset;
+            smoothPosition = source.smoothPosition;
+            positionSmoothTime = Mathf.Max(0.01f, source.positionSmoothTime);
+            smoothRotation = source.smoothRotation;
+            rotationSmoothSpeed = Mathf.Max(0.01f, source.rotationSmoothSpeed);
+            fovSmoothTime = Mathf.Max(0f, source.fovSmoothTime);
+        }
+    }
+
+    [Header("Références")]
+    [Tooltip("Caméra à piloter. Laisser vide pour utiliser Camera.main lors de l'entrée dans la zone.")]
+    public Camera targetCamera;
+
+    [Tooltip("Tag utilisé pour identifier le joueur. Par défaut 'Player'.")]
+    public string playerTag = "Player";
+
+    [Header("Configuration principale")]
+    public ZoneSettings baseSettings = new ZoneSettings();
+
+    // Sauvegarde de l'état de la caméra avant d'entrer dans la zone
+    private struct CameraBackup
+    {
+        public Vector3 position;
+        public Quaternion rotation;
+        public float fieldOfView;
+    }
+
+    private CameraBackup previousState;
+
+    // Références runtime
+    private Camera runtimeCamera;
+    private Transform activeActor;
+    private bool zoneActive;
+    private Vector3 velocity;
+    private float fovVelocity;
+    private readonly List<TwoDZoneSubZone> activeSubZones = new();
+
+    private Vector3 PlaneOrigin => transform.position;
+
+    private void Reset()
+    {
+        // Garantit que le collider agit comme un déclencheur.
+        Collider col = GetComponent<Collider>();
+        col.isTrigger = true;
+    }
+
+    private void OnValidate()
+    {
+        // Sécurise l'état du collider même si un designer change le prefab.
+        Collider col = GetComponent<Collider>();
+        if (col != null)
+        {
+            col.isTrigger = true;
+        }
+    }
+
+    private void LateUpdate()
+    {
+        if (!zoneActive || runtimeCamera == null)
+        {
+            return;
+        }
+
+        ApplyCameraBehaviour(false);
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!other.CompareTag(playerTag))
+        {
+            return;
+        }
+
+        ActivateZone(other.transform);
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (!other.CompareTag(playerTag))
+        {
+            return;
+        }
+
+        if (activeActor == other.transform)
+        {
+            DeactivateZone();
+        }
+    }
+
+    /// <summary>
+    /// Enregistre une sous-zone actuellement traversée par le joueur.
+    /// </summary>
+    /// <param name="subZone">Sous-zone qui vient d'être activée.</param>
+    internal void RegisterSubZone(TwoDZoneSubZone subZone)
+    {
+        if (subZone == null)
+        {
+            return;
+        }
+
+        if (!activeSubZones.Contains(subZone))
+        {
+            activeSubZones.Add(subZone);
+            // Application immédiate des nouveaux paramètres pour éviter un frame de décalage.
+            ApplyCameraBehaviour(false);
+        }
+    }
+
+    /// <summary>
+    /// Retire une sous-zone du suivi lorsque le joueur en sort.
+    /// </summary>
+    /// <param name="subZone">Sous-zone à retirer.</param>
+    internal void UnregisterSubZone(TwoDZoneSubZone subZone)
+    {
+        if (subZone == null)
+        {
+            return;
+        }
+
+        if (activeSubZones.Remove(subZone))
+        {
+            ApplyCameraBehaviour(false);
+        }
+    }
+
+    /// <summary>
+    /// Point d'entrée lorsqu'un joueur pénètre dans la zone.
+    /// </summary>
+    /// <param name="actor">Transform du joueur.</param>
+    private void ActivateZone(Transform actor)
+    {
+        runtimeCamera = targetCamera != null ? targetCamera : Camera.main;
+        if (runtimeCamera == null)
+        {
+            Debug.LogWarning("[TwoDZone] Aucune caméra n'a été trouvée pour activer la zone.", this);
+            return;
+        }
+
+        activeActor = actor;
+
+        previousState.position = runtimeCamera.transform.position;
+        previousState.rotation = runtimeCamera.transform.rotation;
+        previousState.fieldOfView = runtimeCamera.fieldOfView;
+
+        velocity = Vector3.zero;
+        fovVelocity = 0f;
+        zoneActive = true;
+
+        // Placement instantané pour éviter un flash en entrée.
+        ApplyCameraBehaviour(true);
+    }
+
+    /// <summary>
+    /// Restaure la caméra lorsque le joueur quitte la zone.
+    /// </summary>
+    private void DeactivateZone()
+    {
+        if (!zoneActive)
+        {
+            return;
+        }
+
+        if (runtimeCamera != null)
+        {
+            runtimeCamera.transform.position = previousState.position;
+            runtimeCamera.transform.rotation = previousState.rotation;
+            runtimeCamera.fieldOfView = previousState.fieldOfView;
+        }
+
+        zoneActive = false;
+        activeActor = null;
+        runtimeCamera = null;
+        activeSubZones.Clear();
+    }
+
+    /// <summary>
+    /// Applique le comportement défini par la zone et les éventuelles sous-zones.
+    /// </summary>
+    /// <param name="instant">Si vrai, ignore les lissages pour un positionnement immédiat.</param>
+    private void ApplyCameraBehaviour(bool instant)
+    {
+        if (runtimeCamera == null)
+        {
+            return;
+        }
+
+        Transform followTarget = ResolveFollowTarget();
+        ResolvedSettings settings = ResolveSettings(followTarget);
+
+        // Mise à jour du champ de vision avec un éventuel lissage.
+        float targetFov = settings.fieldOfView;
+        if (instant || settings.fovSmoothTime <= 0f)
+        {
+            runtimeCamera.fieldOfView = targetFov;
+        }
+        else
+        {
+            runtimeCamera.fieldOfView = Mathf.SmoothDamp(runtimeCamera.fieldOfView, targetFov, ref fovVelocity, settings.fovSmoothTime);
+        }
+
+        Vector3 desiredPosition;
+        Quaternion desiredRotation;
+        Vector3 planeNormal = settings.planeNormal.sqrMagnitude < 0.0001f
+            ? Vector3.up
+            : settings.planeNormal.normalized;
+        Vector3 planeUp = ResolvePlaneUp(planeNormal);
+
+        if (settings.keepCameraFixed)
+        {
+            Transform anchor = settings.fixedCameraAnchor != null ? settings.fixedCameraAnchor : transform;
+            desiredPosition = anchor.position + settings.cameraOffset;
+            desiredRotation = anchor.rotation * Quaternion.Euler(settings.rotationOffset);
+        }
+        else
+        {
+            Vector3 focusPoint = DetermineFocusPoint(settings);
+            Vector3 projectedPoint = ProjectPointOnPlane(focusPoint, planeNormal, PlaneOrigin);
+            desiredPosition = projectedPoint + settings.cameraOffset - planeNormal * settings.distance;
+
+            Vector3 lookDirection = focusPoint - desiredPosition;
+            if (lookDirection.sqrMagnitude < 0.001f)
+            {
+                lookDirection = -planeNormal;
+            }
+
+            desiredRotation = Quaternion.LookRotation(lookDirection.normalized, planeUp) * Quaternion.Euler(settings.rotationOffset);
+        }
+
+        if (instant || !settings.smoothPosition)
+        {
+            runtimeCamera.transform.position = desiredPosition;
+        }
+        else
+        {
+            runtimeCamera.transform.position = Vector3.SmoothDamp(runtimeCamera.transform.position, desiredPosition, ref velocity, settings.positionSmoothTime);
+        }
+
+        if (instant || !settings.smoothRotation)
+        {
+            runtimeCamera.transform.rotation = desiredRotation;
+        }
+        else
+        {
+            runtimeCamera.transform.rotation = Quaternion.Slerp(runtimeCamera.transform.rotation, desiredRotation, Time.deltaTime * settings.rotationSmoothSpeed);
+        }
+    }
+
+    /// <summary>
+    /// Détermine la cible de suivi en fonction des réglages de la zone.
+    /// </summary>
+    private Transform ResolveFollowTarget()
+    {
+        if (baseSettings.explicitFollowTarget != null)
+        {
+            return baseSettings.explicitFollowTarget;
+        }
+
+        if (baseSettings.followPlayerByDefault)
+        {
+            return activeActor;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Combine les réglages de base avec ceux des sous-zones actives.
+    /// </summary>
+    private ResolvedSettings ResolveSettings(Transform followTarget)
+    {
+        ResolvedSettings settings = new ResolvedSettings(baseSettings, followTarget);
+
+        // Les sous-zones s'appliquent dans l'ordre d'entrée, la dernière ayant la priorité.
+        for (int i = 0; i < activeSubZones.Count; i++)
+        {
+            TwoDZoneSubZone subZone = activeSubZones[i];
+            if (subZone == null)
+            {
+                continue;
+            }
+
+            subZone.ApplyOverrides(ref settings);
+        }
+
+        return settings;
+    }
+
+    /// <summary>
+    /// Détermine le point de focus de la caméra (centre de l'écran).
+    /// </summary>
+    private Vector3 DetermineFocusPoint(ResolvedSettings settings)
+    {
+        if (settings.followTarget != null)
+        {
+            return settings.followTarget.position + settings.followOffset;
+        }
+
+        // Si aucune cible n'est définie, on se base sur l'origine de la zone.
+        return PlaneOrigin + settings.followOffset;
+    }
+
+    /// <summary>
+    /// Calcule la normale du plan en fonction des réglages.
+    /// </summary>
+    internal static Vector3 ResolvePlaneNormal(CameraPlane plane, Vector3 customNormal)
+    {
+        return plane switch
+        {
+            CameraPlane.XY => Vector3.forward,
+            CameraPlane.XZ => Vector3.up,
+            CameraPlane.YZ => Vector3.right,
+            CameraPlane.Custom => customNormal.sqrMagnitude < 0.0001f ? Vector3.up : customNormal.normalized,
+            _ => Vector3.up
+        };
+    }
+
+    /// <summary>
+    /// Fournit un vecteur "up" cohérent pour LookRotation, même si la normale pointe vers le haut.
+    /// </summary>
+    private static Vector3 ResolvePlaneUp(Vector3 planeNormal)
+    {
+        Vector3 up = Vector3.up;
+        if (Mathf.Abs(Vector3.Dot(up.normalized, planeNormal.normalized)) > 0.99f)
+        {
+            // Si la normale est quasiment parallèle à l'up mondial, on choisit un autre axe.
+            up = Vector3.right;
+        }
+
+        return up;
+    }
+
+    /// <summary>
+    /// Projette un point sur le plan défini par une normale et une origine.
+    /// </summary>
+    private static Vector3 ProjectPointOnPlane(Vector3 point, Vector3 normal, Vector3 origin)
+    {
+        float distanceToPlane = Vector3.Dot(point - origin, normal);
+        return point - normal * distanceToPlane;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/TwoDZone.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/TwoDZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ab8ef5aeb14e2a82cfe37001b847f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/TwoDZoneSubZone.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TwoDZoneSubZone.cs
@@ -1,0 +1,195 @@
+using UnityEngine;
+
+/// <summary>
+/// Sous-zone permettant d'ajuster temporairement les paramètres d'une <see cref="TwoDZone"/>.
+/// Idéal pour créer des variations de distance, de FOV ou de comportement à l'intérieur
+/// d'une même zone principale (par exemple lors d'un couloir qui se resserre).
+/// </summary>
+[RequireComponent(typeof(Collider))]
+[AddComponentMenu("Camera/2D Sub Zone")]
+public class TwoDZoneSubZone : MonoBehaviour
+{
+    [Header("Références")]
+    [Tooltip("Zone 2D parente. Si vide, sera automatiquement recherchée dans les parents.")]
+    public TwoDZone parentZone;
+
+    [Header("Overrides")]
+    [Tooltip("Remplace la distance de caméra définie par la zone principale.")]
+    public bool overrideDistance;
+    public float distance = 6f;
+
+    [Tooltip("Remplace le champ de vision.")]
+    public bool overrideFieldOfView;
+    [Range(1f, 179f)]
+    public float fieldOfView = 55f;
+
+    [Tooltip("Remplace l'offset appliqué au suivi de la cible.")]
+    public bool overrideFollowOffset;
+    public Vector3 followOffset = new Vector3(0f, 1.6f, 0f);
+
+    [Tooltip("Remplace l'offset appliqué à la position de la caméra.")]
+    public bool overrideCameraOffset;
+    public Vector3 cameraOffset = Vector3.zero;
+
+    [Tooltip("Remplace l'offset de rotation.")]
+    public bool overrideRotationOffset;
+    public Vector3 rotationOffset = Vector3.zero;
+
+    [Tooltip("Remplace les réglages de lissage de position.")]
+    public bool overridePositionSmoothing;
+    public bool smoothPosition = true;
+    public float positionSmoothTime = 0.3f;
+
+    [Tooltip("Remplace les réglages de lissage de rotation.")]
+    public bool overrideRotationSmoothing;
+    public bool smoothRotation = true;
+    public float rotationSmoothSpeed = 6f;
+
+    [Tooltip("Remplace la durée de lissage du FOV.")]
+    public bool overrideFovSmoothTime;
+    public float fovSmoothTime = 0.25f;
+
+    [Tooltip("Remplace le plan de déplacement.")]
+    public bool overridePlane;
+    public TwoDZone.CameraPlane plane = TwoDZone.CameraPlane.XZ;
+    public Vector3 customPlaneNormal = Vector3.up;
+
+    [Tooltip("Forcer la caméra à rester fixe depuis cette sous-zone.")]
+    public bool overrideFixedBehaviour;
+    public bool keepCameraFixed;
+    public Transform fixedCameraAnchor;
+
+    [Tooltip("Override de la cible suivie.")]
+    public bool overrideFollowTarget;
+    public Transform followTargetOverride;
+
+    private Collider cachedCollider;
+
+    private void Reset()
+    {
+        Collider col = GetComponent<Collider>();
+        col.isTrigger = true;
+    }
+
+    private void Awake()
+    {
+        cachedCollider = GetComponent<Collider>();
+        if (cachedCollider != null)
+        {
+            cachedCollider.isTrigger = true;
+        }
+
+        if (parentZone == null)
+        {
+            parentZone = GetComponentInParent<TwoDZone>();
+        }
+    }
+
+    private void OnValidate()
+    {
+        Collider col = GetComponent<Collider>();
+        if (col != null)
+        {
+            col.isTrigger = true;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (parentZone == null)
+        {
+            return;
+        }
+
+        if (other.CompareTag(parentZone.playerTag))
+        {
+            parentZone.RegisterSubZone(this);
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (parentZone == null)
+        {
+            return;
+        }
+
+        if (other.CompareTag(parentZone.playerTag))
+        {
+            parentZone.UnregisterSubZone(this);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (parentZone != null)
+        {
+            parentZone.UnregisterSubZone(this);
+        }
+    }
+
+    /// <summary>
+    /// Applique les overrides actifs aux réglages courants de la zone.
+    /// </summary>
+    /// <param name="settings">Réglages à modifier.</param>
+    public void ApplyOverrides(ref TwoDZone.ResolvedSettings settings)
+    {
+        if (overrideDistance)
+        {
+            settings.distance = Mathf.Max(0f, distance);
+        }
+
+        if (overrideFieldOfView)
+        {
+            settings.fieldOfView = Mathf.Clamp(fieldOfView, 1f, 179f);
+        }
+
+        if (overrideFollowOffset)
+        {
+            settings.followOffset = followOffset;
+        }
+
+        if (overrideCameraOffset)
+        {
+            settings.cameraOffset = cameraOffset;
+        }
+
+        if (overrideRotationOffset)
+        {
+            settings.rotationOffset = rotationOffset;
+        }
+
+        if (overridePositionSmoothing)
+        {
+            settings.smoothPosition = smoothPosition;
+            settings.positionSmoothTime = Mathf.Max(0.01f, positionSmoothTime);
+        }
+
+        if (overrideRotationSmoothing)
+        {
+            settings.smoothRotation = smoothRotation;
+            settings.rotationSmoothSpeed = Mathf.Max(0.01f, rotationSmoothSpeed);
+        }
+
+        if (overrideFovSmoothTime)
+        {
+            settings.fovSmoothTime = Mathf.Max(0f, fovSmoothTime);
+        }
+
+        if (overridePlane)
+        {
+            settings.planeNormal = TwoDZone.ResolvePlaneNormal(plane, customPlaneNormal);
+        }
+
+        if (overrideFixedBehaviour)
+        {
+            settings.keepCameraFixed = keepCameraFixed;
+            settings.fixedCameraAnchor = fixedCameraAnchor;
+        }
+
+        if (overrideFollowTarget)
+        {
+            settings.followTarget = followTargetOverride != null ? followTargetOverride : settings.followTarget;
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/TwoDZoneSubZone.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/TwoDZoneSubZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 106d096e0c1c460584a2d93f3eee553a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- ajoute le composant `TwoDZone` permettant de verrouiller la caméra sur un plan 2D avec gestion du suivi, des offsets et du lissage
- ajoute `TwoDZoneSubZone` pour surcharger localement les paramètres de distance, FOV ou d’ancrage
- fournit un prefab `Camera2DZone` prêt à l’emploi avec une sous-zone d’exemple

## Tests
- Non applicable (configuration Unity uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68d8cd635d3c8325948b4433fe1648d8