### PR TITLE
Ajout du système de sets d'inventaire pour les personnages

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using System.Collections.Generic; // Permet l'utilisation de listes génériques
 using UnityEngine.Timeline; // Référence aux timelines d'introduction
@@ -62,6 +63,19 @@ public class CharacterData : ScriptableObject, ITargetable
     public MusicalMoveSO[] musicalAttacks;
     [Tooltip("Attaque musicale toujours disponible")] public MusicalMoveSO specialMusicalMove;
 
+    [Header("Sets personnalisés")]
+    [Tooltip("Configurations d'attaques musicales favorites pour accélérer la sélection en combat.")]
+    public List<CharacterMusicalMoveSet> musicalMoveSets = new();
+
+    [Tooltip("Index utilisé au chargement pour activer un set musical spécifique. -1 pour aucun.")]
+    public int defaultMusicalMoveSetIndex = -1;
+
+    [Tooltip("Configurations d'items favorites pour mettre en avant les objets clefs en combat.")]
+    public List<CharacterItemSet> itemSets = new();
+
+    [Tooltip("Index utilisé au chargement pour activer un set d'objets spécifique. -1 pour aucun.")]
+    public int defaultItemSetIndex = -1;
+
     [Header("Etat (runtime)")]
     public float currentInitiative;
     public float currentRange;
@@ -80,6 +94,9 @@ public class CharacterData : ScriptableObject, ITargetable
     public float currentSpeed;
     public float currentInterceptionRange;
     public float currentInterceptionChance;
+
+    [HideInInspector] public int currentMusicalMoveSetIndex = -1;
+    [HideInInspector] public int currentItemSetIndex = -1;
 
     [Header("Effets visuels et sonores")]
     public AudioClipSO hitSound;
@@ -157,11 +174,193 @@ public class CharacterData : ScriptableObject, ITargetable
         currentMobility = baseMobility;
         currentRange = baseRange;
         currentFatigue = baseFatigue;
+
+        // Assure que les sets actifs sont correctement initialisés pour les combats.
+        currentMusicalMoveSetIndex = NormalizeSetIndex(musicalMoveSets, defaultMusicalMoveSetIndex);
+        currentItemSetIndex = NormalizeSetIndex(itemSets, defaultItemSetIndex);
     }
 
     public Transform GetTransform()
     {
         return owner != null ? owner.transform : null;
+    }
+
+    /// <summary>
+    /// Retourne la configuration d'attaques musicales actuellement active pour ce personnage.
+    /// </summary>
+    public CharacterMusicalMoveSet GetActiveMusicalMoveSet()
+    {
+        if (musicalMoveSets == null || musicalMoveSets.Count == 0)
+            return null; // Aucun set défini : on conserve l'ordre par défaut.
+
+        if (currentMusicalMoveSetIndex < 0 || currentMusicalMoveSetIndex >= musicalMoveSets.Count)
+            currentMusicalMoveSetIndex = NormalizeSetIndex(musicalMoveSets, 0);
+
+        return currentMusicalMoveSetIndex >= 0 ? musicalMoveSets[currentMusicalMoveSetIndex] : null;
+    }
+
+    /// <summary>
+    /// Retourne la configuration d'items actuellement active pour ce personnage.
+    /// </summary>
+    public CharacterItemSet GetActiveItemSet()
+    {
+        if (itemSets == null || itemSets.Count == 0)
+            return null;
+
+        if (currentItemSetIndex < 0 || currentItemSetIndex >= itemSets.Count)
+            currentItemSetIndex = NormalizeSetIndex(itemSets, 0);
+
+        return currentItemSetIndex >= 0 ? itemSets[currentItemSetIndex] : null;
+    }
+
+    /// <summary>
+    /// Met à jour le set d'attaques musicales actif en se basant sur son nom.
+    /// </summary>
+    public void SetActiveMusicalMoveSet(string setName)
+    {
+        if (musicalMoveSets == null || musicalMoveSets.Count == 0)
+        {
+            currentMusicalMoveSetIndex = -1;
+            return;
+        }
+
+        for (int i = 0; i < musicalMoveSets.Count; i++)
+        {
+            if (musicalMoveSets[i] == null)
+                continue;
+
+            if (string.Equals(musicalMoveSets[i].setName, setName, StringComparison.OrdinalIgnoreCase))
+            {
+                currentMusicalMoveSetIndex = i;
+                return;
+            }
+        }
+
+        // Aucun set ne correspond au nom renseigné : on se replie sur le premier.
+        currentMusicalMoveSetIndex = NormalizeSetIndex(musicalMoveSets, 0);
+    }
+
+    /// <summary>
+    /// Met à jour le set d'items actif en se basant sur son nom.
+    /// </summary>
+    public void SetActiveItemSet(string setName)
+    {
+        if (itemSets == null || itemSets.Count == 0)
+        {
+            currentItemSetIndex = -1;
+            return;
+        }
+
+        for (int i = 0; i < itemSets.Count; i++)
+        {
+            if (itemSets[i] == null)
+                continue;
+
+            if (string.Equals(itemSets[i].setName, setName, StringComparison.OrdinalIgnoreCase))
+            {
+                currentItemSetIndex = i;
+                return;
+            }
+        }
+
+        currentItemSetIndex = NormalizeSetIndex(itemSets, 0);
+    }
+
+    /// <summary>
+    /// Applique l'ordre défini dans le set actif aux attaques musicales proposées.
+    /// </summary>
+    public List<MusicalMoveSO> ApplyMusicalSetOrdering(IList<MusicalMoveSO> availableMoves)
+    {
+        var result = new List<MusicalMoveSO>();
+        if (availableMoves == null)
+            return result;
+
+        var activeSet = GetActiveMusicalMoveSet();
+
+        if (activeSet != null && activeSet.prioritizedMoves != null)
+        {
+            foreach (var prioritized in activeSet.prioritizedMoves)
+            {
+                if (prioritized == null)
+                    continue; // Sécurité : ignore les références manquantes.
+
+                for (int i = 0; i < availableMoves.Count; i++)
+                {
+                    var candidate = availableMoves[i];
+                    if (candidate == null || candidate != prioritized)
+                        continue;
+
+                    if (!result.Contains(candidate))
+                        result.Add(candidate); // Place le move favori en tête de liste.
+                    break;
+                }
+            }
+        }
+
+        foreach (var move in availableMoves)
+        {
+            if (move == null)
+                continue;
+
+            if (!result.Contains(move))
+                result.Add(move); // Conserve les autres attaques dans leur ordre original.
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Applique l'ordre défini dans le set actif aux items proposés.
+    /// </summary>
+    public List<ItemData> ApplyItemSetOrdering(IList<ItemData> availableItems)
+    {
+        var result = new List<ItemData>();
+        if (availableItems == null)
+            return result;
+
+        var activeSet = GetActiveItemSet();
+
+        if (activeSet != null && activeSet.prioritizedItems != null)
+        {
+            foreach (var prioritized in activeSet.prioritizedItems)
+            {
+                if (prioritized == null)
+                    continue;
+
+                for (int i = 0; i < availableItems.Count; i++)
+                {
+                    var candidate = availableItems[i];
+                    if (candidate == null || candidate != prioritized)
+                        continue;
+
+                    if (!result.Contains(candidate))
+                        result.Add(candidate);
+                    break;
+                }
+            }
+        }
+
+        foreach (var item in availableItems)
+        {
+            if (item == null)
+                continue;
+
+            if (!result.Contains(item))
+                result.Add(item);
+        }
+
+        return result;
+    }
+
+    private static int NormalizeSetIndex<T>(IList<T> sets, int desiredIndex)
+    {
+        if (sets == null || sets.Count == 0)
+            return -1;
+
+        if (desiredIndex < 0 || desiredIndex >= sets.Count)
+            return sets.Count > 0 ? 0 : -1;
+
+        return desiredIndex;
     }
 }
 

--- a/Assets/Scripts/Classes/CharacterLoadoutSet.cs
+++ b/Assets/Scripts/Classes/CharacterLoadoutSet.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Regroupe toutes les données permettant de décrire un ensemble
+/// préconfiguré pour un personnage jouable.
+/// </summary>
+[System.Serializable]
+public class CharacterMusicalMoveSet
+{
+    [Tooltip("Nom affiché dans l'éditeur pour identifier rapidement ce set.")]
+    public string setName = "Répertoire principal";
+
+    [Tooltip("Liste des attaques musicales mises en avant pour ce set.")]
+    public List<MusicalMoveSO> prioritizedMoves = new();
+}
+
+/// <summary>
+/// Décrit un regroupement d'items favoris pour accélérer la navigation dans les menus.
+/// </summary>
+[System.Serializable]
+public class CharacterItemSet
+{
+    [Tooltip("Nom affiché dans l'éditeur pour identifier rapidement ce set d'objets.")]
+    public string setName = "Trousses favorites";
+
+    [Tooltip("Items à mettre en tête de liste lorsque ce set est actif.")]
+    public List<ItemData> prioritizedItems = new();
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -76,6 +76,60 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public PlayableDirector BattleDirector => battleDirector;
 
+    #region Gestion des sets personnalisés
+    /// <summary>
+    /// Renvoie le set d'attaques musicales actuellement actif pour cette unité.
+    /// </summary>
+    public CharacterMusicalMoveSet ActiveMusicalMoveSet => Data?.GetActiveMusicalMoveSet();
+
+    /// <summary>
+    /// Renvoie le set d'objets actuellement actif pour cette unité.
+    /// </summary>
+    public CharacterItemSet ActiveItemSet => Data?.GetActiveItemSet();
+
+    /// <summary>
+    /// Active un set d'attaques musicales spécifique en fonction de son nom.
+    /// </summary>
+    public void ActivateMusicalMoveSet(string setName)
+    {
+        Data?.SetActiveMusicalMoveSet(setName);
+    }
+
+    /// <summary>
+    /// Active un set d'objets spécifique en fonction de son nom.
+    /// </summary>
+    public void ActivateItemSet(string setName)
+    {
+        Data?.SetActiveItemSet(setName);
+    }
+
+    /// <summary>
+    /// Retourne une nouvelle liste d'attaques musicales en respectant l'ordre du set actif.
+    /// </summary>
+    public List<MusicalMoveSO> OrderMovesForCurrentSet(IList<MusicalMoveSO> baseMoves)
+    {
+        if (baseMoves == null)
+            return new List<MusicalMoveSO>();
+
+        return Data != null
+            ? Data.ApplyMusicalSetOrdering(baseMoves)
+            : new List<MusicalMoveSO>(baseMoves);
+    }
+
+    /// <summary>
+    /// Retourne une nouvelle liste d'items en respectant l'ordre du set actif.
+    /// </summary>
+    public List<ItemData> OrderItemsForCurrentSet(IList<ItemData> availableItems)
+    {
+        if (availableItems == null)
+            return new List<ItemData>();
+
+        return Data != null
+            ? Data.ApplyItemSetOrdering(availableItems)
+            : new List<ItemData>(availableItems);
+    }
+    #endregion
+
     /// <summary>
     /// Indique si l'unité est en état Awake (fusion avec l'ange gardien).
     /// </summary>

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -50,9 +50,20 @@ public class InventoryManager : MonoBehaviour
 
     /// <summary>
     /// Renvoie la liste des items possédés et utilisables en combat.
+    /// Lorsque <paramref name="prioritizedFor"/> est défini, les items sont
+    /// réordonnés pour placer les favoris du set actif en tête de liste.
     /// </summary>
-    public List<ItemData> GetUsableItems()
-        => inventoryItems.Where(item => item.isUsableInBattle && CanUseItem(item)).ToList();
+    public List<ItemData> GetUsableItems(CharacterUnit prioritizedFor = null)
+    {
+        var usable = inventoryItems
+            .Where(item => item != null && item.isUsableInBattle && CanUseItem(item))
+            .ToList();
+
+        if (prioritizedFor == null || prioritizedFor.Data == null)
+            return usable;
+
+        return prioritizedFor.OrderItemsForCurrentSet(usable);
+    }
 
     /// <summary>
     /// Ajoute un item à l'inventaire (uniquement si c'est un item valide du jeu).

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1734,7 +1734,7 @@ public class NewBattleManager : MonoBehaviour
             caster.GetHarmonicCount(caster.Data.harmonicType) >= m.harmonicCost &&
             (!m.enterAwake || caster.GetHarmonicCount(caster.Data.harmonicType) >= caster.Data.resonancePoint) &&
             !caster.IsMoveOnCooldown(m));
-        bool hasItem = InventoryManager.Instance.GetUsableItems().Count > 0;
+        bool hasItem = InventoryManager.Instance.GetUsableItems(caster).Count > 0;
 
         if (!hasSkill && !hasItem)
             EndTurn();
@@ -2455,6 +2455,9 @@ public class NewBattleManager : MonoBehaviour
             .Where(m => currentCharacterUnit.CanUseMove(m))
             .ToList();
 
+        // Réordonne les attaques selon le set sélectionné afin de mettre en avant les favoris.
+        skillChoices = currentCharacterUnit.OrderMovesForCurrentSet(skillChoices);
+
         // Détermine le mouvement spécial autorisé, qui sera affiché dans le 4e slot
         specialMoveChoice = (currentCharacterUnit.Data.specialMusicalMove != null &&
             currentCharacterUnit.CanUseMove(currentCharacterUnit.Data.specialMusicalMove))
@@ -2591,7 +2594,7 @@ public class NewBattleManager : MonoBehaviour
         // Démarre la Timeline d'attente de sélection d'objet
         StartItemPreparingTimeline();
 
-        itemChoices = InventoryManager.Instance.GetUsableItems();
+        itemChoices = InventoryManager.Instance.GetUsableItems(currentCharacterUnit);
 
         // 6) Création des boutons d’items
         for (int i = 0; i < itemChoices.Count && i < currentItemsMenuSlots.Count; i++)

--- a/Docs/SystemeSetsInventaire.md
+++ b/Docs/SystemeSetsInventaire.md
@@ -1,0 +1,57 @@
+# Système de sets d'inventaire et de répertoire musical
+
+Afin de respecter l'intention de Symphonie, chaque personnage jouable peut désormais
+configurer des ensembles de compétences et d'objets favoris. Ces sets permettent
+de mettre en avant les outils les plus utilisés tout en conservant l'accès complet
+à tout le répertoire d'un héros.
+
+## Principes généraux
+
+- **Accessibilité** : les débutants retrouvent immédiatement leurs actions
+  essentielles, affichées en tête de liste dans les menus de combat.
+- **Profondeur** : les joueurs expérimentés peuvent préparer plusieurs combinaisons
+  de MusicalMoves et d'Items pour adapter leur stratégie aux événements de
+  l'histoire décrite dans `HistoireSymphonie.md`.
+- **Souplesse** : lorsqu'aucun set n'est actif, l'ordre original est conservé et
+  toutes les actions restent disponibles sans restriction.
+
+## Configuration dans l'inspecteur Unity
+
+Chaque `CharacterData` expose deux nouvelles listes :
+
+1. **Sets personnalisés d'attaques musicales** (`musicalMoveSets`)
+   - `setName` : nom éditorial pour identifier rapidement le set.
+   - `prioritizedMoves` : liste ordonnée de `MusicalMoveSO` mis en avant.
+   - `defaultMusicalMoveSetIndex` permet de choisir le set actif par défaut
+     (mettre `-1` pour conserver l'ordre original).
+2. **Sets personnalisés d'items** (`itemSets`)
+   - `setName` : identifiant du regroupement d'objets.
+   - `prioritizedItems` : liste ordonnée des `ItemData` favoris.
+   - `defaultItemSetIndex` suit la même logique que pour les attaques.
+
+Les champs `currentMusicalMoveSetIndex` et `currentItemSetIndex` sont gérés
+automatiquement au lancement d'un combat.
+
+## Utilisation en jeu
+
+- Le menu de compétences appelle automatiquement `OrderMovesForCurrentSet` pour
+  afficher les MusicalMoves favoris en premier.
+- L'ouverture de l'inventaire utilise `OrderItemsForCurrentSet` afin de proposer
+  les objets clefs avant le reste de la réserve.
+- Les listes complètes restent intactes : si un set ne contient pas une entrée,
+  elle sera tout de même disponible après les favoris.
+
+## Conseils de conception
+
+- Créez un set « Apprentissage » avec trois actions simples pour les premiers
+  combats d'un personnage, puis un set « Maîtrise » reprenant les combinaisons
+  avancées reliées aux arcs narratifs de la symphonie.
+- N'oubliez pas de maintenir la documentation des MusicalMoves et Items lorsque
+  vous en créez de nouveaux : leurs descriptions doivent rester cohérentes avec
+  l'évolution de l'histoire.
+- Lors d'un changement majeur d'équipement (par exemple après une scène clé du
+  `Docs/HistoireSymphonie.md`), basculez vers un set adapté via
+  `CharacterUnit.ActivateMusicalMoveSet` ou `ActivateItemSet`.
+
+Ce système vise à fluidifier les combats tout en préservant la richesse
+chorégraphique propre à Symphonie.


### PR DESCRIPTION
## Summary
- ajoute les classes de sets favoris pour les attaques musicales et les objets des personnages
- priorise automatiquement les listes de compétences et d'items en fonction du set actif dans les menus de combat
- documente la configuration du nouveau système de sets et expose des méthodes utilitaires dans CharacterUnit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91f02b4988325beaced51c4dbb180