### PR TITLE
Refactor performing timelines to pause and resume in slow battles

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -98,11 +98,10 @@ public class ItemData : ScriptableObject
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation de l'item")]
     public TimelineAsset preparingTimeline;
-    [Tooltip("Timeline à jouer lors de la première phase d'utilisation de l'item.")]
+    [Tooltip("Timeline complète d'utilisation. Un Signal peut y suspendre l'action en mode lent.")]
+    [FormerlySerializedAs("performingTimelinePhase1")]
     [FormerlySerializedAs("performingTimeline")]
-    public TimelineAsset performingTimelinePhase1;
-    [Tooltip("Timeline secondaire déclenchée en fin de manche lorsque le SlowBattleManager est actif.")]
-    public TimelineAsset performingTimelinePhase2;
+    public TimelineAsset performingTimeline;
     [Tooltip("Timeline jouée lors du repli après utilisation")]
     public TimelineAsset retreatTimeline;
 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -148,11 +148,10 @@ public class MusicalMoveSO : ScriptableObject
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation du move")]
     public TimelineAsset preparingTimeline;
-    [Tooltip("Timeline à jouer lors de la première phase d'exécution du move.")]
+    [Tooltip("Timeline d'exécution complète du move. Un Signal peut y être placé pour la mettre en pause en mode lent.")]
+    [FormerlySerializedAs("performingTimelinePhase1")]
     [FormerlySerializedAs("performingTimeline")]
-    public TimelineAsset performingTimelinePhase1;
-    [Tooltip("Timeline déclenchée en fin de manche lorsque l'on utilise le SlowBattleManager.")]
-    public TimelineAsset performingTimelinePhase2;
+    public TimelineAsset performingTimeline;
     [Tooltip("Timeline jouée lors du repli après l'exécution du move")]
     public TimelineAsset retreatTimeline;
 

--- a/Assets/Scripts/Classes/SlowBattleTimelineSequence.cs
+++ b/Assets/Scripts/Classes/SlowBattleTimelineSequence.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using UnityEngine.Timeline;
 
 /// <summary>
-///     Données sérialisables décrivant une séquence différée (phase 2 + repli)
+///     Données sérialisables décrivant une séquence différée (reprise de Performing + repli)
 ///     à jouer lorsque le <see cref="SlowBattleManager"/> est actif.
 ///     La structure est volontairement générique afin de couvrir aussi bien
 ///     les <see cref="MusicalMoveSO"/> que les <see cref="ItemData"/>.
@@ -22,8 +22,11 @@ public class SlowBattleTimelineSequence
     public bool stayInPlace;
 
     [Header("Timelines")] 
-    public TimelineAsset performingPhase2;
+    public TimelineAsset performingTimeline;
     public TimelineAsset retreatTimeline;
+
+    [Header("Contrôle de lecture")]
+    public bool resumePausedTimeline;
 
     [Header("Caméra et bindings")]
     public bool useOverlay;
@@ -51,12 +54,13 @@ public class SlowBattleTimelineSequence
         GameObject performingCameraTarget,
         GameObject casterCameraTarget,
         Quaternion initialRotation,
-        TimelineAsset performingPhase2,
+        TimelineAsset performingTimeline,
         TimelineAsset retreatTimeline,
         float performingCameraDelay,
         BattleCameraRole performingCameraRole,
         BattleCameraRole retreatCameraRole,
-        bool wasCritical)
+        bool wasCritical,
+        bool resumePausedTimeline)
     {
         return new SlowBattleTimelineSequence
         {
@@ -67,7 +71,7 @@ public class SlowBattleTimelineSequence
             originPosition = originPosition,
             requiresReturn = move != null && move.requiresMovement && !move.stayInPlace,
             stayInPlace = move != null && move.stayInPlace,
-            performingPhase2 = performingPhase2,
+            performingTimeline = performingTimeline,
             retreatTimeline = retreatTimeline,
             useOverlay = useOverlay,
             casterAnimatorGO = casterAnimatorGO,
@@ -77,7 +81,8 @@ public class SlowBattleTimelineSequence
             performingCameraDelay = performingCameraDelay,
             performingCameraRole = performingCameraRole,
             retreatCameraRole = retreatCameraRole,
-            wasCritical = wasCritical
+            wasCritical = wasCritical,
+            resumePausedTimeline = resumePausedTimeline
         };
     }
 
@@ -94,11 +99,12 @@ public class SlowBattleTimelineSequence
         GameObject performingCameraTarget,
         GameObject casterCameraTarget,
         Quaternion initialRotation,
-        TimelineAsset performingPhase2,
+        TimelineAsset performingTimeline,
         TimelineAsset retreatTimeline,
         float performingCameraDelay,
         BattleCameraRole performingCameraRole,
-        BattleCameraRole retreatCameraRole)
+        BattleCameraRole retreatCameraRole,
+        bool resumePausedTimeline)
     {
         return new SlowBattleTimelineSequence
         {
@@ -109,7 +115,7 @@ public class SlowBattleTimelineSequence
             originPosition = originPosition,
             requiresReturn = item != null && item.requiresMovement && !item.stayInPlace,
             stayInPlace = item != null && item.stayInPlace,
-            performingPhase2 = performingPhase2,
+            performingTimeline = performingTimeline,
             retreatTimeline = retreatTimeline,
             useOverlay = useOverlay,
             casterAnimatorGO = casterAnimatorGO,
@@ -119,7 +125,8 @@ public class SlowBattleTimelineSequence
             performingCameraDelay = performingCameraDelay,
             performingCameraRole = performingCameraRole,
             retreatCameraRole = retreatCameraRole,
-            wasCritical = false
+            wasCritical = false,
+            resumePausedTimeline = resumePausedTimeline
         };
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTimelineManager.cs
@@ -69,6 +69,30 @@ public class BattleTimelineManager : MonoBehaviour
         lastUnitPlaying = unit;
     }
 
+    /// <summary>
+    /// Met en pause la timeline actuellement jouée pour l'unité demandée.
+    /// </summary>
+    public void PauseCasterTimeline(CharacterUnit unit = null)
+    {
+        CharacterUnit target = unit ?? lastUnitPlaying;
+        if (target == null)
+            return;
+
+        target.PauseBattleTimeline();
+    }
+
+    /// <summary>
+    /// Reprend la timeline précédemment mise en pause pour l'unité demandée.
+    /// </summary>
+    public void ResumeCasterTimeline(CharacterUnit unit = null)
+    {
+        CharacterUnit target = unit ?? lastUnitPlaying;
+        if (target == null)
+            return;
+
+        target.ResumeBattleTimeline();
+    }
+
     /// <summary>Arrête la timeline en cours pour l'unité spécifiée.</summary>
     /// <param name="unit">Unité ciblée, ou null pour cibler la dernière unité connue.</param>
     public void StopCasterTimeline(CharacterUnit unit = null)
@@ -91,6 +115,16 @@ public class BattleTimelineManager : MonoBehaviour
     {
         CharacterUnit target = unit ?? lastUnitPlaying;
         return target != null && target.IsBattleTimelinePlaying;
+    }
+
+    /// <summary>
+    /// Indique si la timeline ciblée est simplement en pause (utile pour distinguer un arrêt complet
+    /// d'une suspension volontaire via un Signal de timeline).
+    /// </summary>
+    public bool IsCasterTimelinePaused(CharacterUnit unit = null)
+    {
+        CharacterUnit target = unit ?? lastUnitPlaying;
+        return target != null && target.IsBattleTimelinePaused;
     }
 }
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -819,6 +819,34 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     }
 
     /// <summary>
+    /// Fournit un accès en lecture au <see cref="PlayableDirector"/> pilotant les timelines de combat.
+    /// Cette propriété reste protégée afin d'éviter toute modification extérieure non contrôlée tout
+    /// en permettant aux gestionnaires (comme le <see cref="SlowBattleManager"/>) de vérifier l'état
+    /// du director lorsqu'une timeline est mise en pause pour un tour lent.
+    /// </summary>
+    public PlayableDirector BattleDirector => battleDirector;
+
+    /// <summary>
+    /// Met en pause la timeline courante si elle est en lecture. Ce comportement est principalement
+    /// utilisé par les Signaux des timelines de Performing pour figer la mise en scène le temps que
+    /// le tour se termine dans le mode de combat lent.
+    /// </summary>
+    public void PauseBattleTimeline()
+    {
+        if (battleDirector != null && battleDirector.state == PlayState.Playing)
+            battleDirector.Pause();
+    }
+
+    /// <summary>
+    /// Reprend la lecture d'une timeline précédemment mise en pause via <see cref="PauseBattleTimeline"/>.
+    /// </summary>
+    public void ResumeBattleTimeline()
+    {
+        if (battleDirector != null && battleDirector.state == PlayState.Paused)
+            battleDirector.Resume();
+    }
+
+    /// <summary>
     /// Prépare la timeline d'introduction de combat en reliant explicitement
     /// les pistes "Root" et "Model" du <see cref="PlayableDirector"/> local.
     /// Les autres pistes potentiellement présentes sont nettoyées afin d'éviter
@@ -951,6 +979,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// d'exécution. Utile pour synchroniser les différentes phases d'un move.
     /// </summary>
     public bool IsBattleTimelinePlaying => battleDirector != null && battleDirector.state == PlayState.Playing;
+
+    /// <summary>
+    /// Indique si la timeline locale est simplement en pause (ni arrêtée, ni en lecture).
+    /// Cette information complète <see cref="IsBattleTimelinePlaying"/> pour distinguer un arrêt
+    /// normal d'un gel volontaire orchestré par les timelines Performing.
+    /// </summary>
+    public bool IsBattleTimelinePaused => battleDirector != null && battleDirector.state == PlayState.Paused;
 
     /// <summary>
     /// Réalise le binding d'une piste individuelle d'une timeline vers les

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -171,16 +171,6 @@ public class RhythmQTEManager : MonoBehaviour
     // ------------------------------------------------------------------------------
     // Utilitaires Timeline
     // ------------------------------------------------------------------------------
-    /// <summary>
-    /// Lance une timeline en tant que séquence principale ou en superposition.
-    /// </summary>
-    /// <param name="timeline">Timeline à jouer.</param>
-    /// <param name="overlay">Vrai pour une timeline en superposition.</param>
-    /// <param name="caster">Unité lançant la timeline.</param>
-    /// <param name="animatorGO">Objet de référence pour le binding (caster).</param>
-    /// <param name="cameraTarget">Objet servant d'ancre pour la caméra.</param>
-    /// <param name="autoRestore">Indique si la caméra doit être restaurée automatiquement.</param>
-    /// <param name="initialRotation">Rotation de référence à conserver.</param>
     private void StartTimelinePhase(
         TimelineAsset timeline,
         bool overlay,
@@ -195,37 +185,61 @@ public class RhythmQTEManager : MonoBehaviour
         if (timeline == null || BattleTimelineManager.Instance == null || caster == null)
             return;
 
-        // 🎥 Active la caméra dédiée à cette phase si elle est renseignée.
+        ConfigureCameraForPhase(caster, animatorGO, cameraTarget, initialRotation, cameraRole, cameraSwitchDelay);
+
+        // Lecture de la timeline via le PlayableDirector de l'unité concernée.
+        GameObject defaultCasterTarget = caster.GetCasterBindingTarget();
+        GameObject binding = animatorGO ?? defaultCasterTarget;
+        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, caster, binding);
+    }
+
+    /// <summary>
+    /// Reprend une timeline déjà jouée précédemment (utilisée lorsque la Performing a été suspendue).
+    /// </summary>
+    private void ResumeTimelinePhase(
+        TimelineAsset timeline,
+        CharacterUnit caster,
+        GameObject animatorGO,
+        GameObject cameraTarget,
+        Quaternion initialRotation,
+        BattleCameraRole cameraRole = BattleCameraRole.None)
+    {
+        if (timeline == null || BattleTimelineManager.Instance == null || caster == null)
+            return;
+
+        ConfigureCameraForPhase(caster, animatorGO, cameraTarget, initialRotation, cameraRole, 0f);
+        BattleTimelineManager.Instance.ResumeCasterTimeline(caster);
+    }
+
+    /// <summary>
+    /// Prépare la caméra et annule les délais résiduels avant de lancer ou reprendre une timeline.
+    /// </summary>
+    private void ConfigureCameraForPhase(
+        CharacterUnit caster,
+        GameObject animatorGO,
+        GameObject cameraTarget,
+        Quaternion initialRotation,
+        BattleCameraRole cameraRole,
+        float cameraSwitchDelay)
+    {
+        if (caster == null)
+            return;
+
         if (cameraRole != BattleCameraRole.None)
         {
-            // 🧹 Annule toute requête précédente afin d'éviter qu'un délai résiduel
-            //     ne vienne écraser un nouveau cadrage.
             CancelPendingCameraSwitch();
 
             if (cameraSwitchDelay <= 0f)
-            {
-                // ⏱️ Pas de délai demandé : on applique immédiatement le cadrage.
                 BattleCameraManager.Instance?.SwitchToCamera(cameraRole);
-            }
             else
-            {
-                // ⏳ Délai personnalisé : la caméra reste sur le rôle précédent
-                //     pendant la durée souhaitée avant de basculer.
                 pendingCameraSwitch = StartCoroutine(SwitchCameraAfterDelay(cameraRole, cameraSwitchDelay));
-            }
         }
 
-        // 📽️ La caméra n'étant plus pilotée par les timelines des moves/items,
-        // nous ré-alignons simplement l'origine avant de lancer la timeline du lanceur.
         GameObject defaultCasterTarget = caster.GetCasterBindingTarget();
         BattleTimelineManager.Instance.AlignCameraToTarget(
-            cameraTarget ?? animatorGO ?? defaultCasterTarget, // Fallback sur l'Animator enfant du lanceur
+            cameraTarget ?? animatorGO ?? defaultCasterTarget,
             battleCameraTag,
             initialRotation);
-
-        // Lecture de la timeline via le PlayableDirector de l'unité concernée.
-        GameObject binding = animatorGO ?? defaultCasterTarget;
-        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, caster, binding);
     }
 
     /// <summary>
@@ -432,7 +446,7 @@ public class RhythmQTEManager : MonoBehaviour
             caster,
             casterAnimatorGO,
             casterCameraTarget,
-            move.performingTimelinePhase1 == null && move.performingTimelinePhase2 == null && move.retreatTimeline == null,
+            move.performingTimeline == null && move.retreatTimeline == null,
             initialRotation,
             move.preparingCameraRole);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay, caster);
@@ -461,19 +475,18 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         // --- Phase d'exécution ---
-        TimelineAsset performingPhase1 = move.performingTimelinePhase1;
-        TimelineAsset performingPhase2 = move.performingTimelinePhase2;
+        TimelineAsset performingTimeline = move.performingTimeline;
         bool isSlowMode = NewBattleManager.Instance != null && NewBattleManager.Instance.UseSlowBattleManager && SlowBattleManager.Instance != null;
 
         // Le délai passé en paramètre différera uniquement la bascule de caméra,
         // laissant la timeline de performing démarrer immédiatement.
         StartTimelinePhase(
-            performingPhase1,
+            performingTimeline,
             useOverlay,
             caster,
             casterAnimatorGO,
             performingCameraTarget,
-            performingPhase2 == null && move.retreatTimeline == null,
+            move.retreatTimeline == null,
             initialRotation,
             move.performingCameraRole,
             move.preparingToPerformingCameraDelay);
@@ -502,11 +515,14 @@ public class RhythmQTEManager : MonoBehaviour
             }
         }
 
-        yield return WaitForTimelinePhase(performingPhase1, useOverlay, caster);
+        yield return WaitForTimelinePhase(performingTimeline, useOverlay, caster);
 
         bool critical = successResults != null && successResults.Count > 0 && successResults.All(s => s);
 
-        bool shouldDefer = isSlowMode && (performingPhase2 != null || move.retreatTimeline != null);
+        bool performingPaused =
+            (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePaused(caster)) ||
+            (SlowBattleManager.Instance != null && SlowBattleManager.Instance.IsPerformingTimelinePaused(caster));
+        bool shouldDefer = isSlowMode && (performingPaused || move.retreatTimeline != null);
         if (shouldDefer)
         {
             var sequence = SlowBattleTimelineSequence.ForMusicalMove(
@@ -519,12 +535,13 @@ public class RhythmQTEManager : MonoBehaviour
                 performingCameraTarget,
                 casterCameraTarget,
                 initialRotation,
-                performingPhase2,
+                performingPaused ? performingTimeline : null,
                 move.retreatTimeline,
                 0f,
                 move.performingCameraRole,
                 move.retreatCameraRole,
-                critical);
+                critical,
+                performingPaused);
 
             SlowBattleManager.Instance.RegisterDeferredTimelineSequence(sequence);
 
@@ -543,20 +560,6 @@ public class RhythmQTEManager : MonoBehaviour
 
             isActive = false;
             yield break;
-        }
-
-        if (performingPhase2 != null)
-        {
-            StartTimelinePhase(
-                performingPhase2,
-                useOverlay,
-                caster,
-                casterAnimatorGO,
-                performingCameraTarget,
-                move.retreatTimeline == null,
-                initialRotation,
-                move.performingCameraRole);
-            yield return WaitForTimelinePhase(performingPhase2, useOverlay, caster);
         }
 
         // --- Retour ou téléportation de repli ---
@@ -679,7 +682,7 @@ public class RhythmQTEManager : MonoBehaviour
             caster,
             casterAnimatorGO,
             casterCameraTarget,
-            item.performingTimelinePhase1 == null && item.performingTimelinePhase2 == null && item.retreatTimeline == null,
+            item.performingTimeline == null && item.retreatTimeline == null,
             initialRotation,
             item.preparingCameraRole);
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay, caster);
@@ -701,17 +704,16 @@ public class RhythmQTEManager : MonoBehaviour
         // --- Phase d'utilisation ---
         // Comme pour les MusicalMoves, le délai fourni retarde uniquement le changement
         // de caméra sans bloquer l'exécution de la timeline principale.
-        TimelineAsset itemPerformingPhase1 = item.performingTimelinePhase1;
-        TimelineAsset itemPerformingPhase2 = item.performingTimelinePhase2;
+        TimelineAsset itemPerformingTimeline = item.performingTimeline;
         bool itemSlowMode = NewBattleManager.Instance != null && NewBattleManager.Instance.UseSlowBattleManager && SlowBattleManager.Instance != null;
 
         StartTimelinePhase(
-            itemPerformingPhase1,
+            itemPerformingTimeline,
             useOverlay,
             caster,
             casterAnimatorGO,
             performingCameraTarget,
-            itemPerformingPhase2 == null && item.retreatTimeline == null,
+            item.retreatTimeline == null,
             initialRotation,
             item.performingCameraRole,
             item.preparingToPerformingCameraDelay);
@@ -730,9 +732,12 @@ public class RhythmQTEManager : MonoBehaviour
             LastItemSuccess = successResults.All(v => v);
         }
 
-        yield return WaitForTimelinePhase(itemPerformingPhase1, useOverlay, caster);
+        yield return WaitForTimelinePhase(itemPerformingTimeline, useOverlay, caster);
 
-        bool deferItem = itemSlowMode && (itemPerformingPhase2 != null || item.retreatTimeline != null);
+        bool performingPaused =
+            (BattleTimelineManager.Instance != null && BattleTimelineManager.Instance.IsCasterTimelinePaused(caster)) ||
+            (SlowBattleManager.Instance != null && SlowBattleManager.Instance.IsPerformingTimelinePaused(caster));
+        bool deferItem = itemSlowMode && (performingPaused || item.retreatTimeline != null);
         if (deferItem)
         {
             var sequence = SlowBattleTimelineSequence.ForItem(
@@ -745,11 +750,12 @@ public class RhythmQTEManager : MonoBehaviour
                 performingCameraTarget,
                 casterCameraTarget,
                 initialRotation,
-                itemPerformingPhase2,
+                performingPaused ? itemPerformingTimeline : null,
                 item.retreatTimeline,
                 0f,
                 item.performingCameraRole,
-                item.retreatCameraRole);
+                item.retreatCameraRole,
+                performingPaused);
 
             SlowBattleManager.Instance.RegisterDeferredTimelineSequence(sequence);
 
@@ -759,20 +765,6 @@ public class RhythmQTEManager : MonoBehaviour
             BattleCameraManager.Instance?.ClearRigTargets();
             isActive = false;
             yield break;
-        }
-
-        if (itemPerformingPhase2 != null)
-        {
-            StartTimelinePhase(
-                itemPerformingPhase2,
-                useOverlay,
-                caster,
-                casterAnimatorGO,
-                performingCameraTarget,
-                item.retreatTimeline == null,
-                initialRotation,
-                item.performingCameraRole);
-            yield return WaitForTimelinePhase(itemPerformingPhase2, useOverlay, caster);
         }
 
         // --- Retour à la position d'origine ---
@@ -808,7 +800,7 @@ public class RhythmQTEManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Joue la phase différée (PerformingTimeline_2 puis Retreat) pour un move ou un item en mode lent.
+    /// Joue la phase différée (reprise de Performing puis Retreat) pour un move ou un item en mode lent.
     /// </summary>
     public IEnumerator PlayDeferredSlowSequence(SlowBattleTimelineSequence sequence)
     {
@@ -833,10 +825,24 @@ public class RhythmQTEManager : MonoBehaviour
 
         isActive = true;
 
-        if (sequence.performingPhase2 != null)
+        if (sequence.resumePausedTimeline)
+        {
+            ResumeTimelinePhase(
+                sequence.performingTimeline,
+                caster,
+                sequence.casterAnimatorGO,
+                sequence.performingCameraTarget,
+                sequence.initialRotation,
+                sequence.performingCameraRole);
+
+            yield return WaitForTimelinePhase(sequence.performingTimeline, sequence.useOverlay, caster);
+
+            SlowBattleManager.Instance?.MarkPerformingTimelineResumed(caster);
+        }
+        else if (sequence.performingTimeline != null)
         {
             StartTimelinePhase(
-                sequence.performingPhase2,
+                sequence.performingTimeline,
                 sequence.useOverlay,
                 caster,
                 sequence.casterAnimatorGO,
@@ -846,7 +852,7 @@ public class RhythmQTEManager : MonoBehaviour
                 sequence.performingCameraRole,
                 sequence.performingCameraDelay);
 
-            yield return WaitForTimelinePhase(sequence.performingPhase2, sequence.useOverlay, caster);
+            yield return WaitForTimelinePhase(sequence.performingTimeline, sequence.useOverlay, caster);
         }
 
         if (sequence.requiresReturn && caster != null && sequence.target != null)
@@ -885,10 +891,24 @@ public class RhythmQTEManager : MonoBehaviour
 
         isActive = true;
 
-        if (sequence.performingPhase2 != null)
+        if (sequence.resumePausedTimeline)
+        {
+            ResumeTimelinePhase(
+                sequence.performingTimeline,
+                caster,
+                sequence.casterAnimatorGO,
+                sequence.performingCameraTarget,
+                sequence.initialRotation,
+                sequence.performingCameraRole);
+
+            yield return WaitForTimelinePhase(sequence.performingTimeline, sequence.useOverlay, caster);
+
+            SlowBattleManager.Instance?.MarkPerformingTimelineResumed(caster);
+        }
+        else if (sequence.performingTimeline != null)
         {
             StartTimelinePhase(
-                sequence.performingPhase2,
+                sequence.performingTimeline,
                 sequence.useOverlay,
                 caster,
                 sequence.casterAnimatorGO,
@@ -898,7 +918,7 @@ public class RhythmQTEManager : MonoBehaviour
                 sequence.performingCameraRole,
                 sequence.performingCameraDelay);
 
-            yield return WaitForTimelinePhase(sequence.performingPhase2, sequence.useOverlay, caster);
+            yield return WaitForTimelinePhase(sequence.performingTimeline, sequence.useOverlay, caster);
         }
 
         if (sequence.requiresReturn && caster != null && sequence.target != null && sequence.item != null)

--- a/Assets/Scripts/MonoBehavioursUsed/SlowBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SlowBattleManager.cs
@@ -99,9 +99,15 @@ public class SlowBattleManager : MonoBehaviour
     private int roundIndex;
 
     /// <summary>
-    /// Liste des séquences (PerformingTimeline_2 + Retreat) à jouer en fin de manche.
+    /// Liste des séquences différées (reprise de Performing + retrait) à jouer en fin de manche.
     /// </summary>
     private readonly List<SlowBattleTimelineSequence> deferredTimelineSequences = new();
+
+    /// <summary>
+    /// Ensemble des unités dont la timeline de Performing a été suspendue via un Signal.
+    /// Cette collection sert à identifier rapidement quelles timelines devront être reprises.
+    /// </summary>
+    private readonly HashSet<CharacterUnit> pausedPerformingUnits = new();
 
     #region Événements publics
     /// <summary>
@@ -347,6 +353,7 @@ public class SlowBattleManager : MonoBehaviour
         turnQueue.Clear();
         roundIndex = 0;
         deferredTimelineSequences.Clear();
+        pausedPerformingUnits.Clear();
     }
 
     private IEnumerator BattleLoop()
@@ -403,6 +410,37 @@ public class SlowBattleManager : MonoBehaviour
         }
 
         deferredTimelineSequences.Clear();
+        pausedPerformingUnits.Clear();
+    }
+
+    /// <summary>
+    /// Appelé par un Signal de Performing pour mémoriser la pause sur l'unité concernée.
+    /// </summary>
+    public void NotifyPerformingTimelinePaused(CharacterUnit unit)
+    {
+        if (unit == null)
+            return;
+
+        pausedPerformingUnits.Add(unit);
+    }
+
+    /// <summary>
+    /// Vérifie si une unité possède actuellement une Performing suspendue en attente de reprise.
+    /// </summary>
+    public bool IsPerformingTimelinePaused(CharacterUnit unit)
+    {
+        return unit != null && pausedPerformingUnits.Contains(unit);
+    }
+
+    /// <summary>
+    /// Indique que la Performing de l'unité peut être retirée des pauses suivies (reprise effectuée).
+    /// </summary>
+    public void MarkPerformingTimelineResumed(CharacterUnit unit)
+    {
+        if (unit == null)
+            return;
+
+        pausedPerformingUnits.Remove(unit);
     }
 
     private void PrepareNewRound()
@@ -504,7 +542,7 @@ public class SlowBattleManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Met de côté une séquence de timeline à jouer en fin de manche (PerformingTimeline_2 + Retreat).
+    /// Met de côté une séquence de timeline à jouer en fin de manche (reprise de Performing et retrait).
     /// </summary>
     /// <param name="sequence">Séquence construite par le <see cref="RhythmQTEManager"/>.</param>
     public void RegisterDeferredTimelineSequence(SlowBattleTimelineSequence sequence)

--- a/Assets/Scripts/MonoBehavioursUsed/SlowBattleTimelineSignalReceiver.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/SlowBattleTimelineSignalReceiver.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// Récepteur de Signal utilisé par les timelines Performing pour indiquer au <see cref="SlowBattleManager"/>
+/// qu'elles doivent être suspendues jusqu'à la fin du tour en cours. Le Signal appelle simplement
+/// <see cref="PauseTimelineForSlowTurn"/> depuis la timeline.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(CharacterUnit))]
+public class SlowBattleTimelineSignalReceiver : MonoBehaviour
+{
+    private CharacterUnit owner;
+
+    private void Awake()
+    {
+        owner = GetComponent<CharacterUnit>();
+    }
+
+    /// <summary>
+    /// Appelé par un Signal d'une timeline Performing pour la mettre en pause le temps que le tour
+    /// se termine (mode de combat lent). On délègue la mise en pause au <see cref="BattleTimelineManager"/>
+    /// puis on enregistre l'information auprès du <see cref="SlowBattleManager"/> afin qu'il reprenne
+    /// la lecture au moment opportun.
+    /// </summary>
+    public void PauseTimelineForSlowTurn()
+    {
+        if (owner == null)
+            return;
+
+        if (BattleTimelineManager.Instance == null || SlowBattleManager.Instance == null)
+            return;
+
+        BattleTimelineManager.Instance.PauseCasterTimeline(owner);
+        SlowBattleManager.Instance.NotifyPerformingTimelinePaused(owner);
+    }
+}


### PR DESCRIPTION
## Summary
- Remplacer les champs PerformingTimeline phase 1/2 des MusicalMoves et Items par une unique timeline d'exécution
- Introduire un signal SlowBattle permettant de mettre en pause la timeline Performing puis de la reprendre via le SlowBattleManager
- Ajouter les API de pause/reprise aux CharacterUnit/BattleTimelineManager et adapter le RhythmQTEManager pour orchestrer les séquences différées

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dd525a89a88325a436af11fccdc624