### PR TITLE
Configure les MusicalMoves et Items

### DIFF
--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
@@ -13,19 +13,22 @@ MonoBehaviour:
   m_Name: MusicalMove_CryingAngel_Etreinte du Linceul
   m_EditorClassIdentifier: 
   moveName: Etreinte du Linceul
-  moveType: 1
+  moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Des bras translucides se mat\xE9rialisent et tentent de retenir la
-    cible."
+  description: "Des bras translucides immobilisent la cible en la plongeant dans un\n    sommeil forc\xE9 jusqu'\xE0 ce qu'elle subisse des d\xE9g\xE2ts."
+  inventoryCategory: Boss
+  inventorySummary: "Immobilisation par sommeil."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
   harmonicCost: 1
   harmonicGeneration: 0
-  power: 10
-  effectType: 0
-  effectValue: 10
+  power: 0
+  effectType: 4
+  effectValue: 0
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -38,7 +41,7 @@ MonoBehaviour:
   altitudeCondition: 2
   targetType: 1
   defaultTargetType: 1
-  targetTypes: 
+  targetTypes: 01000000
   travelTime: 0
   legacyMoveSpeed: 0
   legacyMoveSpeedConverted: 1
@@ -58,7 +61,7 @@ MonoBehaviour:
   preparingTimeline: {fileID: 11400000, guid: 923281249d69c464c96295029f742965, type: 2}
   performingTimeline: {fileID: 11400000, guid: b86e10946b4e6fb4d975fd2aee69fae3, type: 2}
   retreatTimeline: {fileID: 11400000, guid: 57375bf4baa7d8e4d9e3f34c0e6b607f, type: 2}
-  preparingCameraRole: 8
-  preparingToPerformingCameraDelay: 0.1
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
   performingCameraRole: 2
-  retreatCameraRole: 8
+  retreatCameraRole: 4

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
@@ -16,8 +16,11 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Des larmes lumineuses tombent en rafales comme une pluie in\xE9vitable.\nUne
-    b\xE9n\xE9diction devenue mal\xE9diction, une berceuse qui se transforme en temp\xEAte."
+  description: "Des larmes lumineuses s'abattent sur toute l'escouade, infligeant environ\n    25\u202f000 points de d\xE9g\xE2ts par cible."
+  inventoryCategory: Boss
+  inventorySummary: "AOE ~25\u202f000 d\xE9g\xE2ts."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
@@ -25,7 +28,7 @@ MonoBehaviour:
   harmonicGeneration: 0
   power: 0
   effectType: 0
-  effectValue: 10
+  effectValue: 25000
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -38,7 +41,7 @@ MonoBehaviour:
   altitudeCondition: 2
   targetType: 2
   defaultTargetType: 2
-  targetTypes: 
+  targetTypes: 02000000
   moveSpeed: 0
   castDistance: 0
   requiresMovement: 1
@@ -56,3 +59,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 7116d965a53bbee449dc994ffb5382ce, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
@@ -13,11 +13,14 @@ MonoBehaviour:
   m_Name: MusicalMove_CryingAngel_SanglotEcorchant
   m_EditorClassIdentifier: 
   moveName: Sanglot Ecorchant
-  moveType: 1
+  moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Un cri de douleur muet, une vibration qui lac\xE8re l\u2019air et
-    d\xE9soriente tout se qui se trouve \xE0 proximit\xE9."
+  description: "Une onde aigu\xEB inflige environ 18\u202f000 d\xE9g\xE2ts \xE0 tous les adversaires\n    et ralentit leur initiative pendant un tour."
+  inventoryCategory: Boss
+  inventorySummary: "AOE ~18\u202f000 + -200 initiative."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
@@ -25,7 +28,15 @@ MonoBehaviour:
   harmonicGeneration: 0
   power: 0
   effectType: 0
-  effectValue: 10
+  effectValue: 18000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 3
+  debuffAmount: 200
+  debuffDuration: 1
+  debuffIsPercentage: 0
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -38,7 +49,7 @@ MonoBehaviour:
   altitudeCondition: 2
   targetType: 2
   defaultTargetType: 2
-  targetTypes: 
+  targetTypes: 02000000
   moveSpeed: 0
   castDistance: 0
   requiresMovement: 1
@@ -56,3 +67,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: 7116d965a53bbee449dc994ffb5382ce, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
+++ b/Assets/Items/Item_AntiInterception/Item_AntiInterception.asset
@@ -14,14 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: AntiInterception
   itemName: Anti-Interception
-  description: "Emp\xEAche la cible d'\xEAtre intercept\xE9e pendant un court laps
-    de temps."
+  description: "Tisse un champ harmonique qui prot\xE8ge un alli\xE9 de toute interception\n    pendant deux tours."
+  inventoryCategory: Consommable
+  inventorySummary: "Immunit\xE9 interception (2 tours)."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
-  effectValue: 10
+  effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -35,7 +38,7 @@ MonoBehaviour:
   revivePercentage: 50
   buffStat: 0
   buffAmount: 0
-  buffDuration: 1
+  buffDuration: 2
   buffIsPercentage: 0
   debuffStat: 0
   debuffAmount: 0
@@ -53,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_Endormissement/Item_Endormissement.asset
+++ b/Assets/Items/Item_Endormissement/Item_Endormissement.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: Endormissement
   itemName: Endormissement
-  description: "Endort la cible jusqu\xE0 ce qu'elle subisse des d\xE9g\xE2ts."
+  description: "Diffuse une poudre soporifique endormant une cible jusqu'\xE0 ce qu'elle\n    soit bless\xE9e. Parfait pour contr\xF4ler une menace majeure."
+  inventoryCategory: Consommable
+  inventorySummary: "Endort une cible."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
   effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 500
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -44,7 +48,7 @@ MonoBehaviour:
   timingBoostAmount: 0
   timingDuration: 0
   defaultTargetType: 1
-  targetTypes: 0100000003000000
+  targetTypes: 01000000
   tpVfx_Start: {fileID: 0}
   tpVfx_End: {fileID: 0}
   tpSFx_Start: {fileID: 0}
@@ -52,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
+++ b/Assets/Items/Item_ExtensionEffets/Item_ExtensionEffets.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: ExtensionEffets
   itemName: Extension d'Effets
-  description: Prolonge de deux tours tous les effets actifs de la cible.
+  description: "Etire la dur\xE9e de tous les effets temporaires de la cible de deux tours,\n    utile pour verrouiller un contr\xF4le ou prolonger une protection."
+  inventoryCategory: Consommable
+  inventorySummary: "+2 tours sur tous les effets."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
   effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -52,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
+++ b/Assets/Items/Item_LonguePortee/Item_LonguePortee.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: LonguePortee
   itemName: "Longue Port\xE9e"
-  description: "Augmente la port\xE9e du lanceur de 10 pour ce tour."
+  description: "Etend le champ d'action du lanceur de 15 m\xE8tres pour ce tour, id\xE9al\n    pour ouvrir des combos \xE0 distance."
+  inventoryCategory: Consommable
+  inventorySummary: "+15 port\xE9e (1 tour)."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
-  effectValue: 20
+  effectValue: 15
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0

--- a/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
+++ b/Assets/Items/Item_MetronomePrecision/Item_MetronomePrecision.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: MetronomePrecision
   itemName: "M\xE9tronome de Pr\xE9cision"
-  description: "Am\xE9liore la fen\xEAtre de parade ou d'esquive pendant deux tours."
+  description: "Stabilise le tempo de Munin et augmente les fen\xEAtres de parade/esquive\n    de 10\u202f% pendant deux tours."
+  inventoryCategory: Consommable
+  inventorySummary: "+10\u202f% parade/esquive (2 tours)."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
   effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -52,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
+++ b/Assets/Items/Item_PotionMelodique/Item_PotionMelodique.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: PotionMelodique
   itemName: "Potion M\xE9lodique"
-  description: "Restaure des PV \xE0 une unit\xE9 alli\xE9e."
+  description: "Restaure environ 12\u202f000 PV \xE0 une unit\xE9 alli\xE9e, un soin id\xE9al\n    avant d'encha\xEEner sur une d\xE9fense renforc\xE9e."
+  inventoryCategory: Consommable
+  inventorySummary: "Soigne ~12\u202f000 PV."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
   effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -29,7 +33,7 @@ MonoBehaviour:
   criticalEffectValue: 20
   stayInPlace: 0
   effectType: 1
-  healAmount: 50
+  healAmount: 12000
   healIsPercentage: 0
   revivePercentage: 0
   buffStat: 0
@@ -52,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/Items/Item_Reveil/Item_Reveil.asset
+++ b/Assets/Items/Item_Reveil/Item_Reveil.asset
@@ -14,13 +14,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemID: Reveil
   itemName: Reveil
-  description: "R\xE9veille une unit\xE9 endormie."
+  description: "Frappe une note claire qui r\xE9veille instantan\xE9ment une unit\xE9 alli\xE9e\n    endormie sans consommer de ressources."
+  inventoryCategory: Consommable
+  inventorySummary: "R\xE9veille un alli\xE9."
+  consumeOnUse: 1
+  recommendedMusicalMoves: []
   itemIcon: {fileID: 21300000, guid: 108ca3e7dda90d945b0914bf9259ec94, type: 3}
   effectValue: 0
   isUsableInBattle: 1
   moveSpeed: 0
   castDistance: 0
-  requiresMovement: 1
+  requiresMovement: 0
   teleportDelay: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
@@ -52,5 +56,9 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: f7714b3b704f3c74f98ee23bcd7f4b23, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 2
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 4
   beatPattern: []
   notes: []

--- a/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
+++ b/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
@@ -16,8 +16,11 @@ MonoBehaviour:
   moveType: 2
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Soigne l\xE9g\xE8rement un alli\xE9 et augmente sa D\xE9fense pour
-    deux tours."
+  description: "Accorde une phrase apaisante soignant environ 10\u202f000 PV et offrant\n    +400 D\xE9fense \xE0 un alli\xE9 durant deux tours."
+  inventoryCategory: Soutien
+  inventorySummary: "Soins ~10\u202f000 + +400 D\xE9fense."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
@@ -25,7 +28,15 @@ MonoBehaviour:
   harmonicGeneration: 0
   power: 0
   effectType: 1
-  effectValue: 10
+  effectValue: 10000
+  buffStat: 2
+  buffAmount: 400
+  buffDuration: 2
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -56,3 +67,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -16,15 +16,19 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Cr\xE9e une onde dissonante touchant tous les ennemis pour environ 13\u202f000\n    points de d\xE9g\xE2ts avant amplifications."
+  inventoryCategory: Assaut de zone
+  inventorySummary: "AOE ~13\u202f000 d\xE9g\xE2ts chacun."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
   harmonicCost: 3
   harmonicGeneration: 0
-  power: 50
+  power: 0
   effectType: 0
-  effectValue: 50
+  effectValue: 13000
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -37,7 +41,7 @@ MonoBehaviour:
   altitudeCondition: 2
   targetType: 2
   defaultTargetType: 2
-  targetTypes: 01000000
+  targetTypes: 02000000
   travelTime: 0.075
   legacyMoveSpeed: 20
   legacyMoveSpeedConverted: 1
@@ -59,4 +63,4 @@ MonoBehaviour:
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 5
   performingCameraRole: 2
-  retreatCameraRole: 3
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -16,15 +16,19 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Projette un trait fulgurant infligeant environ 11\u202f000 points de d\xE9g\xE2ts\n    \xE0 une cible isol\xE9e."
+  inventoryCategory: Assaut rapide
+  inventorySummary: "Frappe instantan\xE9e ~11\u202f000 d\xE9g\xE2ts."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
   harmonicCost: 1
   harmonicGeneration: 0
-  power: 10
+  power: 0
   effectType: 0
-  effectValue: 10
+  effectValue: 11000
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -55,3 +59,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 11400000, guid: bc1a72aa23e36b84d8d545619e3b5f19, type: 2}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -13,10 +13,14 @@ MonoBehaviour:
   m_Name: MusicalMove_FausseNote
   m_EditorClassIdentifier: 
   moveName: Fausse note
-  moveType: 1
+  moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Brise l'envo\xFBtement et r\xE9veille imm\xE9diatement toutes les unit\xE9s\n    alli\xE9es endormies."
+  inventoryCategory: Soutien
+  inventorySummary: "Dissipe le sommeil de l'\xE9quipe."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
@@ -35,9 +39,9 @@ MonoBehaviour:
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
   altitudeCondition: 2
-  targetType: 0
-  defaultTargetType: 0
-  targetTypes: 01000000
+  targetType: 4
+  defaultTargetType: 4
+  targetTypes: 04000000
   moveSpeed: 20
   castDistance: 0
   requiresMovement: 1
@@ -55,3 +59,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -13,10 +13,14 @@ MonoBehaviour:
   m_Name: MusicalMove_Hate
   m_EditorClassIdentifier: 
   moveName: Hate
-  moveType: 1
+  moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Se place devant l'unit\xE9 cible."
+  description: "Lucian se projette devant la cible pour intercepter la prochaine attaque\n    et prot\xE9ger ses alli\xE9s."
+  inventoryCategory: Placement
+  inventorySummary: "Se positionne comme bouclier."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
@@ -55,3 +59,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -16,7 +16,12 @@ MonoBehaviour:
   moveType: 2
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: Applique une marque sur un ennemi.
+  description: "Relie l'adversaire au lanceur en pla\xE7ant une marque de lien qui
+    facilite les combos synchronis\xE9s."
+  inventoryCategory: Tactique
+  inventorySummary: "Applique une Marque de lien."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
@@ -59,5 +64,5 @@ MonoBehaviour:
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 5
   preparingToPerformingCameraDelay: 0
-  performingCameraRole: 8
-  retreatCameraRole: 3
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -16,7 +16,11 @@ MonoBehaviour:
   moveType: 2
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Applique une marque de loyaut\xE9 sur un alli\xE9."
+  description: "Sculpte une marque de loyaut\xE9 liant la cible au lanceur pour encourager\n    les interceptions h\xE9ro\xEFques."
+  inventoryCategory: Protection
+  inventorySummary: "D\xE9signe un protecteur loyal."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
@@ -59,5 +63,5 @@ MonoBehaviour:
   retreatTimeline: {fileID: 0}
   preparingCameraRole: 5
   preparingToPerformingCameraDelay: 0
-  performingCameraRole: 8
-  retreatCameraRole: 3
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -16,15 +16,19 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Encha\xEEne un motif classique infligeant environ 7\u202f500 points de d\xE9g\xE2ts\n    avant application des multiplicateurs de runes."
+  inventoryCategory: Attaque de base
+  inventorySummary: "Attaque simple ~7\u202f500 d\xE9g\xE2ts."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 0
   harmonicCost: 0
   harmonicGeneration: 0
-  power: 10
+  power: 0
   effectType: 0
-  effectValue: 10
+  effectValue: 6500
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -57,6 +61,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 11400000, guid: 4fa946d42fae10b48bc20bf37f9fc9eb, type: 2}
   performingTimeline: {fileID: 11400000, guid: 361e91e8ca92edc459ed5ed247a853bd, type: 2}
   retreatTimeline: {fileID: 0}
-  preparingCameraRole: 2
-  performingCameraRole: 8
+  preparingCameraRole: 5
+  performingCameraRole: 2
   retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
+++ b/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
@@ -16,15 +16,27 @@ MonoBehaviour:
   moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Inflige des d\xE9g\xE2ts et r\xE9duit la D\xE9fense de la cible."
+  description: "Frappe cibl\xE9e infligeant environ 9\u202f500 d\xE9g\xE2ts et fracturant la d\xE9fense\n    adverse pendant deux tours."
+  inventoryCategory: Affaiblissement
+  inventorySummary: "D\xE9g\xE2ts + -400 D\xE9fense (2 tours)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
   harmonicCost: 2
   harmonicGeneration: 0
-  power: 10
+  power: 0
   effectType: 0
-  effectValue: 10
+  effectValue: 9500
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 2
+  debuffAmount: 400
+  debuffDuration: 2
+  debuffIsPercentage: 0
   useCriticalVariant: 0
   criticalEffectType: 0
   criticalEffectValue: 20
@@ -55,3 +67,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -13,10 +13,14 @@ MonoBehaviour:
   m_Name: MusicalMove_Tunnel
   m_EditorClassIdentifier: 
   moveName: Tunnel
-  moveType: 1
+  moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: 
+  description: "Fait vibrer le sol sous la cible et l'endort jusqu'\xE0 ce qu'elle\n    subisse des d\xE9g\xE2ts."
+  inventoryCategory: Contr\xF4le
+  inventorySummary: "Endort un ennemi isol\xE9."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
   fatigueCost: 1
@@ -55,3 +59,6 @@ MonoBehaviour:
   preparingTimeline: {fileID: 0}
   performingTimeline: {fileID: 0}
   retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  performingCameraRole: 2
+  retreatCameraRole: 4

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -65,6 +65,28 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Valeur numérique associée à l'effet principal.")]
     public int effectValue = 10;
 
+    // ------------------------------------------------------------------
+    // Buffs et débuffs supplémentaires
+    // ------------------------------------------------------------------
+    [Header("Effets secondaires optionnels")]
+    [Tooltip("Stat à augmenter après l'application de l'effet principal (None = aucun bonus).")]
+    public BuffStatType buffStat = BuffStatType.None;
+    [Tooltip("Valeur brute ajoutée par le buff (en points ou pourcentage selon buffIsPercentage).")]
+    public int buffAmount = 0;
+    [Tooltip("Durée du buff en tours.")]
+    public float buffDuration = 0f;
+    [Tooltip("Interpréter buffAmount comme un pourcentage ?")]
+    public bool buffIsPercentage = false;
+
+    [Tooltip("Stat à réduire après l'effet principal (None = aucun malus).")]
+    public DebuffStatType debuffStat = DebuffStatType.None;
+    [Tooltip("Valeur brute retirée par le débuff (en points ou pourcentage selon debuffIsPercentage).")]
+    public int debuffAmount = 0;
+    [Tooltip("Durée du débuff en tours.")]
+    public float debuffDuration = 0f;
+    [Tooltip("Interpréter debuffAmount comme un pourcentage ?")]
+    public bool debuffIsPercentage = false;
+
     [Header("Coup Critique")]
     [Tooltip("Active une variante lorsque le QTE est réussi")]
     public bool useCriticalVariant = false;
@@ -280,8 +302,17 @@ public class MusicalMoveSO : ScriptableObject
         float finalValue = baseValue;
         if (caster != null)
         {
-            finalValue += caster.currentPower;
+            float powerToUse = caster.currentPower;
+            if (typeToUse == MusicalEffectType.Heal)
+                powerToUse = Mathf.Max(caster.currentSagacity, caster.currentPower);
+
+            finalValue += powerToUse;
             finalValue *= caster.GetAttackMultiplier();
+
+            if (typeToUse == MusicalEffectType.Damage)
+                finalValue = caster.ApplyDamageModifiers(finalValue);
+            else if (typeToUse == MusicalEffectType.Heal)
+                finalValue = caster.ApplyHealingModifiers(finalValue);
         }
 
         // Ancien comportement : simple multiplicateur si aucune variante
@@ -290,19 +321,22 @@ public class MusicalMoveSO : ScriptableObject
 
         if (typeToUse == MusicalEffectType.Damage)
         {
-            // ⚠️ Correction : les dégâts doivent maintenant s'appliquer à toutes les cibles valides.
-            // Auparavant, une vérification restrictive empêchait les ennemis
-            // d'endommager l'escouade car seules les EnemyUnit recevaient des dégâts.
-            // En retirant ce filtre, on rétablit la logique attendue tout en conservant
-            // la transmission de la source pour les animations directionnelles.
             target.TakeDamage(finalValue, caster != null ? caster.transform : null);
             NewBattleManager.Instance?.RegisterDamage(caster, finalValue);
         }
         else if (typeToUse == MusicalEffectType.Heal)
         {
-            // Même logique que pour les dégâts : l'appelant gère déjà la sélection
-            // de cible, inutile de limiter la guérison aux seules unités alliées.
             target.Heal(finalValue);
+        }
+        else if (typeToUse == MusicalEffectType.Buff)
+        {
+            // Les buffs intrinsèques sont gérés via l'InventoryManager pour
+            // conserver une logique unique entre les Items et les MusicalMoves.
+            InventoryManager.Instance?.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
+        }
+        else if (typeToUse == MusicalEffectType.Debuff)
+        {
+            InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
         }
         else if (typeToUse == MusicalEffectType.Sleep)
         {
@@ -327,12 +361,33 @@ public class MusicalMoveSO : ScriptableObject
             if (target.GetComponent<LinkMark>() == null)
                 target.gameObject.AddComponent<LinkMark>();
         }
+        else if (typeToUse == MusicalEffectType.AnchorGround)
+        {
+            int turns = Mathf.Max(1, Mathf.RoundToInt(baseValue));
+            target.EnsureAltitudeOverrideStatus().AnchorToGround(turns);
+        }
+        else if (typeToUse == MusicalEffectType.SuspendAir)
+        {
+            int turns = Mathf.Max(1, Mathf.RoundToInt(baseValue));
+            target.EnsureAltitudeOverrideStatus().SuspendInAir(turns);
+        }
         // Les effets visuels comme la création ou la suppression de sol sont
         // désormais entièrement gérés par la timeline, aucune instanciation
         // de prefab n'est nécessaire ici.
         if (caster != null && caster.Data.gameplayType == GameplayType.Fatigue)
         {
             caster.GetComponent<FatigueSystem>()?.OnActionPerformed(fatigueToApply);
+        }
+
+        // Applique ensuite les éventuels effets secondaires définis plus haut.
+        if (buffStat != BuffStatType.None && typeToUse != MusicalEffectType.Buff)
+        {
+            InventoryManager.Instance?.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
+        }
+
+        if (debuffStat != DebuffStatType.None && typeToUse != MusicalEffectType.Debuff)
+        {
+            InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
         }
     }
 }
@@ -350,7 +405,7 @@ public enum MoveType
     Alteration  // Modifie le terrain ou l'état d'une cible sans être purement offensif ou défensif.
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark, AnchorGround, SuspendAir }
 
 public enum RelativePosition { Front, Back, Left, Right , NC}
 

--- a/Docs/RepertoireMusicalEtItems.md
+++ b/Docs/RepertoireMusicalEtItems.md
@@ -1,0 +1,55 @@
+# Répertoire des MusicalMoves et Items
+
+> Ce mémento synthétise les effets des actions musicales et des objets en
+> s'appuyant sur l'histoire décrite dans `Docs/HistoireSymphonie.md`. Les
+> valeurs indiquées sont les bases avant application des multiplicateurs de
+> runes : un joueur avancé pourra aisément dépasser le million de dégâts ou de
+> soins en optimisant ses configurations.
+
+## Actions musicales jouables
+
+| Nom | Type | Coûts (Fatigue / Harmonie) | Effet de base | Combinaisons & Conseils |
+|-----|------|----------------------------|---------------|-------------------------|
+| **Rhapsodie** | Attaque | 0 / 0 | ~7 500 dégâts + puissance actuelle du lanceur. | Idéal pour les débutants : aucune ressource, permet d'accumuler des fragments avant de déclencher un combo majeur. |
+| **Éclair** | Attaque | 1 / 1 | ~11 000 dégâts instantanés. | À lier avec la *Clé du Courage* ou des runes de puissance pour éliminer les menaces rapides. |
+| **Contrepoint Chaotique** | Attaque de zone | 1 / 3 | ~13 000 dégâts à chaque ennemi. | Prépare des balayages massifs avant un *Crescendo Fulgurant* pour achever les survivants. |
+| **Tunnel** | Contrôle | 1 / 1 | Endort un ennemi jusqu’à la prochaine blessure. | Combinez avec *Pont Harmonique* pour fixer une cible aérienne puis la neutraliser durablement. |
+| **Fausse Note** | Altération | 1 / 1 | Réveille toutes les unités alliées. | Annule les effets soporifiques des Entités du Rêve ou de l’*Endormissement*. |
+| **Accord Bienveillant** | Soutien | 1 / 1 | Soigne ~10 000 PV et +400 Défense (2 tours). | Ancre parfaite pour les runes défensives lorsque les assauts de l’Ange Pleureur se déchaînent. |
+| **Rupture Harmonieuse** | Affaiblissement | 1 / 2 | ~9 500 dégâts et -400 Défense sur l’ennemi (2 tours). | Lancez-la avant *Crescendo Fulgurant* ou *Sforzando* pour maximiser les dégâts critiques. |
+| **Pour qui sonne le glas** | Protection | 1 / 1 | Applique une marque de loyauté reliant l’allié au lanceur. | Encourage les interceptions héroïques de Lucian pour protéger Thalia et Kael. |
+| **Marque** | Tactique | 1 / 1 | Appose une marque de lien sur l’ennemi. | Sert de point d’ancrage pour les combos de Kael ou les runes d’exécution. |
+| **Hate** | Placement | 1 / 0 | Lucian se place devant la cible pour absorber les attaques. | À utiliser juste avant *Sforzando* pour rester au contact de l’adversaire. |
+| **Pont Harmonique** | Altération | 1 / 1 | Ramène une cible volante au sol pour 2 tours. | Indispensable contre les entités en suspension avant d’enchaîner les attaques terrestres. |
+| **Staccato Étourdissant** | Contrôle | 2 / 2 | Endort un ennemi pendant 1 tour. | À coupler avec des runes de contrôle pour verrouiller un boss pendant la préparation d’une offensive majeure. |
+| **Sforzando** | Attaque téléportée | 1 / 1 | ~20 000 dégâts, génère +1 Harmonie. | Offre un repositionnement agressif idéal pour capitaliser sur la marque de loyauté. |
+| **Crescendo Fulgurant** | Attaque | 2 / 2 | ~30 000 dégâts concentrés. | L’ultime exécution de Lucian, à déclencher après une *Rupture Harmonieuse*. |
+| **Arpège Régénérant** | Soutien | 2 / 2 | ~20 000 PV à toute l’équipe. | Associé aux runes de soin, il permet de soutenir des combats prolongés contre les Séraphins. |
+| **Abîme Harmonique** | Altération | 1 / 1 | Force la cible à flotter pendant 2 tours. | Prépare les stratégies aériennes de Luna et contrebalance les défenses terrestres. |
+
+## Attaques musicales de l’Ange Pleureur
+
+| Nom | Type | Effet | Astuces pour survivre |
+|-----|------|-------|------------------------|
+| **Pluie du Requiem** | Attaque | ~25 000 dégâts à tous les membres de l’escouade. | Utiliser *Accord Bienveillant* ou des runes défensives avant la pluie de larmes. |
+| **Sanglot Écorchant** | Affaiblissement | ~18 000 dégâts de zone et -200 Initiative pendant 1 tour. | Garder une *Potion Mélodique* ou un *Métronome de Précision* pour retrouver le tempo. |
+| **Étreinte du Linceul** | Contrôle | Plonge la cible dans un sommeil forcé jusqu’à ce qu’elle soit frappée. | Une *Fausse Note* bien placée ou un *Réveil* rapide permet de libérer la victime. |
+
+## Objets utilisables
+
+| Nom | Catégorie | Effet de base | Conseils d’utilisation |
+|-----|-----------|---------------|-------------------------|
+| **Potion Mélodique** | Consommable | Soigne ~12 000 PV à un allié. | À enchaîner avec *Accord Bienveillant* pour amortir les pluies de l’ange. |
+| **Élixir Revitalisant** | Consommable | Ranime un allié à 50 % de ses PV massifs. | Sauvetage indispensable après un *Crescendo* adverse ; combinez avec des runes de protection. |
+| **Clé du Courage** | Consommable | +1 500 Force pendant 2 tours. | Préparation idéale pour un duo *Rupture* + *Crescendo*. |
+| **Bombe Sonique** | Consommable | ~15 000 dégâts à tous les ennemis. | Permet de nettoyer un groupe avant qu’il n’impose ses altérations. |
+| **Endormissement** | Consommable | Endort une cible jusqu’à ce qu’elle subisse des dégâts. | À coupler avec les runes de contrôle ou *Pont Harmonique*. |
+| **Réveil** | Consommable | Réveille immédiatement un allié. | Neutralise l’*Étreinte du Linceul* ou les contre-mesures soporifiques. |
+| **Anti-Interception** | Consommable | Immunité à l’interception pendant 2 tours. | Garanti pour déplacer Munin ou Lucian sans risque lors des séquences narratives clés. |
+| **Longue Portée** | Consommable | +15 mètres de portée pour le tour en cours. | Offre des opportunités aux attaques à distance pendant les phases aériennes. |
+| **Extension d’Effets** | Consommable | Prolonge tous les effets d’un allié de 2 tours. | À lancer juste après un buff majeur (Clé du Courage, runes temporaires). |
+| **Métronome de Précision** | Consommable | +10 % fenêtre de parade/esquive pendant 2 tours. | Synchronise les joueurs experts avec les attaques rythmées des boss. |
+
+Ces réglages assurent une lecture claire pour les nouveaux venus tout en
+laissant aux stratèges expérimentés la possibilité d’exploiter pleinement les
+runes harmonisées d’Azazel.


### PR DESCRIPTION
## Résumé
- Ajout d'un support natif des buffs/débuffs dans `MusicalMoveSO` afin que les actions musicales appliquent désormais des modificateurs persistants en plus des effets principaux.
- Rééquilibrage des MusicalMoves jouables et des attaques de l'Ange Pleureur avec descriptions détaillées, valeurs en milliers et caméras cohérentes pour guider les combinaisons.
- Mise à jour des items de contrôle et de soutien (Potion Mélodique, Endormissement, Anti-Interception, etc.) et création d'une documentation de synthèse `Docs/RepertoireMusicalEtItems.md` pour faciliter la progression.

## Tests
- ⚠️ Non exécutés (tests Unity non disponibles dans cet environnement)


------
https://chatgpt.com/codex/tasks/task_e_68e00a3018748325b66661dcd0d68063