### PR TITLE
Corriger l'application des cibles Cinemachine 3.x

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleCameraManager.cs
@@ -658,18 +658,18 @@ public class BattleCameraManager : MonoBehaviour
 
         // 🔐 On force systématiquement la Cinemachine à considérer l'ancre comme source de Follow pour
         //     empêcher un autre système (Timeline, previous state, etc.) de déplacer la caméra après coup.
-        targetSettings.CustomFollowTarget = anchor != null;
-        targetSettings.FollowTarget = anchor;
+        //     Depuis Cinemachine 3.x, le booléen « CustomFollowTarget » n'existe plus : le moteur déduit
+        //     désormais automatiquement l'état à partir de la présence d'un transform. On assigne donc
+        //     directement la référence souhaitée.
+        targetSettings.Follow = anchor;
 
         if (lookTarget != null)
         {
-            targetSettings.CustomLookAtTarget = true;
-            targetSettings.LookAtTarget = lookTarget;
+            targetSettings.LookAt = lookTarget;
         }
         else
         {
-            targetSettings.CustomLookAtTarget = false;
-            targetSettings.LookAtTarget = null;
+            targetSettings.LookAt = null;
         }
 
         camera.Target = targetSettings;


### PR DESCRIPTION
## Résumé
- mettre à jour `BattleCameraManager` pour utiliser les nouvelles propriétés `Follow` et `LookAt` de `CinemachineCamera.Target`
- documenter via commentaire la disparition de `CustomFollowTarget` dans Cinemachine 3.x

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68d8f4cc495c83258816ad44fe5019b4