### PR TITLE
Gestion automatique des états Awake et Dissonant

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -134,6 +134,7 @@ public class CharacterData : ScriptableObject, ITargetable
     public AnimationClip prepareToUndergoAnimation;   // Prépare la cible à subir un coup
 
     public AnimationClip awakenIdleAnimation;       // Jouée quand l'unité est en état Awake
+    public AnimationClip dissonantIdleAnimation;    // Jouée lorsque l'unité tombe en état Dissonant
 
     [Header("Timeline d'introduction")]
     [Tooltip("Timeline jouée lors de l'introduction du combat pour cette unité.")]
@@ -146,6 +147,16 @@ public class CharacterData : ScriptableObject, ITargetable
     [Header("Effets sonores d'interface")]
     [Tooltip("Clip joué lorsque cette unité devient active dans les menus de combat.")]
     public AudioClipSO menuSelectionClip;
+
+    [Header("Sons d'état")] // Clips joués lors des transitions entre les états majeurs de l'unité.
+    [Tooltip("Clip joué lorsque l'unité entre automatiquement en éveil (Awake).")]
+    public AudioClipSO awakeEnterClip;
+    [Tooltip("Clip joué lorsque l'unité quitte l'éveil (Awake).")]
+    public AudioClipSO awakeExitClip;
+    [Tooltip("Clip joué lorsqu'une animation d'Idle démarre (tous états confondus).")]
+    public AudioClipSO idleEnterClip;
+    [Tooltip("Clip joué lorsqu'une animation d'Idle est interrompue.")]
+    public AudioClipSO idleExitClip;
 
     [Header("Voix de deuil")]
     [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt")]

--- a/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AwakeState.cs
@@ -66,6 +66,15 @@ public class AwakeState : UnitStateEffects
         // le déclenchement du loop VFX ainsi que le retour automatique sur l'Idle.
         cachedAwakeOnDuration = GetAnimationClipDuration(AnimatorAwakeOnStateName);
         cachedAwakeOffDuration = GetAnimationClipDuration(AnimatorAwakeOffStateName);
+
+        // Relie automatiquement les clips d'entrée/sortie configurés dans la fiche personnage.
+        if (unit != null && unit.Data != null)
+        {
+            if (unit.Data.awakeEnterClip != null)
+                enterClip = unit.Data.awakeEnterClip;
+            if (unit.Data.awakeExitClip != null)
+                exitClip = unit.Data.awakeExitClip;
+        }
     }
 
     public void EnterAwake()
@@ -73,6 +82,7 @@ public class AwakeState : UnitStateEffects
         if (isAwake) return;
         isAwake = true;
         ApplyStatBonus();
+        unit?.NotifyIdleStateExit(); // Le son de sortie d'Idle doit être joué avant la transition Awake.
         // Activation des ailes de feu lorsque le personnage entre en mode Awake
         if (fireWing != null)
             fireWing.SetActive(true);

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -41,6 +41,10 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     // Indicateur évitant de répéter les avertissements lorsqu'on détecte plusieurs Animator valides chez les enfants.
     private bool hasLoggedMultipleChildAnimatorsWithController;
     private AwakeState awakeState;
+    private DissonantState dissonantState; // Gestionnaire dédié à l'état dissonant (perte d'harmonie).
+
+    // Permet de suivre si l'unité joue actuellement son animation d'Idle pour déclencher les sons adéquats.
+    private bool isIdleActive;
 
     /// <summary>Hash du state Animator "Idle_Battle" pour accélérer les vérifications de disponibilité.</summary>
     private static readonly int AnimatorStateIdleBattle = Animator.StringToHash("Idle_Battle");
@@ -128,6 +132,9 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// Indique si l'unité est en état Awake (fusion avec l'ange gardien).
     /// </summary>
     public bool IsAwake => awakeState != null && awakeState.IsAwake;
+
+    /// <summary>Indique si l'unité est tombée dans l'état Dissonant.</summary>
+    public bool IsDissonant => dissonantState != null && dissonantState.IsDissonant;
 
     // Gestionnaire de physique pour déléguer les collisions et la gravité à Unity.
     private CharacterController controller;
@@ -828,6 +835,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         // Recherche proactive de l'Animator dédié aux timelines dans les enfants (même inactifs).
         animator = GetCasterAnimator(forceRefresh: true);
         awakeState = GetComponent<AwakeState>();
+        dissonantState = GetComponent<DissonantState>();
+        isIdleActive = false; // L'unité n'est pas encore en Idle : permet de jouer le son d'entrée lors du premier appel.
 
         // Setup graphique
         if (spriteRenderer != null && Data.portrait != null)
@@ -851,6 +860,9 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
                 customBar.SetValue(currentFatigue);
             }
         }
+
+        // Vérifie immédiatement l'état harmonique pour déclencher Awake/Dissonant si nécessaire au lancement du combat.
+        CheckDissonance();
     }
 
     /// <summary>
@@ -879,6 +891,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
             Debug.LogError($"[CharacterUnit] Aucun PlayableDirector disponible sur {name}. La timeline '{timeline.name}' ne peut pas être jouée.");
             return;
         }
+
+        NotifyIdleStateExit(); // On quitte l'Idle : joue le son associé et réinitialise l'état sonore.
 
         // Évite que plusieurs timelines se chevauchent sur la même unité.
         battleDirector.Stop();
@@ -1816,12 +1830,41 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     }
 
     /// <summary>
-    /// Vérifie si l'unité doit sortir de l'état Awake en fonction de ses harmoniques.
+    /// Vérifie les seuils harmoniques pour orchestrer automatiquement les transitions Awake/Dissonant.
     /// </summary>
     private void CheckDissonance()
     {
-        if (IsAwake && GetHarmonicCount(Data.harmonicType) < Data.dissonancePoint)
-            ExitAwakeState();
+        if (Data == null)
+            return;
+
+        int currentHarmonics = GetHarmonicCount(Data.harmonicType);
+
+        // 1) Seuil d'éveil atteint : priorité absolue à l'état Awake.
+        if (currentHarmonics >= Data.awakeHarmonicThreshold)
+        {
+            if (IsDissonant)
+                ExitDissonantState();
+            if (!IsAwake)
+                EnterAwakeState();
+            return;
+        }
+
+        // 2) Seuil inférieur atteint : on perd l'éveil et on passe en dissonance.
+        if (currentHarmonics < Data.dissonancePoint)
+        {
+            if (IsAwake)
+                ExitAwakeState();
+            if (!IsDissonant)
+                EnterDissonantState();
+        }
+        else
+        {
+            // 3) Zone tampon entre les deux seuils : aucun état spécial ne doit rester actif.
+            if (IsAwake)
+                ExitAwakeState();
+            if (IsDissonant)
+                ExitDissonantState();
+        }
     }
 
     /// <summary>
@@ -1829,6 +1872,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// </summary>
     public void EnterAwakeState()
     {
+        if (IsDissonant)
+            ExitDissonantState(); // L'éveil annule immédiatement toute dissonance résiduelle.
         awakeState?.EnterAwake();
     }
 
@@ -1838,6 +1883,22 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     public void ExitAwakeState()
     {
         awakeState?.ExitAwake();
+    }
+
+    /// <summary>
+    /// Active l'état Dissonant lorsque le seuil inférieur d'harmonie est franchi.
+    /// </summary>
+    public void EnterDissonantState()
+    {
+        dissonantState?.EnterDissonant();
+    }
+
+    /// <summary>
+    /// Désactive l'état Dissonant afin de revenir à un comportement classique.
+    /// </summary>
+    public void ExitDissonantState()
+    {
+        dissonantState?.ExitDissonant();
     }
 
     public float GetAttackMultiplier()
@@ -1860,6 +1921,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         if (TryGetComponent<FatigueSystem>(out var fatigue) && fatigue.IsAsleep)
             return;
 
+        // Si on atteint réellement l'Idle, on déclenche son éventuel son d'entrée.
+        if (!isIdleActive)
+        {
+            PlayStateClip(Data != null ? Data.idleEnterClip : null);
+            isIdleActive = true;
+        }
+
         if (animator != null)
         {
             const int baseLayerIndex = 0;
@@ -1875,6 +1943,29 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
                 animator.Play("Idle_Battle");
             }
         }
+    }
+
+    /// <summary>
+    /// Informe le système que l'unité quitte son Idle actuel afin de jouer le son de sortie une seule fois.
+    /// </summary>
+    public void NotifyIdleStateExit()
+    {
+        if (!isIdleActive)
+            return; // Aucun son à jouer si l'Idle n'était pas actif.
+
+        isIdleActive = false;
+        PlayStateClip(Data != null ? Data.idleExitClip : null);
+    }
+
+    /// <summary>
+    /// Joue un clip stocké dans un <see cref="AudioClipSO"/> en respectant son volume interne.
+    /// </summary>
+    private void PlayStateClip(AudioClipSO clip)
+    {
+        if (clip == null || clip.Clip == null || audioSource == null)
+            return;
+
+        audioSource.PlayOneShot(clip.Clip, clip.Volume);
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/DissonantState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DissonantState.cs
@@ -1,0 +1,218 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+///     Gère la transition d'une unité vers l'état « Dissonant » lorsque ses harmoniques
+///     chutent sous le seuil défini. L'objectif est de reproduire un fonctionnement
+///     comparable à l'Awake tout en conservant une identité visuelle et sonore propre.
+/// </summary>
+[RequireComponent(typeof(CharacterUnit))]
+public class DissonantState : UnitStateEffects
+{
+    [Header("Paramètres d'animation")] [Tooltip("Nom de l'état Idle utilisé comme clé d'override dans l'Animator.")]
+    private const string AnimatorIdleStateName = "Idle_Battle";
+
+    private const string AnimatorDissonanceOnStateName = "Dissonance_On";  // Animation jouée quand l'état démarre.
+    private const string AnimatorDissonanceOffStateName = "Dissonance_Off"; // Animation jouée quand l'état se termine.
+
+    private static readonly int AnimatorDissonanceOnHash = Animator.StringToHash(AnimatorDissonanceOnStateName);
+    private static readonly int AnimatorDissonanceOffHash = Animator.StringToHash(AnimatorDissonanceOffStateName);
+
+    private const int AnimatorBaseLayerIndex = 0;      // Index de la couche par défaut.
+    private const float AnimatorCrossFadeDuration = .1f; // Durée des transitions déclenchées en script.
+
+    private CharacterUnit unit;                        // Référence directe à l'unité pour accéder aux données.
+    private bool isDissonant;                          // Indique si l'état est actuellement actif.
+
+    private AnimatorOverrideController animatorOverrideController; // Permet de remplacer l'Idle dynamiquement.
+    private AnimationClip idleClipOriginalKey;         // Clip servant de clé dans l'AnimatorOverrideController.
+    private AnimationClip idleClipOriginalValue;       // Valeur à restaurer lorsque l'état prend fin.
+
+    private float cachedDissonanceOnDuration = -1f;    // Durées mises en cache pour planifier le retour à l'Idle.
+    private float cachedDissonanceOffDuration = -1f;
+    private Coroutine idleRestoreCoroutine;            // Coroutine relançant l'Idle après les transitions.
+
+    /// <summary>
+    ///     Indique publiquement si l'état Dissonant est actif. Simplifie les vérifications côté CharacterUnit.
+    /// </summary>
+    public bool IsDissonant => isDissonant;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        unit = GetComponent<CharacterUnit>();
+
+        // Mise en place du contrôleur d'override pour pouvoir substituer l'Idle par sa version dissonante.
+        InitializeAnimatorOverrideData();
+
+        // Mise en cache immédiate des durées des animations On/Off afin de garantir un timing cohérent.
+        cachedDissonanceOnDuration = GetAnimationClipDuration(AnimatorDissonanceOnStateName);
+        cachedDissonanceOffDuration = GetAnimationClipDuration(AnimatorDissonanceOffStateName);
+    }
+
+    /// <summary>
+    ///     Active l'état Dissonant : animations spécifiques, Idle alternatif et effets hérités de UnitStateEffects.
+    /// </summary>
+    public void EnterDissonant()
+    {
+        if (isDissonant)
+            return; // Aucun traitement inutile si l'état est déjà actif.
+
+        isDissonant = true;
+
+        unit?.NotifyIdleStateExit(); // Permet de jouer immédiatement le son de sortie d'Idle si défini.
+
+        PlayDissonanceOnAnimation();
+        OverrideIdleAnimation();
+        ScheduleIdlePlayback(cachedDissonanceOnDuration);
+
+        EnterState(); // Déclenche les effets visuels/sonores configurés sur UnitStateEffects.
+    }
+
+    /// <summary>
+    ///     Désactive l'état Dissonant et restaure l'Idle de base.
+    /// </summary>
+    public void ExitDissonant()
+    {
+        if (!isDissonant)
+            return;
+
+        isDissonant = false;
+
+        PlayDissonanceOffAnimation();
+        RestoreIdleAnimation();
+        ScheduleIdlePlayback(cachedDissonanceOffDuration);
+
+        ExitState();
+    }
+
+    #region Gestion de l'override d'Idle
+
+    private void InitializeAnimatorOverrideData()
+    {
+        if (animator == null)
+            return;
+
+        if (animator.runtimeAnimatorController is AnimatorOverrideController existingOverride)
+        {
+            animatorOverrideController = existingOverride;
+        }
+        else if (animator.runtimeAnimatorController != null)
+        {
+            animatorOverrideController = new AnimatorOverrideController(animator.runtimeAnimatorController);
+            animator.runtimeAnimatorController = animatorOverrideController;
+        }
+
+        if (animatorOverrideController == null)
+            return;
+
+        var overrides = new System.Collections.Generic.List<KeyValuePair<AnimationClip, AnimationClip>>(animatorOverrideController.overridesCount);
+        animatorOverrideController.GetOverrides(overrides);
+
+        foreach (var pair in overrides)
+        {
+            if (pair.Key != null && pair.Key.name == AnimatorIdleStateName)
+            {
+                idleClipOriginalKey = pair.Key;
+                idleClipOriginalValue = pair.Value != null ? pair.Value : pair.Key;
+                break;
+            }
+        }
+    }
+
+    private void OverrideIdleAnimation()
+    {
+        if (animatorOverrideController == null || idleClipOriginalKey == null)
+            return;
+
+        var dissonantIdle = unit != null ? unit.Data?.dissonantIdleAnimation : null;
+        if (dissonantIdle == null)
+            return; // Pas de configuration spécifique : on garde l'Idle original.
+
+        animatorOverrideController[idleClipOriginalKey] = dissonantIdle;
+    }
+
+    private void RestoreIdleAnimation()
+    {
+        if (animatorOverrideController == null || idleClipOriginalKey == null || idleClipOriginalValue == null)
+            return;
+
+        animatorOverrideController[idleClipOriginalKey] = idleClipOriginalValue;
+    }
+
+    #endregion
+
+    #region Gestion des animations Dissonance_On / Off
+
+    private void PlayDissonanceOnAnimation()
+    {
+        if (animator == null)
+            return;
+
+        if (animator.HasState(AnimatorBaseLayerIndex, AnimatorDissonanceOnHash))
+            animator.CrossFade(AnimatorDissonanceOnHash, AnimatorCrossFadeDuration, AnimatorBaseLayerIndex, 0f);
+        else
+            animator.Play(AnimatorDissonanceOnStateName, AnimatorBaseLayerIndex, 0f);
+    }
+
+    private void PlayDissonanceOffAnimation()
+    {
+        if (animator == null)
+            return;
+
+        if (animator.HasState(AnimatorBaseLayerIndex, AnimatorDissonanceOffHash))
+            animator.CrossFade(AnimatorDissonanceOffHash, AnimatorCrossFadeDuration, AnimatorBaseLayerIndex, 0f);
+        else
+            animator.Play(AnimatorDissonanceOffStateName, AnimatorBaseLayerIndex, 0f);
+    }
+
+    #endregion
+
+    #region Gestion du retour vers l'Idle
+
+    private void ScheduleIdlePlayback(float delaySeconds)
+    {
+        if (unit == null)
+            return;
+
+        if (idleRestoreCoroutine != null)
+        {
+            StopCoroutine(idleRestoreCoroutine);
+            idleRestoreCoroutine = null;
+        }
+
+        float safeDelay = delaySeconds > 0f ? delaySeconds : AnimatorCrossFadeDuration;
+        idleRestoreCoroutine = StartCoroutine(PlayIdleAfterDelay(safeDelay));
+    }
+
+    private IEnumerator PlayIdleAfterDelay(float delaySeconds)
+    {
+        if (delaySeconds > 0f)
+            yield return new WaitForSeconds(delaySeconds);
+        else
+            yield return null; // Permet à l'Animator de valider son changement d'état au frame suivant.
+
+        unit?.PlayIdleAnimation();
+        idleRestoreCoroutine = null;
+    }
+
+    private float GetAnimationClipDuration(string clipName)
+    {
+        if (animator == null)
+            return 0f;
+
+        var controller = animator.runtimeAnimatorController;
+        if (controller == null)
+            return 0f;
+
+        foreach (var clip in controller.animationClips)
+        {
+            if (clip != null && clip.name == clipName)
+                return clip.length;
+        }
+
+        return 0f;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Résumé
- automatiser l’activation d’Awake et l’entrée en Dissonant selon les seuils d’harmoniques
- ajouter un composant DissonantState avec animations, override d’Idle et déclenchement audio
- enrichir les données personnage avec idle dissonant et clips sonores pour Awake/Idle
- gérer les sons d’entrée/sortie d’Idle et synchroniser les clips d’Awake

## Tests
- non exécutés (projet Unity, pas de suite de tests automatique disponible)


------
https://chatgpt.com/codex/tasks/task_e_68e02c74e4f88325b14db3f5da1a8a04