### PR TITLE
Bloque le saut près des interactables

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -241,8 +241,40 @@ public class ThirdPersonPlayerController : MonoBehaviour
 
         if (InputsManager.Instance.playerInputs.World.Jump.triggered)
         {
-            lastJumpPressedTimestamp = Time.time;
+            // Le saut est volontairement bloqué à proximité d'un interactable pour éviter les
+            // erreurs de manipulation (un appui sur saut déclenchait l'interaction).
+            if (CanProcessJumpInput())
+            {
+                // Aucun interactable prioritaire : on mémorise l'appui pour la logique de buffer.
+                lastJumpPressedTimestamp = Time.time;
+            }
+            else
+            {
+                // Dès qu'un interactable est actif, on annule la tentative de saut pour empêcher
+                // un déclenchement immédiat lorsque le joueur s'écarte de l'objet interactif.
+                lastJumpPressedTimestamp = float.NegativeInfinity;
+            }
         }
+    }
+
+    /// <summary>
+    /// Indique si le joueur peut consommer l'entrée de saut. Lorsque Lucian est
+    /// suffisamment proche d'un interactable (détecté par <see cref="InteractionManager"/>),
+    /// on désactive volontairement le saut pour privilégier l'action contextuelle.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> si aucun interactable prioritaire n'est en portée et que le saut peut être traité.
+    /// </returns>
+    private bool CanProcessJumpInput()
+    {
+        // Si le gestionnaire d'interactions n'est pas encore initialisé, on laisse le saut actif.
+        if (InteractionManager.Instance == null)
+        {
+            return true;
+        }
+
+        // La présence d'un objet interactable courant signifie que le joueur est à portée : on bloque le saut.
+        return InteractionManager.Instance.currentInteractable == null;
     }
 
     /// <summary>
@@ -477,7 +509,7 @@ public class ThirdPersonPlayerController : MonoBehaviour
     private void HandleVerticalMove()
     {
         bool recentlyGrounded = Time.time - lastGroundedTimestamp <= coyoteTime;
-        bool jumpBuffered = Time.time - lastJumpPressedTimestamp <= jumpBufferTime;
+        bool jumpBuffered = CanProcessJumpInput() && Time.time - lastJumpPressedTimestamp <= jumpBufferTime;
 
         if (jumpBuffered && recentlyGrounded && !landingAnimationLocked)
         {


### PR DESCRIPTION
## Summary
- empêche la mise en mémoire du saut lorsque Lucian est à portée d’un interactable
- ajoute un garde-fou dans la logique du saut pour vérifier l’état du gestionnaire d’interactions

## Testing
- non testé (non applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dff96f11f88325946a59449a228d55