### PR TITLE
Add altitude override management to CharacterUnit

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AltitudeOverrideStatus.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AltitudeOverrideStatus.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+
+/// <summary>
+///     Gère les effets temporaires qui forcent une unité à rester collée au sol
+///     ou, au contraire, à flotter dans les airs pendant un certain nombre de tours.
+///     Cette classe agit comme un tampon centralisé afin que les MusicalMoves,
+///     les Items et les systèmes de gestion de tour puissent consulter ou
+///     prolonger facilement ces contraintes sans dupliquer la logique.
+/// </summary>
+[DisallowMultipleComponent]
+public class AltitudeOverrideStatus : MonoBehaviour
+{
+    [SerializeField, Tooltip("Nombre de tours restants durant lesquels l'unité est contrainte au sol.")]
+    private int forcedGroundRemainingTurns;
+
+    [SerializeField, Tooltip("Nombre de tours restants durant lesquels l'unité est suspendue dans les airs.")]
+    private int forcedAirRemainingTurns;
+
+    /// <summary>
+    ///     Indique si un override est encore actif (sol ou air).
+    ///     Utile pour savoir si le composant peut être ignoré par les routines de fin de tour.
+    /// </summary>
+    public bool HasActiveOverride => forcedGroundRemainingTurns > 0 || forcedAirRemainingTurns > 0;
+
+    /// <summary>
+    ///     Indique si l'unité doit être considérée comme rivée au sol quel que soit son type d'origine.
+    /// </summary>
+    public bool IsForcedGrounded => forcedGroundRemainingTurns > 0;
+
+    /// <summary>
+    ///     Indique si l'unité est forcée de flotter dans les airs et doit être traitée comme telle
+    ///     lors des vérifications d'altitude.
+    /// </summary>
+    public bool IsSuspendedInAir => forcedAirRemainingTurns > 0;
+
+    /// <summary>
+    ///     Applique (ou prolonge) un ancrage au sol pour un nombre de tours donné.
+    ///     Toute suspension aérienne active est annulée pour éviter les états contradictoires.
+    /// </summary>
+    public void AnchorToGround(int turns)
+    {
+        forcedGroundRemainingTurns = Mathf.Max(forcedGroundRemainingTurns, Mathf.Max(0, turns));
+        forcedAirRemainingTurns = 0;
+    }
+
+    /// <summary>
+    ///     Applique (ou prolonge) une suspension dans les airs pour un nombre de tours donné.
+    ///     Toute contrainte au sol active est annulée dans la foulée.
+    /// </summary>
+    public void SuspendInAir(int turns)
+    {
+        forcedAirRemainingTurns = Mathf.Max(forcedAirRemainingTurns, Mathf.Max(0, turns));
+        forcedGroundRemainingTurns = 0;
+    }
+
+    /// <summary>
+    ///     Décrémente les compteurs en fin de tour afin que les overrides expirent naturellement.
+    ///     La méthode renvoie vrai si un état reste actif, ce qui facilite la surveillance côté appelant.
+    /// </summary>
+    public bool TickTurn()
+    {
+        if (forcedGroundRemainingTurns > 0)
+            forcedGroundRemainingTurns = Mathf.Max(0, forcedGroundRemainingTurns - 1);
+
+        if (forcedAirRemainingTurns > 0)
+            forcedAirRemainingTurns = Mathf.Max(0, forcedAirRemainingTurns - 1);
+
+        return HasActiveOverride;
+    }
+
+    /// <summary>
+    ///     Réinitialise complètement les overrides en cours.
+    ///     Pratique si un effet annule brutalement toutes les contraintes d'altitude.
+    /// </summary>
+    public void ResetOverrides()
+    {
+        forcedGroundRemainingTurns = 0;
+        forcedAirRemainingTurns = 0;
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -145,12 +145,82 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// <summary>
     /// Indique si l'unité touche actuellement un support solide.
     /// </summary>
-    public bool IsGrounded => controller != null && controller.isGrounded;
+    public bool IsGrounded
+    {
+        get
+        {
+            // 🎯 Avant toute chose, on vérifie si un override d'altitude est en cours.
+            //     Cela permet par exemple à une attaque d'ancrage de considérer
+            //     une unité aérienne comme solidement arrimée au sol durant
+            //     quelques tours.
+            var altitudeOverride = GetAltitudeOverrideStatus();
+            if (altitudeOverride != null)
+            {
+                if (altitudeOverride.IsSuspendedInAir)
+                    return false; // Statut "en l'air" prioritaire : on force une réponse négative.
+
+                if (altitudeOverride.IsForcedGrounded)
+                    return true; // Inutile de consulter la physique : la contrainte prime.
+            }
+
+            return controller != null && controller.isGrounded;
+        }
+    }
 
     /// <summary>
     /// Indique si l'unité est de type aérien.
     /// </summary>
     public bool IsAirUnit => Data != null && Data.isAirUnit;
+
+    /// <summary>
+    ///     Référence mise en cache du composant gérant les overrides d'altitude.
+    ///     L'objectif est d'éviter les <see cref="GetComponent{T}()"/> répétés
+    ///     à chaque interrogation des propriétés publiques.
+    /// </summary>
+    private AltitudeOverrideStatus altitudeOverrideStatus;
+
+    /// <summary>
+    ///     Accès paresseux au composant <see cref="AltitudeOverrideStatus"/>.
+    ///     Le paramètre <paramref name="forceRefresh"/> permet de synchroniser
+    ///     la référence si un script externe supprime le composant à la volée.
+    /// </summary>
+    private AltitudeOverrideStatus GetAltitudeOverrideStatus(bool forceRefresh = false)
+    {
+        if (forceRefresh || altitudeOverrideStatus == null)
+            altitudeOverrideStatus = GetComponent<AltitudeOverrideStatus>();
+
+        return altitudeOverrideStatus;
+    }
+
+    /// <summary>
+    ///     S'assure qu'un composant <see cref="AltitudeOverrideStatus"/> est présent
+    ///     sur cette unité. Les MusicalMoves peuvent ainsi appliquer leurs effets
+    ///     sans se soucier de l'état initial du GameObject.
+    /// </summary>
+    public AltitudeOverrideStatus EnsureAltitudeOverrideStatus()
+    {
+        var status = GetAltitudeOverrideStatus();
+        if (status == null)
+        {
+            status = gameObject.AddComponent<AltitudeOverrideStatus>();
+            altitudeOverrideStatus = status;
+        }
+
+        return status;
+    }
+
+    /// <summary>
+    ///     Indique si l'unité est actuellement contrainte à rester au sol.
+    ///     Cette information complète la propriété <see cref="IsGrounded"/>
+    ///     en reflétant explicitement l'existence d'un override forcé.
+    /// </summary>
+    public bool IsForcedGrounded => GetAltitudeOverrideStatus()?.IsForcedGrounded ?? false;
+
+    /// <summary>
+    ///     Indique si l'unité est suspendue dans les airs via un override temporaire.
+    ///     Pratique pour les contrôles d'altitude ou pour désactiver certains mouvements.
+    /// </summary>
+    public bool IsSuspendedInAir => GetAltitudeOverrideStatus()?.IsSuspendedInAir ?? false;
 
     /// <summary>
     /// Détecte si un sol existe sous l'unité à portée de <see cref="groundCheckDistance"/>.
@@ -162,6 +232,21 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public bool HasGroundBelow()
     {
+        // 🪄 Un override d'altitude actif prime sur la physique classique :
+        //     * une unité ancrée au sol doit être traitée comme si un support
+        //       se trouvait toujours sous elle ;
+        //     * une unité suspendue ne doit jamais détecter de sol pendant
+        //       la durée de l'effet.
+        var altitudeOverride = GetAltitudeOverrideStatus();
+        if (altitudeOverride != null)
+        {
+            if (altitudeOverride.IsForcedGrounded)
+                return true;
+
+            if (altitudeOverride.IsSuspendedInAir)
+                return false;
+        }
+
         // Définit un masque par défaut si aucun n'est précisé dans l'éditeur.
         if (battleGroundLayer == 0)
             battleGroundLayer = LayerMask.GetMask("Battle_Ground");
@@ -1186,6 +1271,27 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     }
 
     /// <summary>
+    ///     Point d'extension pour appliquer des modificateurs de dégâts contextuels.
+    ///     À ce stade du projet, nous nous contentons de normaliser la valeur afin
+    ///     d'éviter toute quantité négative, mais le hook restera disponible pour
+    ///     intégrer facilement d'autres systèmes (talents, états temporaires...).
+    /// </summary>
+    public float ApplyDamageModifiers(float baseValue)
+    {
+        return Mathf.Max(0f, baseValue);
+    }
+
+    /// <summary>
+    ///     Point d'extension équivalent pour les soins. Cela garantit que les
+    ///     MusicalMoves et Items disposent d'un pipeline commun pour ajuster la
+    ///     valeur finale selon les buffs/malus futurs.
+    /// </summary>
+    public float ApplyHealingModifiers(float baseValue)
+    {
+        return Mathf.Max(0f, baseValue);
+    }
+
+    /// <summary>
     /// Appelé quand la cible pare une attaque.
     /// </summary>
     public void TakeParry()
@@ -1286,6 +1392,24 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public void Heal(float amount)
     {
         currentHP = Mathf.Min(currentHP + amount, Data.baseHP + currentVitality);
+    }
+
+    /// <summary>
+    ///     Gestion centralisée des statuts temporaires résolus en fin de tour.
+    ///     Aujourd'hui cela se limite aux overrides d'altitude, mais la méthode
+    ///     servira également de point d'entrée pour d'autres effets persistants.
+    /// </summary>
+    public void ProcessEndOfTurnStatuses()
+    {
+        var altitudeOverride = GetAltitudeOverrideStatus();
+        if (altitudeOverride == null)
+            return;
+
+        // On décale l'état d'un tour ; si plus aucun override n'est actif,
+        // on rafraîchit la référence pour éviter des consultations futures inutiles.
+        bool stillActive = altitudeOverride.TickTurn();
+        if (!stillActive)
+            altitudeOverrideStatus = null;
     }
 
     public void ApplyBuff(float value)

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1702,6 +1702,11 @@ public class NewBattleManager : MonoBehaviour
                     endingUnit.isInterceptionImmune = false;
             }
 
+            // ⏳ Gère la décrémentation des états temporaires (ancrage, suspension…)
+            //     directement sur l'unité afin que le BattleManager n'ait pas à
+            //     connaître les détails d'implémentation.
+            endingUnit.ProcessEndOfTurnStatuses();
+
             if (endingUnit.Data.characterType == CharacterType.SquadUnit && currentTurnDamage > maxTurnDamage)
             {
                 maxTurnDamage = currentTurnDamage;


### PR DESCRIPTION
## Summary
- add an AltitudeOverrideStatus component to persist ground/air overrides applied by moves
- expose helper methods on CharacterUnit so moves can safely apply damage/heal modifiers and altitude constraints
- ensure end-of-turn processing ticks altitude overrides inside NewBattleManager

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e01a4bca7c8325a39bd642b9a42664