### PR TITLE
Fix: réinitialisation du parent de la WorldCamera après Zone2D

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/SubZone2D.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SubZone2D.cs
@@ -66,6 +66,11 @@ public class SubZone2D : MonoBehaviour
 
     private Collider cachedCollider;
 
+    // Suivi de l'état d'occupation afin de savoir si le joueur est toujours présent lorsque la sous-zone
+    // est désactivée. Cela nous permet de prévenir la zone principale pour qu'elle restaure le parent
+    // de la WorldCamera immédiatement et évite des transitions bancales.
+    private bool playerInside;
+
     private void Reset()
     {
         Collider col = GetComponent<Collider>();
@@ -107,6 +112,7 @@ public class SubZone2D : MonoBehaviour
             // Dès que le joueur pénètre dans la sous-zone, on notifie la zone parente afin qu'elle
             // recalcule immédiatement ses paramètres (y compris la nouvelle cible WorldCam_Origin).
             parentZone.RegisterSubZone(this);
+            playerInside = true; // Mémorise l'état pour une désactivation éventuelle de la sous-zone.
         }
     }
 
@@ -122,15 +128,22 @@ public class SubZone2D : MonoBehaviour
             // Lorsque le joueur quitte le volume, on retire la sous-zone pour restaurer les réglages
             // par défaut de la zone 2D et redonner la main aux autres sous-zones éventuelles.
             parentZone.UnregisterSubZone(this);
+            playerInside = false;
         }
     }
 
     private void OnDisable()
     {
-        if (parentZone != null)
+        if (playerInside && parentZone != null)
         {
+            // Si la sous-zone s'éteint alors que le joueur est encore dedans (ex : activation/désactivation
+            // dynamique de volumes), on force immédiatement la zone principale à recalculer ses paramètres.
+            // Cela évite qu'un override temporaire laisse la WorldCamera attachée à un parent inattendu.
             parentZone.UnregisterSubZone(this);
         }
+
+        // Réinitialise l'état interne pour éviter toute incohérence à la prochaine activation.
+        playerInside = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/Zone2D.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/Zone2D.cs
@@ -131,6 +131,10 @@ public class Zone2D : MonoBehaviour
         public Vector3 rigPosition;
         public Quaternion rigRotation;
         public bool usedRig;
+
+        // Hiérarchie d'origine à restaurer pour la WorldCamera et pour son éventuel rig (WorldCam_Origin).
+        public Transform cameraParent;
+        public Transform rigParent;
     }
 
     private CameraBackup previousState;
@@ -166,6 +170,15 @@ public class Zone2D : MonoBehaviour
         {
             col.isTrigger = true;
         }
+    }
+
+    private void OnDisable()
+    {
+        // Si la zone est désactivée (ex : changement de scène, activation/désactivation dynamique),
+        // on force la sortie propre afin de restaurer immédiatement la hiérarchie et l'état de la caméra.
+        // Sans cette mesure, la WorldCamera pouvait rester attachée à un parent temporaire défini
+        // pendant la séquence 2D, ce qui provoquait des sauts ou des comportements inattendus ensuite.
+        DeactivateZone();
     }
 
     private void LateUpdate()
@@ -269,6 +282,9 @@ public class Zone2D : MonoBehaviour
         previousState.cameraRotation = cameraTransform.rotation;
         previousState.fieldOfView = runtimeCamera.fieldOfView;
         previousState.usedRig = runtimeCameraMotionRoot != null && runtimeCameraMotionRoot != cameraTransform;
+        // Conservation du parent pour restaurer la hiérarchie une fois sorti de la zone.
+        previousState.cameraParent = cameraTransform.parent;
+        previousState.rigParent = runtimeCameraMotionRoot != null ? runtimeCameraMotionRoot.parent : null;
         if (runtimeCameraMotionRoot != null)
         {
             // On mémorise systématiquement la position du pivot (WorldCam_Origin) afin de pouvoir
@@ -293,6 +309,20 @@ public class Zone2D : MonoBehaviour
         if (!zoneActive)
         {
             return;
+        }
+
+        Transform cameraTransform = runtimeCamera != null ? runtimeCamera.transform : null;
+
+        // On restaure en priorité la hiérarchie d'origine pour garantir que les prochaines mises à jour
+        // (par le CameraController ou d'autres systèmes) retrouvent exactement la même organisation.
+        if (previousState.usedRig && runtimeCameraMotionRoot != null)
+        {
+            RestoreTransformParent(runtimeCameraMotionRoot, previousState.rigParent);
+        }
+
+        if (cameraTransform != null)
+        {
+            RestoreTransformParent(cameraTransform, previousState.cameraParent);
         }
 
         if (runtimeCamera != null)
@@ -327,6 +357,37 @@ public class Zone2D : MonoBehaviour
         runtimeCamera = null;
         runtimeCameraMotionRoot = null;
         activeSubZones.Clear();
+    }
+
+    /// <summary>
+    /// Replace un transform sous son parent d'origine en conservant sa transformation monde.
+    /// </summary>
+    /// <param name="target">Transform à replacer.</param>
+    /// <param name="originalParent">Parent qui était actif avant l'entrée dans la zone.</param>
+    private static void RestoreTransformParent(Transform target, Transform originalParent)
+    {
+        if (target == null)
+        {
+            return;
+        }
+
+        Transform currentParent = target.parent;
+        if (currentParent == originalParent)
+        {
+            // Rien à faire si la hiérarchie n'a pas changé.
+            return;
+        }
+
+        if (originalParent != null)
+        {
+            // On conserve la transformation monde pour éviter tout déplacement indésirable.
+            target.SetParent(originalParent, true);
+        }
+        else
+        {
+            // Cas d'une caméra initialement à la racine : on détache simplement le transform.
+            target.SetParent(null, true);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- mémorisation et restauration du parent de la WorldCamera lors de l'entrée et la sortie d'une Zone2D
- sécurisation de la désactivation des zones et sous-zones pour libérer correctement la caméra
- nettoyage de l'état runtime des SubZone2D pour éviter les overrides persistants

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ef3425908325bb37b7b714b4dfd3