### PR TITLE
feat: build inventory set management UI

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InventorySetPanelController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventorySetPanelController.cs
@@ -1,0 +1,1018 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+
+/// <summary>
+/// Gestionnaire principal de l'onglet "Inventory_Sets". Cette classe orchestre
+/// la navigation entre les deux viewports (attaques musicales et items), permet
+/// de construire des sets personnalisés puis de les sauvegarder ou de les
+/// supprimer.
+/// </summary>
+public class InventorySetPanelController : MonoBehaviour, PlayerInputs.IInventoryActions
+{
+    public static InventorySetPanelController Instance { get; private set; }
+
+    [Header("Racine UI")]
+    [Tooltip("GameObject racine du panneau d'inventaire.")]
+    [SerializeField] private GameObject panelRoot;
+
+    [Header("Viewports de sélection")]
+    [SerializeField] private InventoryViewportController musicalViewport;
+    [SerializeField] private InventoryViewportController itemViewport;
+
+    [Header("Sélection des sets existants")]
+    [SerializeField] private TMP_Dropdown musicalSetsDropdown;
+    [SerializeField] private TMP_Dropdown itemSetsDropdown;
+
+    [Header("Boutons d'action")]
+    [SerializeField] private Button saveMusicalSetButton;
+    [SerializeField] private Button deleteMusicalSetButton;
+    [SerializeField] private Button saveItemSetButton;
+    [SerializeField] private Button deleteItemSetButton;
+    [SerializeField] private Button closeButton;
+
+    [Header("Libellés d'aide")]
+    [SerializeField] private TextMeshProUGUI headerLabel;
+    [SerializeField] private TextMeshProUGUI helperLabel;
+    [SerializeField] private TextMeshProUGUI feedbackLabel;
+
+    [Header("Textes par défaut")]
+    [SerializeField] private string musicalViewportTitle = "Répertoire musical";
+    [SerializeField] private string itemViewportTitle = "Sac d'objets";
+    [SerializeField] [TextArea] private string helperNavigationText = "🕹️ Joystick pour naviguer — ✅ pour ajouter/retirer — ❌ pour fermer.";
+
+    // Données runtime manipulées par le panneau.
+    private readonly List<ItemData> availableItems = new();
+    private readonly List<InventorySetSlot> musicalSelection = new();
+    private readonly List<InventorySetSlot> itemSelection = new();
+    private readonly Dictionary<MusicalMoveSO, InventorySetSlot> musicalSlotLookup = new();
+    private readonly Dictionary<ItemData, InventorySetSlot> itemSlotLookup = new();
+    private readonly List<int> musicalDropdownMap = new();
+    private readonly List<int> itemDropdownMap = new();
+
+    private InventoryViewportController[] viewports;
+    private int currentViewportIndex = 0;
+    private bool isOpen = false;
+    private bool ownsLocalInputs = false;
+    private bool isAwaitingNameInput = false;
+
+    private CharacterUnit currentCharacter;
+    private InputsManager inputsManager;
+    private PlayerInputs playerInputs;
+
+    private enum PendingPromptType { None, SaveMusical, SaveItem }
+    private PendingPromptType pendingPrompt = PendingPromptType.None;
+    private string pendingSetName = string.Empty;
+    private List<MusicalMoveSO> pendingMusicalOrder;
+    private List<ItemData> pendingItemOrder;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        inputsManager = InputsManager.Instance;
+        if (inputsManager != null)
+        {
+            playerInputs = inputsManager.playerInputs;
+            ownsLocalInputs = false;
+        }
+        else
+        {
+            playerInputs = new PlayerInputs();
+            ownsLocalInputs = true;
+        }
+
+        if (panelRoot == null)
+            panelRoot = gameObject;
+
+        panelRoot.SetActive(false);
+        viewports = new[] { musicalViewport, itemViewport };
+
+        RegisterButton(saveMusicalSetButton, RequestSaveMusicalSet);
+        RegisterButton(deleteMusicalSetButton, RequestDeleteMusicalSet);
+        RegisterButton(saveItemSetButton, RequestSaveItemSet);
+        RegisterButton(deleteItemSetButton, RequestDeleteItemSet);
+        RegisterButton(closeButton, ClosePanel);
+
+        if (musicalSetsDropdown != null)
+            musicalSetsDropdown.onValueChanged.AddListener(OnMusicalSetDropdownChanged);
+        if (itemSetsDropdown != null)
+            itemSetsDropdown.onValueChanged.AddListener(OnItemSetDropdownChanged);
+    }
+
+    private void OnDestroy()
+    {
+        if (musicalSetsDropdown != null)
+            musicalSetsDropdown.onValueChanged.RemoveListener(OnMusicalSetDropdownChanged);
+        if (itemSetsDropdown != null)
+            itemSetsDropdown.onValueChanged.RemoveListener(OnItemSetDropdownChanged);
+
+        if (ownsLocalInputs && playerInputs != null)
+            playerInputs.Dispose();
+    }
+
+    private void OnEnable()
+    {
+        if (playerInputs != null)
+            playerInputs.World.Inventory.performed += OnInventoryShortcut;
+    }
+
+    private void OnDisable()
+    {
+        if (playerInputs != null)
+            playerInputs.World.Inventory.performed -= OnInventoryShortcut;
+
+        // Sécurité : garantit la fermeture même en cas de désactivation extérieure.
+        if (isOpen)
+            ClosePanelImmediate();
+    }
+
+    #region Configuration publique
+
+    /// <summary>
+    /// Définit le personnage dont on souhaite configurer les sets.
+    /// </summary>
+    public void SetTargetCharacter(CharacterUnit unit)
+    {
+        currentCharacter = unit;
+        RebuildMusicalSlots();
+        RefreshMusicalSetDropdown();
+    }
+
+    /// <summary>
+    /// Indique la liste d'objets disponibles pour la construction des sets.
+    /// </summary>
+    public void SetAvailableItems(IEnumerable<ItemData> items)
+    {
+        availableItems.Clear();
+        if (items != null)
+            availableItems.AddRange(items.Where(i => i != null));
+
+        RebuildItemSlots();
+        RefreshItemSetDropdown();
+    }
+
+    #endregion
+
+    #region Ouverture / fermeture du panneau
+
+    /// <summary>
+    /// Appelé par l'InputsManager lorsque le joueur presse la touche d'inventaire.
+    /// </summary>
+    private void OnInventoryShortcut(InputAction.CallbackContext context)
+    {
+        if (!context.performed)
+            return;
+
+        if (isOpen)
+            ClosePanel();
+        else
+            OpenPanel();
+    }
+
+    /// <summary>
+    /// Ouvre le panneau et active la map d'inputs "Inventory" uniquement.
+    /// </summary>
+    private void OpenPanel()
+    {
+        if (isOpen)
+            return;
+
+        if (panelRoot != null)
+            panelRoot.SetActive(true);
+
+        if (inputsManager != null)
+            inputsManager.ActivateOnly(playerInputs.Inventory.Get());
+        else
+            playerInputs.Inventory.Enable();
+
+        playerInputs.Inventory.AddCallbacks(this);
+        isOpen = true;
+        isAwaitingNameInput = false;
+
+        SelectViewport(0);
+        UpdateHelperTexts();
+        ShowFeedback("Bienvenue dans la gestion des sets !");
+
+        // Propose par défaut les objets actuellement dans l'inventaire si aucun contexte n'a été fourni.
+        if (availableItems.Count == 0 && InventoryManager.Instance != null)
+            SetAvailableItems(InventoryManager.Instance.GetInventoryItems());
+
+        // S'assure que les slots reflètent la configuration courante.
+        RebuildMusicalSlots();
+        RebuildItemSlots();
+        ApplyMusicalSetFromDropdown();
+        ApplyItemSetFromDropdown();
+    }
+
+    /// <summary>
+    /// Ferme le panneau et réactive les contrôles monde.
+    /// </summary>
+    public void ClosePanel()
+    {
+        if (!isOpen)
+            return;
+
+        ClosePanelImmediate();
+
+        if (inputsManager != null)
+            inputsManager.ActivateOnly(playerInputs.World.Get());
+        else
+            playerInputs.World.Enable();
+    }
+
+    /// <summary>
+    /// Ferme le panneau sans réactiver automatiquement les autres maps
+    /// (utilisé lors des OnDisable pour éviter les appels superflus).
+    /// </summary>
+    private void ClosePanelImmediate()
+    {
+        if (panelRoot != null)
+            panelRoot.SetActive(false);
+
+        if (playerInputs != null)
+        {
+            playerInputs.Inventory.RemoveCallbacks(this);
+            playerInputs.Inventory.Disable();
+        }
+        isOpen = false;
+        isAwaitingNameInput = false;
+        pendingPrompt = PendingPromptType.None;
+    }
+
+    #endregion
+
+    #region Gestion des slots et des viewports
+
+    private void RebuildMusicalSlots()
+    {
+        if (musicalViewport == null)
+            return;
+
+        musicalViewport.Clear();
+        musicalSelection.Clear();
+        musicalSlotLookup.Clear();
+
+        var data = currentCharacter?.Data;
+        if (data == null)
+        {
+            ShowFeedback("Aucun personnage sélectionné.");
+            return;
+        }
+
+        HashSet<MusicalMoveSO> uniqueMoves = new();
+        if (data.musicalAttacks != null)
+        {
+            foreach (var move in data.musicalAttacks)
+            {
+                if (move == null || !uniqueMoves.Add(move))
+                    continue;
+
+                CreateMusicalSlot(move);
+            }
+        }
+
+        if (data.specialMusicalMove != null && uniqueMoves.Add(data.specialMusicalMove))
+            CreateMusicalSlot(data.specialMusicalMove);
+
+        musicalViewport.FocusFirstEntry();
+    }
+
+    private void RebuildItemSlots()
+    {
+        if (itemViewport == null)
+            return;
+
+        itemViewport.Clear();
+        itemSelection.Clear();
+        itemSlotLookup.Clear();
+
+        if (availableItems.Count == 0)
+        {
+            ShowFeedback("Aucun objet disponible pour construire un set.");
+            return;
+        }
+
+        HashSet<ItemData> uniqueItems = new();
+        foreach (var item in availableItems)
+        {
+            if (item == null || !uniqueItems.Add(item))
+                continue;
+
+            var slot = itemViewport.CreateSlot();
+            if (slot == null)
+                continue;
+
+            slot.BindItem(item);
+            slot.Clicked += OnSlotClicked;
+            itemSlotLookup[item] = slot;
+        }
+
+        itemViewport.FocusFirstEntry();
+    }
+
+    private void CreateMusicalSlot(MusicalMoveSO move)
+    {
+        var slot = musicalViewport.CreateSlot();
+        if (slot == null)
+            return;
+
+        slot.BindMusicalMove(move);
+        slot.Clicked += OnSlotClicked;
+        musicalSlotLookup[move] = slot;
+    }
+
+    private void OnSlotClicked(InventorySetSlot slot)
+    {
+        if (!isOpen || slot == null || isAwaitingNameInput)
+            return;
+
+        ToggleSlotSelection(slot);
+    }
+
+    private void ToggleSlotSelection(InventorySetSlot slot)
+    {
+        if (slot.Kind == InventorySetSlot.SlotKind.MusicalMove)
+        {
+            if (slot.BoundMove == null)
+                return;
+
+            ToggleSlotInList(slot, musicalSelection);
+        }
+        else
+        {
+            if (slot.BoundItem == null)
+                return;
+
+            ToggleSlotInList(slot, itemSelection);
+        }
+    }
+
+    private static void ToggleSlotInList(InventorySetSlot slot, List<InventorySetSlot> list)
+    {
+        if (!slot.IsSelected)
+        {
+            list.Add(slot);
+            slot.SetOrderIndex(list.Count - 1);
+        }
+        else
+        {
+            int index = list.IndexOf(slot);
+            if (index < 0)
+                return;
+
+            list.RemoveAt(index);
+            slot.SetOrderIndex(-1);
+
+            for (int i = index; i < list.Count; i++)
+                list[i].SetOrderIndex(i);
+        }
+    }
+
+    private void SelectViewport(int index)
+    {
+        if (viewports == null || viewports.Length == 0)
+            return;
+
+        if (index < 0)
+            index = viewports.Length - 1;
+        if (index >= viewports.Length)
+            index = 0;
+
+        currentViewportIndex = index;
+
+        for (int i = 0; i < viewports.Length; i++)
+            viewports[i]?.SetFocus(i == currentViewportIndex);
+
+        viewports[currentViewportIndex]?.FocusFirstEntry();
+        UpdateHelperTexts();
+    }
+
+    private InventoryViewportController CurrentViewport =>
+        (viewports != null && currentViewportIndex >= 0 && currentViewportIndex < viewports.Length)
+            ? viewports[currentViewportIndex]
+            : null;
+
+    #endregion
+
+    #region Dropdowns et chargement des sets
+
+    private void RefreshMusicalSetDropdown(string setToSelect = null)
+    {
+        if (musicalSetsDropdown == null)
+            return;
+
+        musicalDropdownMap.Clear();
+        musicalSetsDropdown.ClearOptions();
+        musicalSetsDropdown.value = 0;
+        musicalSetsDropdown.RefreshShownValue();
+
+        var data = currentCharacter?.Data;
+        if (data == null || data.musicalMoveSets == null || data.musicalMoveSets.Count == 0)
+            return;
+
+        List<string> options = new();
+        for (int i = 0; i < data.musicalMoveSets.Count; i++)
+        {
+            var set = data.musicalMoveSets[i];
+            if (set == null || string.IsNullOrWhiteSpace(set.setName))
+                continue;
+
+            musicalDropdownMap.Add(i);
+            options.Add(set.setName);
+        }
+
+        musicalSetsDropdown.AddOptions(options);
+
+        if (options.Count == 0)
+            return;
+
+        int targetIndex = 0;
+        if (!string.IsNullOrWhiteSpace(setToSelect))
+        {
+            int idx = options.FindIndex(o => string.Equals(o, setToSelect, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0)
+                targetIndex = idx;
+        }
+
+        musicalSetsDropdown.value = targetIndex;
+        musicalSetsDropdown.RefreshShownValue();
+    }
+
+    private void RefreshItemSetDropdown(string setToSelect = null)
+    {
+        if (itemSetsDropdown == null)
+            return;
+
+        itemDropdownMap.Clear();
+        itemSetsDropdown.ClearOptions();
+        itemSetsDropdown.value = 0;
+        itemSetsDropdown.RefreshShownValue();
+
+        var data = currentCharacter?.Data;
+        if (data == null || data.itemSets == null || data.itemSets.Count == 0)
+            return;
+
+        List<string> options = new();
+        for (int i = 0; i < data.itemSets.Count; i++)
+        {
+            var set = data.itemSets[i];
+            if (set == null || string.IsNullOrWhiteSpace(set.setName))
+                continue;
+
+            itemDropdownMap.Add(i);
+            options.Add(set.setName);
+        }
+
+        itemSetsDropdown.AddOptions(options);
+
+        if (options.Count == 0)
+            return;
+
+        int targetIndex = 0;
+        if (!string.IsNullOrWhiteSpace(setToSelect))
+        {
+            int idx = options.FindIndex(o => string.Equals(o, setToSelect, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0)
+                targetIndex = idx;
+        }
+
+        itemSetsDropdown.value = targetIndex;
+        itemSetsDropdown.RefreshShownValue();
+    }
+
+    private void OnMusicalSetDropdownChanged(int index)
+    {
+        if (!isOpen || isAwaitingNameInput)
+            return;
+
+        ApplyMusicalSetFromDropdown();
+    }
+
+    private void OnItemSetDropdownChanged(int index)
+    {
+        if (!isOpen || isAwaitingNameInput)
+            return;
+
+        ApplyItemSetFromDropdown();
+    }
+
+    private void ApplyMusicalSetFromDropdown()
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.musicalMoveSets == null)
+            return;
+
+        CharacterMusicalMoveSet selected = null;
+        if (musicalSetsDropdown != null && musicalDropdownMap.Count > 0)
+        {
+            int uiIndex = Mathf.Clamp(musicalSetsDropdown.value, 0, musicalDropdownMap.Count - 1);
+            int dataIndex = musicalDropdownMap[uiIndex];
+            if (dataIndex >= 0 && dataIndex < data.musicalMoveSets.Count)
+                selected = data.musicalMoveSets[dataIndex];
+        }
+
+        ApplyMusicalSet(selected);
+    }
+
+    private void ApplyItemSetFromDropdown()
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.itemSets == null)
+            return;
+
+        CharacterItemSet selected = null;
+        if (itemSetsDropdown != null && itemDropdownMap.Count > 0)
+        {
+            int uiIndex = Mathf.Clamp(itemSetsDropdown.value, 0, itemDropdownMap.Count - 1);
+            int dataIndex = itemDropdownMap[uiIndex];
+            if (dataIndex >= 0 && dataIndex < data.itemSets.Count)
+                selected = data.itemSets[dataIndex];
+        }
+
+        ApplyItemSet(selected);
+    }
+
+    private void ApplyMusicalSet(CharacterMusicalMoveSet set)
+    {
+        musicalSelection.Clear();
+        foreach (var slot in musicalSlotLookup.Values)
+            slot.SetOrderIndex(-1);
+
+        if (set == null || set.prioritizedMoves == null)
+            return;
+
+        foreach (var move in set.prioritizedMoves)
+        {
+            if (move == null)
+                continue;
+
+            if (!musicalSlotLookup.TryGetValue(move, out var slot))
+                continue;
+
+            if (musicalSelection.Contains(slot))
+                continue;
+
+            musicalSelection.Add(slot);
+            slot.SetOrderIndex(musicalSelection.Count - 1);
+        }
+    }
+
+    private void ApplyItemSet(CharacterItemSet set)
+    {
+        itemSelection.Clear();
+        foreach (var slot in itemSlotLookup.Values)
+            slot.SetOrderIndex(-1);
+
+        if (set == null || set.prioritizedItems == null)
+            return;
+
+        foreach (var item in set.prioritizedItems)
+        {
+            if (item == null)
+                continue;
+
+            if (!itemSlotLookup.TryGetValue(item, out var slot))
+                continue;
+
+            if (itemSelection.Contains(slot))
+                continue;
+
+            itemSelection.Add(slot);
+            slot.SetOrderIndex(itemSelection.Count - 1);
+        }
+    }
+
+    #endregion
+
+    #region Sauvegarde / suppression des sets
+
+    private void RequestSaveMusicalSet()
+    {
+        if (!isOpen || isAwaitingNameInput)
+            return;
+
+        if (currentCharacter?.Data == null)
+        {
+            ShowFeedback("Aucun personnage sélectionné.");
+            return;
+        }
+
+        pendingPrompt = PendingPromptType.SaveMusical;
+        pendingSetName = string.Empty;
+        pendingMusicalOrder = BuildMusicalOrder();
+
+        if (pendingMusicalOrder.Count == 0)
+        {
+            ShowFeedback("Sélectionnez au moins une attaque avant d'enregistrer un set.");
+            pendingPrompt = PendingPromptType.None;
+            return;
+        }
+
+        OpenNamePrompt("Nom du set musical");
+    }
+
+    private void RequestSaveItemSet()
+    {
+        if (!isOpen || isAwaitingNameInput)
+            return;
+
+        if (currentCharacter?.Data == null)
+        {
+            ShowFeedback("Aucun personnage sélectionné.");
+            return;
+        }
+
+        pendingPrompt = PendingPromptType.SaveItem;
+        pendingSetName = string.Empty;
+        pendingItemOrder = BuildItemOrder();
+
+        if (pendingItemOrder.Count == 0)
+        {
+            ShowFeedback("Sélectionnez au moins un objet avant d'enregistrer un set.");
+            pendingPrompt = PendingPromptType.None;
+            return;
+        }
+
+        OpenNamePrompt("Nom du set d'objets");
+    }
+
+    private void RequestDeleteMusicalSet()
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.musicalMoveSets == null || data.musicalMoveSets.Count == 0 || musicalDropdownMap.Count == 0)
+        {
+            ShowFeedback("Aucun set musical à supprimer.");
+            return;
+        }
+
+        string setName = GetSelectedDropdownName(musicalSetsDropdown, data.musicalMoveSets, musicalDropdownMap);
+        if (string.IsNullOrWhiteSpace(setName))
+        {
+            ShowFeedback("Sélectionnez d'abord un set musical.");
+            return;
+        }
+
+        ConfirmationBox.Instance?.Show(
+            $"Supprimer le set musical \"{setName}\" ?",
+            () =>
+            {
+                DeleteMusicalSet(setName);
+                RestoreInventoryInputAfterPopup();
+            },
+            () => RestoreInventoryInputAfterPopup());
+    }
+
+    private void RequestDeleteItemSet()
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.itemSets == null || data.itemSets.Count == 0 || itemDropdownMap.Count == 0)
+        {
+            ShowFeedback("Aucun set d'objets à supprimer.");
+            return;
+        }
+
+        string setName = GetSelectedDropdownName(itemSetsDropdown, data.itemSets, itemDropdownMap);
+        if (string.IsNullOrWhiteSpace(setName))
+        {
+            ShowFeedback("Sélectionnez d'abord un set d'objets.");
+            return;
+        }
+
+        ConfirmationBox.Instance?.Show(
+            $"Supprimer le set d'objets \"{setName}\" ?",
+            () =>
+            {
+                DeleteItemSet(setName);
+                RestoreInventoryInputAfterPopup();
+            },
+            () => RestoreInventoryInputAfterPopup());
+    }
+
+    private void DeleteMusicalSet(string setName)
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.musicalMoveSets == null)
+            return;
+
+        data.musicalMoveSets.RemoveAll(s => s != null && string.Equals(s.setName, setName, StringComparison.OrdinalIgnoreCase));
+        RefreshMusicalSetDropdown();
+        ApplyMusicalSetFromDropdown();
+        ShowFeedback($"Set musical \"{setName}\" supprimé.");
+    }
+
+    private void DeleteItemSet(string setName)
+    {
+        var data = currentCharacter?.Data;
+        if (data == null || data.itemSets == null)
+            return;
+
+        data.itemSets.RemoveAll(s => s != null && string.Equals(s.setName, setName, StringComparison.OrdinalIgnoreCase));
+        RefreshItemSetDropdown();
+        ApplyItemSetFromDropdown();
+        ShowFeedback($"Set d'objets \"{setName}\" supprimé.");
+    }
+
+    private void SaveMusicalSet(string setName, List<MusicalMoveSO> order)
+    {
+        var data = currentCharacter?.Data;
+        if (data == null)
+            return;
+
+        if (data.musicalMoveSets == null)
+            data.musicalMoveSets = new List<CharacterMusicalMoveSet>();
+
+        var existing = data.musicalMoveSets.FirstOrDefault(s => s != null && string.Equals(s.setName, setName, StringComparison.OrdinalIgnoreCase));
+        if (existing != null)
+        {
+            existing.prioritizedMoves = new List<MusicalMoveSO>(order);
+        }
+        else
+        {
+            data.musicalMoveSets.Add(new CharacterMusicalMoveSet
+            {
+                setName = setName,
+                prioritizedMoves = new List<MusicalMoveSO>(order)
+            });
+        }
+
+        RefreshMusicalSetDropdown(setName);
+        ApplyMusicalSetFromDropdown();
+        ShowFeedback($"Set musical \"{setName}\" enregistré !");
+    }
+
+    private void SaveItemSet(string setName, List<ItemData> order)
+    {
+        var data = currentCharacter?.Data;
+        if (data == null)
+            return;
+
+        if (data.itemSets == null)
+            data.itemSets = new List<CharacterItemSet>();
+
+        var existing = data.itemSets.FirstOrDefault(s => s != null && string.Equals(s.setName, setName, StringComparison.OrdinalIgnoreCase));
+        if (existing != null)
+        {
+            existing.prioritizedItems = new List<ItemData>(order);
+        }
+        else
+        {
+            data.itemSets.Add(new CharacterItemSet
+            {
+                setName = setName,
+                prioritizedItems = new List<ItemData>(order)
+            });
+        }
+
+        RefreshItemSetDropdown(setName);
+        ApplyItemSetFromDropdown();
+        ShowFeedback($"Set d'objets \"{setName}\" enregistré !");
+    }
+
+    private List<MusicalMoveSO> BuildMusicalOrder()
+    {
+        List<MusicalMoveSO> order = new();
+        foreach (var slot in musicalSelection)
+        {
+            if (slot?.BoundMove != null)
+                order.Add(slot.BoundMove);
+        }
+        return order;
+    }
+
+    private List<ItemData> BuildItemOrder()
+    {
+        List<ItemData> order = new();
+        foreach (var slot in itemSelection)
+        {
+            if (slot?.BoundItem != null)
+                order.Add(slot.BoundItem);
+        }
+        return order;
+    }
+
+    private string GetSelectedDropdownName<T>(TMP_Dropdown dropdown, IList<T> sets, List<int> mapping) where T : class
+    {
+        if (dropdown == null || sets == null || mapping == null || mapping.Count == 0)
+            return null;
+
+        int uiIndex = Mathf.Clamp(dropdown.value, 0, mapping.Count - 1);
+        int dataIndex = mapping[uiIndex];
+        if (dataIndex < 0 || dataIndex >= sets.Count)
+            return null;
+
+        if (sets[dataIndex] is CharacterMusicalMoveSet musical)
+            return musical?.setName;
+
+        if (sets[dataIndex] is CharacterItemSet itemSet)
+            return itemSet?.setName;
+
+        return null;
+    }
+
+    #endregion
+
+    #region Interaction avec le clavier virtuel
+
+    private void OpenNamePrompt(string subject)
+    {
+        if (VirtualKeyboard.Instance == null)
+        {
+            ShowFeedback("Clavier virtuel indisponible.");
+            pendingPrompt = PendingPromptType.None;
+            return;
+        }
+
+        isAwaitingNameInput = true;
+        VirtualKeyboard.Instance.WordValidated += OnVirtualKeyboardValidated;
+        VirtualKeyboard.Instance.KeyboardClosed += OnVirtualKeyboardClosed;
+        VirtualKeyboard.Instance.OpenVK(subject);
+    }
+
+    private void OnVirtualKeyboardValidated(string value)
+    {
+        HandleNameProvided(value);
+    }
+
+    private void OnVirtualKeyboardClosed()
+    {
+        CleanupKeyboardSubscriptions();
+        RestoreInventoryInput();
+    }
+
+    private void HandleNameProvided(string rawValue)
+    {
+        string sanitized = (rawValue ?? string.Empty).Trim();
+        CleanupKeyboardSubscriptions();
+        RestoreInventoryInput();
+
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            ShowFeedback("Le nom ne peut pas être vide.");
+            pendingPrompt = PendingPromptType.None;
+            return;
+        }
+
+        if (pendingPrompt == PendingPromptType.SaveMusical)
+        {
+            pendingSetName = sanitized;
+            var data = currentCharacter?.Data;
+            if (data != null && data.musicalMoveSets != null && data.musicalMoveSets.Any(s => s != null && string.Equals(s.setName, sanitized, StringComparison.OrdinalIgnoreCase)))
+            {
+                ConfirmationBox.Instance?.Show(
+                    $"Remplacer le set musical \"{sanitized}\" ?",
+                    () =>
+                    {
+                        SaveMusicalSet(pendingSetName, pendingMusicalOrder);
+                        RestoreInventoryInputAfterPopup();
+                    },
+                    () => RestoreInventoryInputAfterPopup());
+            }
+            else
+            {
+                SaveMusicalSet(pendingSetName, pendingMusicalOrder);
+            }
+        }
+        else if (pendingPrompt == PendingPromptType.SaveItem)
+        {
+            pendingSetName = sanitized;
+            var data = currentCharacter?.Data;
+            if (data != null && data.itemSets != null && data.itemSets.Any(s => s != null && string.Equals(s.setName, sanitized, StringComparison.OrdinalIgnoreCase)))
+            {
+                ConfirmationBox.Instance?.Show(
+                    $"Remplacer le set d'objets \"{sanitized}\" ?",
+                    () =>
+                    {
+                        SaveItemSet(pendingSetName, pendingItemOrder);
+                        RestoreInventoryInputAfterPopup();
+                    },
+                    () => RestoreInventoryInputAfterPopup());
+            }
+            else
+            {
+                SaveItemSet(pendingSetName, pendingItemOrder);
+            }
+        }
+
+        pendingPrompt = PendingPromptType.None;
+    }
+
+    private void CleanupKeyboardSubscriptions()
+    {
+        if (VirtualKeyboard.Instance != null)
+        {
+            VirtualKeyboard.Instance.WordValidated -= OnVirtualKeyboardValidated;
+            VirtualKeyboard.Instance.KeyboardClosed -= OnVirtualKeyboardClosed;
+        }
+
+        isAwaitingNameInput = false;
+    }
+
+    private void RestoreInventoryInput()
+    {
+        if (!isOpen)
+            return;
+
+        if (inputsManager != null)
+            inputsManager.ActivateOnly(playerInputs.Inventory.Get());
+        else
+            playerInputs.Inventory.Enable();
+    }
+
+    private void RestoreInventoryInputAfterPopup()
+    {
+        RestoreInventoryInput();
+        ApplyMusicalSetFromDropdown();
+        ApplyItemSetFromDropdown();
+    }
+
+    #endregion
+
+    #region Helpers UI
+
+    private void UpdateHelperTexts()
+    {
+        if (headerLabel != null)
+        {
+            headerLabel.text = currentViewportIndex == 0 ? musicalViewportTitle : itemViewportTitle;
+        }
+
+        if (helperLabel != null)
+            helperLabel.text = helperNavigationText;
+    }
+
+    private void ShowFeedback(string message)
+    {
+        if (feedbackLabel != null)
+            feedbackLabel.text = message;
+    }
+
+    private void RegisterButton(Button button, Action callback)
+    {
+        if (button == null || callback == null)
+            return;
+
+        button.onClick.AddListener(() => callback());
+    }
+
+    #endregion
+
+    #region Implémentation de IInventoryActions
+
+    public void OnSelectViewPort_Left(InputAction.CallbackContext context)
+    {
+        if (!isOpen || !context.performed || isAwaitingNameInput)
+            return;
+
+        SelectViewport(currentViewportIndex - 1);
+    }
+
+    public void OnSelectViewPort_Right(InputAction.CallbackContext context)
+    {
+        if (!isOpen || !context.performed || isAwaitingNameInput)
+            return;
+
+        SelectViewport(currentViewportIndex + 1);
+    }
+
+    public void OnNavigate(InputAction.CallbackContext context)
+    {
+        if (!isOpen || isAwaitingNameInput)
+            return;
+
+        CurrentViewport?.HandleNavigation(context.ReadValue<Vector2>());
+    }
+
+    public void OnConfirm(InputAction.CallbackContext context)
+    {
+        if (!isOpen || !context.performed || isAwaitingNameInput)
+            return;
+
+        var slot = CurrentViewport?.CurrentSlot;
+        if (slot != null)
+            ToggleSlotSelection(slot);
+    }
+
+    public void OnCancel(InputAction.CallbackContext context)
+    {
+        if (!context.performed)
+            return;
+
+        if (isAwaitingNameInput)
+            return; // Le clavier virtuel gère sa propre annulation.
+
+        ClosePanel();
+    }
+
+    #endregion
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/InventorySetPanelController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/InventorySetPanelController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b6e7d30d8df4f6fb21e4159c1c4d6f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/InventorySetSlot.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventorySetSlot.cs
@@ -1,0 +1,161 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Représente un slot interactif dans l'onglet "Sets" de l'inventaire.
+/// Chaque slot peut référencer soit une <see cref="MusicalMoveSO"/>,
+/// soit un <see cref="ItemData"/> et affiche l'ordre de priorité
+/// choisi par le joueur.
+/// </summary>
+public class InventorySetSlot : MonoBehaviour
+{
+    /// <summary>
+    /// Distingue les deux familles de contenus gérées par le panneau.
+    /// </summary>
+    public enum SlotKind
+    {
+        MusicalMove,
+        Item
+    }
+
+    [Header("Références UI")]
+    [Tooltip("Texte principal affichant le nom du move ou de l'objet.")]
+    [SerializeField] private TextMeshProUGUI nameLabel;
+
+    [Tooltip("Label affichant la position du slot dans la liste ordonnée.")]
+    [SerializeField] private TextMeshProUGUI orderLabel;
+
+    [Tooltip("Icône illustrant le contenu du slot (optionnelle).")]
+    [SerializeField] private Image iconImage;
+
+    [Tooltip("Contour ou objet activé lorsque le slot possède le focus navigation.")]
+    [SerializeField] private GameObject focusHighlight;
+
+    [Tooltip("Bouton Unity utilisé pour capter les clics/sélections.")]
+    [SerializeField] private Button button;
+
+    /// <summary>
+    /// Évènement déclenché lorsque le joueur valide ce slot (clic souris ou bouton A).
+    /// </summary>
+    public event Action<InventorySetSlot> Clicked;
+
+    /// <summary>
+    /// Type de donnée actuellement contenue dans le slot.
+    /// </summary>
+    public SlotKind Kind { get; private set; }
+
+    /// <summary>
+    /// Move associé lorsqu'il s'agit d'un slot d'attaque musicale.
+    /// </summary>
+    public MusicalMoveSO BoundMove { get; private set; }
+
+    /// <summary>
+    /// Item associé lorsque le slot représente un objet d'inventaire.
+    /// </summary>
+    public ItemData BoundItem { get; private set; }
+
+    /// <summary>
+    /// Index de priorité (0 = premier dans la liste). -1 signifie non sélectionné.
+    /// </summary>
+    public int OrderIndex { get; private set; } = -1;
+
+    /// <summary>
+    /// Indique rapidement si le slot fait partie de la sélection active.
+    /// </summary>
+    public bool IsSelected => OrderIndex >= 0;
+
+    private void Awake()
+    {
+        // Sécurise le champ bouton pour éviter les NullReferenceException.
+        if (button == null)
+            button = GetComponent<Button>();
+
+        if (button != null)
+            button.onClick.AddListener(HandleClick);
+    }
+
+    private void OnDestroy()
+    {
+        if (button != null)
+            button.onClick.RemoveListener(HandleClick);
+    }
+
+    /// <summary>
+    /// Associe le slot à une attaque musicale.
+    /// </summary>
+    public void BindMusicalMove(MusicalMoveSO move)
+    {
+        Kind = SlotKind.MusicalMove;
+        BoundMove = move;
+        BoundItem = null;
+        RefreshTexts(move != null ? move.moveName : string.Empty);
+        UpdateIcon(move != null ? move.moveSprite : null);
+    }
+
+    /// <summary>
+    /// Associe le slot à un item d'inventaire.
+    /// </summary>
+    public void BindItem(ItemData item)
+    {
+        Kind = SlotKind.Item;
+        BoundItem = item;
+        BoundMove = null;
+        RefreshTexts(item != null ? item.itemName : string.Empty);
+        UpdateIcon(item != null ? item.icon : null);
+    }
+
+    /// <summary>
+    /// Modifie l'état visuel lorsque le slot reçoit ou perd le focus.
+    /// </summary>
+    public void SetFocus(bool hasFocus)
+    {
+        if (focusHighlight != null)
+            focusHighlight.SetActive(hasFocus);
+    }
+
+    /// <summary>
+    /// Applique l'index de priorité et met à jour l'affichage utilisateur.
+    /// </summary>
+    public void SetOrderIndex(int index)
+    {
+        OrderIndex = index;
+
+        if (orderLabel == null)
+            return;
+
+        // Laisse le champ vide lorsqu'aucun ordre n'est défini pour éviter toute confusion.
+        orderLabel.text = index >= 0 ? (index + 1).ToString() : string.Empty;
+    }
+
+    /// <summary>
+    /// Force le libellé principal et assure une valeur non nulle.
+    /// </summary>
+    private void RefreshTexts(string label)
+    {
+        if (nameLabel != null)
+            nameLabel.text = string.IsNullOrWhiteSpace(label) ? "?" : label;
+    }
+
+    /// <summary>
+    /// Met à jour l'icône associée au slot (masque l'image si aucune icône n'est fournie).
+    /// </summary>
+    private void UpdateIcon(Sprite sprite)
+    {
+        if (iconImage == null)
+            return;
+
+        iconImage.sprite = sprite;
+        iconImage.enabled = sprite != null;
+    }
+
+    /// <summary>
+    /// Callback interne lorsque le bouton est activé par l'utilisateur.
+    /// </summary>
+    private void HandleClick()
+    {
+        Clicked?.Invoke(this);
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/InventorySetSlot.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/InventorySetSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3cb6a25d1a64bd181c48b83e2da6e1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryViewportController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryViewportController.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Contrôle un ScrollRect dédié à la sélection de slots (moves ou items).
+/// La navigation au stick gauche/aux flèches est convertie en focus vertical
+/// afin d'assurer une expérience fluide au pad comme au clavier.
+/// </summary>
+public class InventoryViewportController : MonoBehaviour
+{
+    [Header("Références UI")]
+    [Tooltip("ScrollRect parent utilisé pour afficher la liste des slots.")]
+    [SerializeField] private ScrollRect scrollRect;
+
+    [Tooltip("Conteneur recevant les instances de slots.")]
+    [SerializeField] private RectTransform contentRoot;
+
+    [Tooltip("Prefab instancié pour chaque entrée de la liste.")]
+    [SerializeField] private InventorySetSlot slotPrefab;
+
+    [Header("Paramètres de navigation")]
+    [Tooltip("Temps minimal (en secondes) entre deux déplacements successifs au stick.")]
+    [SerializeField] private float navigationCooldown = 0.15f;
+
+    private readonly List<InventorySetSlot> slots = new();
+    private int focusedIndex = 0;
+    private bool hasFocus = false;
+    private float lastNavigationTime = -999f;
+
+    /// <summary>
+    /// Fournit un accès en lecture aux slots instanciés (utile pour le panneau parent).
+    /// </summary>
+    public IReadOnlyList<InventorySetSlot> Slots => slots;
+
+    /// <summary>
+    /// Retourne le slot actuellement ciblé par le focus.
+    /// </summary>
+    public InventorySetSlot CurrentSlot
+    {
+        get
+        {
+            if (focusedIndex < 0 || focusedIndex >= slots.Count)
+                return null;
+            return slots[focusedIndex];
+        }
+    }
+
+    private void Awake()
+    {
+        // Permet de configurer automatiquement la hiérarchie lorsque le ScrollRect est connu.
+        if (scrollRect != null && contentRoot == null)
+            contentRoot = scrollRect.content;
+    }
+
+    /// <summary>
+    /// Supprime tous les slots existants et réinitialise l'état de navigation.
+    /// </summary>
+    public void Clear()
+    {
+        foreach (var slot in slots)
+        {
+            if (slot != null)
+                Destroy(slot.gameObject);
+        }
+
+        slots.Clear();
+        focusedIndex = 0;
+        UpdateFocusVisuals();
+    }
+
+    /// <summary>
+    /// Crée un nouveau slot via le prefab configuré et l'ajoute au contenu.
+    /// </summary>
+    public InventorySetSlot CreateSlot()
+    {
+        if (slotPrefab == null || contentRoot == null)
+        {
+            Debug.LogWarning("[InventoryViewport] Impossible de créer un slot : prefab ou content manquant.");
+            return null;
+        }
+
+        var instance = Instantiate(slotPrefab, contentRoot);
+        instance.SetOrderIndex(-1); // Valeur neutre par défaut.
+        slots.Add(instance);
+
+        // Lorsque l'on ajoute le tout premier slot, on force le focus dessus pour éviter les états incohérents.
+        if (slots.Count == 1)
+            focusedIndex = 0;
+
+        UpdateFocusVisuals();
+        return instance;
+    }
+
+    /// <summary>
+    /// Définit si ce viewport est actuellement ciblé par le joueur.
+    /// </summary>
+    public void SetFocus(bool focus)
+    {
+        hasFocus = focus;
+        UpdateFocusVisuals();
+    }
+
+    /// <summary>
+    /// Positionne le focus sur le premier slot valide (utile lors d'un changement de panneau).
+    /// </summary>
+    public void FocusFirstEntry()
+    {
+        if (slots.Count == 0)
+        {
+            focusedIndex = -1;
+        }
+        else
+        {
+            focusedIndex = Mathf.Clamp(focusedIndex, 0, slots.Count - 1);
+        }
+
+        UpdateFocusVisuals();
+    }
+
+    /// <summary>
+    /// Interprète un vecteur de navigation pour déplacer le focus.
+    /// </summary>
+    public void HandleNavigation(Vector2 input)
+    {
+        if (!hasFocus || slots.Count == 0)
+            return;
+
+        if (Time.unscaledTime - lastNavigationTime < navigationCooldown)
+            return; // Laisse le temps au joueur de relâcher le stick.
+
+        int delta = 0;
+
+        // On privilégie la composante verticale mais on accepte aussi les mouvements horizontaux
+        // pour les joueurs utilisant la croix directionnelle.
+        if (input.y > 0.5f || input.x < -0.5f)
+            delta = -1;
+        else if (input.y < -0.5f || input.x > 0.5f)
+            delta = 1;
+
+        if (delta == 0)
+            return;
+
+        int newIndex = Mathf.Clamp(focusedIndex + delta, 0, slots.Count - 1);
+        if (newIndex == focusedIndex)
+            return;
+
+        focusedIndex = newIndex;
+        lastNavigationTime = Time.unscaledTime;
+        UpdateFocusVisuals();
+    }
+
+    /// <summary>
+    /// Force la caméra du ScrollRect à afficher l'élément actuellement ciblé.
+    /// </summary>
+    private void ScrollToFocusedSlot()
+    {
+        if (scrollRect == null || contentRoot == null)
+            return;
+
+        if (focusedIndex < 0 || focusedIndex >= slots.Count)
+            return;
+
+        if (scrollRect.viewport == null)
+            return;
+
+        var target = slots[focusedIndex]?.transform as RectTransform;
+        if (target == null)
+            return;
+
+        // Garantit que les tailles sont à jour avant le calcul du ratio.
+        Canvas.ForceUpdateCanvases();
+
+        float viewportHeight = scrollRect.viewport.rect.height;
+        float contentHeight = contentRoot.rect.height;
+
+        if (contentHeight <= viewportHeight)
+            return; // Rien à scroller.
+
+        // Les positions dans une ScrollView verticale sont inversées (0 en haut, positif vers le bas).
+        float targetY = Mathf.Abs(target.anchoredPosition.y);
+        float normalized = Mathf.Clamp01(targetY / (contentHeight - viewportHeight));
+        scrollRect.verticalNormalizedPosition = 1f - normalized;
+    }
+
+    /// <summary>
+    /// Met à jour l'état visuel de chaque slot en fonction du focus courant.
+    /// </summary>
+    private void UpdateFocusVisuals()
+    {
+        for (int i = 0; i < slots.Count; i++)
+        {
+            if (slots[i] == null)
+                continue;
+
+            bool active = hasFocus && i == focusedIndex;
+            slots[i].SetFocus(active);
+        }
+
+        if (hasFocus)
+            ScrollToFocusedSlot();
+    }
+}
+

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryViewportController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryViewportController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cbb20fb6d544f8b9f0a3e53285e0b89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/VirtualKeyboard.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/VirtualKeyboard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -38,6 +39,17 @@ public class VirtualKeyboard : MonoBehaviour
     private float _lastMoveTime;
     // Texte actuellement saisi via le clavier virtuel, accessible aux autres systèmes.
     public string currentVKWordText { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Évènement déclenché lorsque le joueur valide sa saisie via le bouton "OK".
+    /// </summary>
+    public event Action<string> WordValidated;
+
+    /// <summary>
+    /// Évènement déclenché à chaque fermeture du clavier, que ce soit après validation
+    /// ou annulation (utile pour réactiver certains panneaux).
+    /// </summary>
+    public event Action KeyboardClosed;
 
     // Référence vers le système d'inputs. On privilégie l'instance centrale fournie par InputsManager
     // afin de conserver une cohérence des contrôles dans tout le projet.
@@ -106,6 +118,9 @@ public class VirtualKeyboard : MonoBehaviour
         cursor.gameObject.SetActive(true);
 
         _currentIndex = 0;
+        currentVKWordText = string.Empty; // Réinitialise systématiquement la saisie.
+        if (currentVKWord != null)
+            currentVKWord.text = string.Empty;
         UpdateCursor();
 
         // On s'assure que le mapping World est actif pour recevoir les entrées.
@@ -147,6 +162,8 @@ public class VirtualKeyboard : MonoBehaviour
 
         if (keyboardRoot != null)
             keyboardRoot.SetActive(false);
+
+        KeyboardClosed?.Invoke();
     }
 
     /// <summary>
@@ -214,7 +231,7 @@ public class VirtualKeyboard : MonoBehaviour
         }
         else if (keyName == "OK")
         {
-            // Pour l'instant, la validation finale ferme simplement le clavier.
+            WordValidated?.Invoke(currentVKWordText);
             CloseVK();
         }
         else

--- a/Assets/Scripts/PlayerInputs.cs
+++ b/Assets/Scripts/PlayerInputs.cs
@@ -1205,6 +1205,9 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         m_Inventory = asset.FindActionMap("Inventory", throwIfNotFound: true);
         m_Inventory_SelectViewPort_Left = m_Inventory.FindAction("SelectViewPort_Left", throwIfNotFound: true);
         m_Inventory_SelectViewPort_Right = m_Inventory.FindAction("SelectViewPort_Right", throwIfNotFound: true);
+        m_Inventory_Navigate = m_Inventory.FindAction("Navigate", throwIfNotFound: true);
+        m_Inventory_Confirm = m_Inventory.FindAction("Confirm", throwIfNotFound: true);
+        m_Inventory_Cancel = m_Inventory.FindAction("Cancel", throwIfNotFound: true);
         // Menu
         m_Menu = asset.FindActionMap("Menu", throwIfNotFound: true);
         m_Menu_Confirm = m_Menu.FindAction("Confirm", throwIfNotFound: true);
@@ -1847,6 +1850,9 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
     private List<IInventoryActions> m_InventoryActionsCallbackInterfaces = new List<IInventoryActions>();
     private readonly InputAction m_Inventory_SelectViewPort_Left;
     private readonly InputAction m_Inventory_SelectViewPort_Right;
+    private readonly InputAction m_Inventory_Navigate;
+    private readonly InputAction m_Inventory_Confirm;
+    private readonly InputAction m_Inventory_Cancel;
     /// <summary>
     /// Provides access to input actions defined in input action map "Inventory".
     /// </summary>
@@ -1866,6 +1872,18 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         /// Provides access to the underlying input action "Inventory/SelectViewPort_Right".
         /// </summary>
         public InputAction @SelectViewPort_Right => m_Wrapper.m_Inventory_SelectViewPort_Right;
+        /// <summary>
+        /// Provides access to the underlying input action "Inventory/Navigate".
+        /// </summary>
+        public InputAction @Navigate => m_Wrapper.m_Inventory_Navigate;
+        /// <summary>
+        /// Provides access to the underlying input action "Inventory/Confirm".
+        /// </summary>
+        public InputAction @Confirm => m_Wrapper.m_Inventory_Confirm;
+        /// <summary>
+        /// Provides access to the underlying input action "Inventory/Cancel".
+        /// </summary>
+        public InputAction @Cancel => m_Wrapper.m_Inventory_Cancel;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -1898,6 +1916,15 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
             @SelectViewPort_Right.started += instance.OnSelectViewPort_Right;
             @SelectViewPort_Right.performed += instance.OnSelectViewPort_Right;
             @SelectViewPort_Right.canceled += instance.OnSelectViewPort_Right;
+            @Navigate.started += instance.OnNavigate;
+            @Navigate.performed += instance.OnNavigate;
+            @Navigate.canceled += instance.OnNavigate;
+            @Confirm.started += instance.OnConfirm;
+            @Confirm.performed += instance.OnConfirm;
+            @Confirm.canceled += instance.OnConfirm;
+            @Cancel.started += instance.OnCancel;
+            @Cancel.performed += instance.OnCancel;
+            @Cancel.canceled += instance.OnCancel;
         }
 
         /// <summary>
@@ -1915,6 +1942,15 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
             @SelectViewPort_Right.started -= instance.OnSelectViewPort_Right;
             @SelectViewPort_Right.performed -= instance.OnSelectViewPort_Right;
             @SelectViewPort_Right.canceled -= instance.OnSelectViewPort_Right;
+            @Navigate.started -= instance.OnNavigate;
+            @Navigate.performed -= instance.OnNavigate;
+            @Navigate.canceled -= instance.OnNavigate;
+            @Confirm.started -= instance.OnConfirm;
+            @Confirm.performed -= instance.OnConfirm;
+            @Confirm.canceled -= instance.OnConfirm;
+            @Cancel.started -= instance.OnCancel;
+            @Cancel.performed -= instance.OnCancel;
+            @Cancel.canceled -= instance.OnCancel;
         }
 
         /// <summary>
@@ -2289,6 +2325,27 @@ public partial class @PlayerInputs: IInputActionCollection2, IDisposable
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnSelectViewPort_Right(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Navigate" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnNavigate(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Confirm" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnConfirm(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "Cancel" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnCancel(InputAction.CallbackContext context);
     }
     /// <summary>
     /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "Menu" which allows adding and removing callbacks.

--- a/Assets/Scripts/PlayerInputs.inputactions
+++ b/Assets/Scripts/PlayerInputs.inputactions
@@ -982,6 +982,33 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "Navigate",
+                    "type": "Value",
+                    "id": "5d93f40e-8f1a-42de-949b-921d3a7828ce",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Confirm",
+                    "type": "Button",
+                    "id": "1e7b3af4-4b34-4b61-b6e0-0a5a0a51890b",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "4c5d5d0f-2c5d-4bbf-bf5e-5c0db1ea0a9a",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -1004,6 +1031,149 @@
                     "processors": "",
                     "groups": "",
                     "action": "SelectViewPort_Right",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "2D Vector",
+                    "id": "b058bb07-8f3e-473c-8be8-4c6299812fee",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "5f47c12b-3630-4b08-9702-719116df12aa",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "4f7bd665-f9c4-42b0-b848-1f0a1fa1104c",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "14ec0c9f-9e3a-414a-890b-2aee847f0f6d",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "114ac023-8fe4-4d43-82e4-0aa39076e70d",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "d439010a-8c5c-4c95-9c09-0e79372ebc19",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ab3d6ba3-36bf-4d75-b612-4c52f3f94630",
+                    "path": "<Gamepad>/dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "026bdfba-15c3-4e76-b67b-4b19a0d434f0",
+                    "path": "<Keyboard>/enter",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Confirm",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c07f12f2-d693-49a6-9dc7-4c6c4db88558",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Confirm",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "de0b0818-e416-4746-b227-44c7026cf8e2",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Confirm",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b2555a5e-2fe2-4ce3-906d-daa15ca19237",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1d6e5771-91a1-4c09-8c4a-32ef9a5f9a3f",
+                    "path": "<Keyboard>/backspace",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1c33320-c6b0-4655-8b23-5aeed6a06b6d",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Cancel",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
## Summary
- introduce InventorySetPanelController, InventoryViewportController and InventorySetSlot scripts to drive the new Inventory_Sets panel with runtime ordering, saving and deletion of musical move and item sets
- extend the input asset and generated PlayerInputs to add dedicated navigation, confirm and cancel actions for the inventory map while wiring viewport switching and joystick navigation
- expose validation events on the VirtualKeyboard to capture user-provided set names and plug confirmation dialogs back into the inventory workflow

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d92baf33b88325a1aa491493a786c2