### PR TITLE
Corrige la navigation des slots d'inventaire

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -660,19 +660,46 @@ public class InventoryManager : MonoBehaviour
         inventoryNavigateAction = inventoryActions.Navigate;
 
         if (inventorySelectPanelLeftAction != null)
+        {
+            // On réactive explicitement l'action au cas où elle aurait été désactivée lors d'un précédent OnDisable.
+            // Sans cela, le simple fait de réactiver l'ActionMap ne suffit pas et la navigation reste bloquée.
+            if (!inventorySelectPanelLeftAction.enabled)
+                inventorySelectPanelLeftAction.Enable();
+
             inventorySelectPanelLeftAction.performed += OnInventorySelectPanelLeft;
+        }
 
         if (inventorySelectPanelRightAction != null)
+        {
+            if (!inventorySelectPanelRightAction.enabled)
+                inventorySelectPanelRightAction.Enable();
+
             inventorySelectPanelRightAction.performed += OnInventorySelectPanelRight;
+        }
 
         if (inventorySelectSubPanelLeftAction != null)
+        {
+            if (!inventorySelectSubPanelLeftAction.enabled)
+                inventorySelectSubPanelLeftAction.Enable();
+
             inventorySelectSubPanelLeftAction.performed += OnInventorySelectSubPanelLeft;
+        }
 
         if (inventorySelectSubPanelRightAction != null)
+        {
+            if (!inventorySelectSubPanelRightAction.enabled)
+                inventorySelectSubPanelRightAction.Enable();
+
             inventorySelectSubPanelRightAction.performed += OnInventorySelectSubPanelRight;
+        }
 
         if (inventoryNavigateAction != null)
+        {
+            if (!inventoryNavigateAction.enabled)
+                inventoryNavigateAction.Enable();
+
             inventoryNavigateAction.performed += OnInventoryNavigate;
+        }
 
         inventoryActionsHooked = true;
     }


### PR DESCRIPTION
## Résumé
- réactive explicitement les actions de navigation de l'inventaire lorsqu'elles sont réabonnées
- garantit que le joystick peut à nouveau changer de slot dans l'ordre attendu

## Tests
- non effectués (modifications centrées sur l'input)


------
https://chatgpt.com/codex/tasks/task_e_68dd0291a44883258a31b59019b8f195