### PR TITLE
Réorganise les catégories de CharacterData

### DIFF
--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -4,67 +4,136 @@ using System.Collections.Generic; // Permet l'utilisation de listes génériques
 using UnityEngine.Timeline; // Référence aux timelines d'introduction
 using UnityEngine.Serialization; // Facilite la migration des anciens champs (par exemple resonancePoint).
 
+/// <summary>
+/// ScriptableObject décrivant complètement un personnage jouable ou ennemi.
+/// L'objectif de cette classe est d'offrir des catégories clairement identifiées
+/// pour faciliter la maintenance et l'extension du contenu.
+/// </summary>
 [CreateAssetMenu(fileName = "CharacterData", menuName = "Symphonie/CharacterData")]
 public class CharacterData : ScriptableObject, ITargetable
 {
-    [Header("General Info")]
+    #region Présentation & Classification
+
+    [Header("Identité visuelle")]
+    [Tooltip("Nom complet affiché dans l'interface et les dialogues.")]
     public string characterName;
+
+    [Tooltip("Portrait principal utilisé dans les menus et fiches de personnage.")]
     public Sprite portrait;
-    // Liste de sprites utilisés pour l'écran Versus et les points d'apparition
-    // Un sprite est choisi aléatoirement lors de l'affichage de l'écran Versus
+
+    [Tooltip("Liste de portraits alternatifs pour l'écran Versus et les points d'apparition.")]
     public List<Sprite> versusSprites = new();
+
+    [Header("Catégories de gameplay")]
+    [Tooltip("Type narratif du personnage, utilisé pour filtrer les interactions scénaristiques.")]
     public CharacterType characterType;
+
+    [Tooltip("Style de jeu principal du personnage (ex : Rage, Harmonie...).")]
     public GameplayType gameplayType = GameplayType.Rage;
+
+    [Tooltip("Affinité harmonique majeure qui influence les synergies de l'équipe.")]
     public HarmonicType harmonicType = HarmonicType.Lumiere;
+
+    [Header("Représentation 3D")]
+    [Tooltip("Prefab affiché dans les environnements explorables.")]
     public GameObject characterWorldModel;
+
+    [Tooltip("Prefab utilisé pendant les combats.")]
     public GameObject characterBattleModel;
 
-    [Header("Battlefield")]
-    public int battlefieldIndex = 0; // Indice du battlefield dans la zone
+    [Header("Positionnement dans les zones")]
+    [Tooltip("Indice du slot de départ dans un champ de bataille scénarisé.")]
+    public int battlefieldIndex = 0;
 
-    [Header("Déplacement")]
+    #endregion
+
+    #region Mobilité & Comportement
+
+    [Header("Mobilité")]
     [Tooltip("Vrai si l'unité évolue dans les airs et n'est pas affectée par la gravité.")]
     public bool isAirUnit = false;
 
-    [Header("Comportement en combat")]
-    [Tooltip("Si vrai, ce personnage peut être intercepté lors de ses actions")]
+    [Header("Réactions en combat")]
+    [Tooltip("Si vrai, ce personnage peut être intercepté lors de ses actions.")]
     public bool interceptable = true;
-    [Tooltip("Si vrai, ses attaques sont inévitables et ne peuvent être esquivées")]
+
+    [Tooltip("Si vrai, ses attaques sont évitables par les adversaires.")]
     public bool avoidable = true;
 
-    [Header("Stats")]
-    [Header("Attributs")]
+    #endregion
+
+    #region Statistiques de base
+
+    [Header("Attributs fondamentaux")]
+    [Tooltip("Mesure de la réactivité aux événements (esquives, parades, etc.).")]
     public float baseReflex;
+
+    [Tooltip("Capacité à se déplacer rapidement sur le terrain.")]
     public float baseMobility;
+
+    [Tooltip("Résilience globale qui augmente les points de vie effectifs.")]
     public float baseVitality;
+
+    [Tooltip("Puissance harmonique servant de base aux calculs magiques.")]
     public float basePower;
+
+    [Tooltip("Stabilité émotionnelle réduisant les risques de désaccords harmoniques.")]
     public float baseStability;
+
+    [Tooltip("Perspicacité permettant d'exploiter les faiblesses ennemies.")]
     public float baseSagacity;
 
-    [Header("Common Stats")]
+    [Header("Paramètres communs")]
+    [Tooltip("Initiative de départ utilisée dans la timeline de combat.")]
     public float baseInitiative;
+
+    [Tooltip("Portée moyenne des attaques physiques.")]
     public float baseRange;
+
+    [Tooltip("Points de vie de base hors bonus narratifs.")]
     public float baseHP;
+
+    [Tooltip("Attaque physique moyenne.")]
     public float baseStrength;
+
+    [Tooltip("Défense physique moyenne.")]
     public float baseDefense;
+
+    [Tooltip("Vitesse de déplacement et d'exécution de base.")]
     public float baseSpeed;
+
+    [Tooltip("Portée d'interception utilisée pour stopper une action adverse.")]
     public float baseInterceptionRange;
 
-    [Header("Custom Stats")]
-    [Header("Lucian")]
+    [Header("Paramètres spécifiques - Lucian")]
+    [Tooltip("Rage initiale de Lucian au début d'un affrontement.")]
     public float baseRage;
+
+    [Tooltip("Réserve maximale de rage que Lucian peut cumuler.")]
     public float maxRage;
+
+    [Tooltip("Multiplicateur appliqué aux dégâts lorsque Lucian consomme sa rage.")]
     public float rageDamageMultiplier;
 
-    [Header("Thalia")]
+    [Header("Paramètres spécifiques - Thalia")]
+    [Tooltip("Fatigue initiale de Thalia, utile pour calibrer la difficulté d'accès à ses combos.")]
     public float baseFatigue;
+
+    [Tooltip("Limite de fatigue avant les malus narratifs ou mécaniques.")]
     public float maxFatigue;
 
-    [Header("Musical Attacks")]
-    public MusicalMoveSO[] musicalAttacks;
-    [Tooltip("Attaque musicale toujours disponible")] public MusicalMoveSO specialMusicalMove;
+    #endregion
 
-    [Header("Sets personnalisés")]
+    #region Configurations de combat
+
+    [Header("Attaques musicales")]
+    [Tooltip("Répertoire complet des attaques disponibles pour ce personnage.")]
+    public MusicalMoveSO[] musicalAttacks;
+
+    [Tooltip("Attaque musicale toujours disponible quel que soit l'équipement.")]
+    public MusicalMoveSO specialMusicalMove;
+
+    [Header("Jeux d'actions favoris")]
     [Tooltip("Configurations d'attaques musicales favorites pour accélérer la sélection en combat.")]
     public List<CharacterMusicalMoveSet> musicalMoveSets = new();
 
@@ -77,108 +146,208 @@ public class CharacterData : ScriptableObject, ITargetable
     [Tooltip("Index utilisé au chargement pour activer un set d'objets spécifique. -1 pour aucun.")]
     public int defaultItemSetIndex = -1;
 
-    [Header("Etat (runtime)")]
+    #endregion
+
+    #region Etats runtime
+
+    [Header("Valeurs dynamiques")]
+    [Tooltip("Initiative courante utilisée pour l'ordre de jeu.")]
     public float currentInitiative;
+
+    [Tooltip("Portée instantanée tenant compte des buffs et malus.")]
     public float currentRange;
+
+    [Tooltip("Points de vie courants.")]
     public float currentHP;
+
+    [Tooltip("Force physique courante.")]
     public float currentStrength;
+
+    [Tooltip("Défense physique courante.")]
     public float currentDefense;
+
+    [Tooltip("Puissance harmonique courante.")]
     public float currentPower;
+
+    [Tooltip("Stabilité émotionnelle courante.")]
     public float currentStability;
+
+    [Tooltip("Vitalité courante.")]
     public float currentVitality;
+
+    [Tooltip("Perspicacité courante.")]
     public float currentSagacity;
+
+    [Tooltip("Indique si l'unité est contrôlée par le joueur à l'instant T.")]
     public bool isPlayerControlled;
+
+    [Tooltip("Rage accumulée actuellement (spécifique à Lucian).")]
     public float currentRage;
+
+    [Tooltip("Fatigue accumulée actuellement (spécifique à Thalia).")]
     public float currentFatigue;
+
+    [Tooltip("Réflexes courants après application des buffs.")]
     public float currentReflex;
+
+    [Tooltip("Mobilité courante après les modificateurs.")]
     public float currentMobility;
+
+    [Tooltip("Vitesse courante tenant compte des effets en cours.")]
     public float currentSpeed;
+
+    [Tooltip("Portée d'interception courante.")]
     public float currentInterceptionRange;
+
+    [Tooltip("Chance de réussir une interception à l'instant T.")]
     public float currentInterceptionChance;
-    [Tooltip("Trace la réserve actuelle d'harmoniques du type signature pour aider le game design.")]
+
+    [Tooltip("Réserve actuelle d'harmoniques du type signature pour aider le game design.")]
     public int currentHarmonicCharge;
 
-    [HideInInspector] public int currentMusicalMoveSetIndex = -1;
-    [HideInInspector] public int currentItemSetIndex = -1;
+    [HideInInspector]
+    public int currentMusicalMoveSetIndex = -1;
 
-    [Header("Effets visuels et sonores")]
+    [HideInInspector]
+    public int currentItemSetIndex = -1;
+
+    #endregion
+
+    #region Audio & Effets
+
+    [Header("Impacts & réactions")]
+    [Tooltip("Effet sonore principal joué lors d'un coup reçu.")]
     public AudioClipSO hitSound;
-    // Voix jouée lors d'un coup dévastateur
+
+    [Tooltip("Cri joué lors d'un coup critique infligé.")]
     public AudioClipSO criticalHitSound;
-    // Voix jouée lorsque l'unité est interceptée
+
+    [Tooltip("Voix jouée lorsque l'unité est interceptée.")]
     public AudioClipSO interceptedSound;
-    // Voix jouée lorsque l'unité intercepte une autre unité
+
+    [Tooltip("Voix jouée lorsque l'unité intercepte une autre unité.")]
     public AudioClipSO interceptionSound;
-    [Tooltip("Joué si la cible meurt avant la fin d'une attaque")] public AudioClipSO prematureDeathTaunt;
+
+    [Tooltip("Réplique jouée si la cible meurt avant la fin d'une attaque.")]
+    public AudioClipSO prematureDeathTaunt;
+
+    [Tooltip("Effet visuel déclenché lorsqu'un coup touche la cible.")]
     public GameObject hitEffect;
+
+    [Tooltip("Effet visuel déclenché lors de la mort du personnage.")]
     public GameObject deathEffect;
 
-    [Header("Effets de déplacement")]
+    [Header("Déplacements rapides")]
     [Tooltip("Système de particules utilisé pendant les déplacements rapides de cette unité.")]
     public GameObject dashParticlesPrefab;
+
     [Tooltip("Effet sonore joué lorsque les particules de dash sont générées pour cette unité.")]
     public AudioClipSO dashSoundClip;
 
+    [Tooltip("Effet visuel déclenché au début de l'éveil (Awake).")]
     public GameObject awakenEffect_Start;
+
+    [Tooltip("Effet visuel maintenu durant l'éveil (Awake).")]
     public GameObject awakenEffect_Loop;
+
+    [Tooltip("Effet visuel utilisé à la fin de l'éveil (Awake).")]
     public GameObject awakenEffect_End;
 
-    [Header("Animations spéciales")]
-    // Animation générique de dégâts
-    public AnimationClip hitAnimation;                // Jouée quand l'unité subit des dégâts
+    #endregion
+
+    #region Animations & Timeline
+
+    [Header("Animations d'impact")]
+    [Tooltip("Animation jouée quand l'unité subit des dégâts.")]
+    public AnimationClip hitAnimation;
+
+    [Tooltip("Animation de décès.")]
     public AnimationClip deathAnimation;
 
-    // Animations liées à la téléportation
-    public AnimationClip TPAnimation_Start;           // Jouée avant la téléportation
-    public AnimationClip TPAnimation_Destination;     // Jouée après la téléportation
-    public AnimationClip prepareToUndergoAnimation;   // Prépare la cible à subir un coup
+    [Header("Animations de téléportation")]
+    [Tooltip("Animation jouée avant la téléportation.")]
+    public AnimationClip TPAnimation_Start;
 
-    public AnimationClip awakenIdleAnimation;       // Jouée quand l'unité est en état Awake
-    public AnimationClip dissonantIdleAnimation;    // Jouée lorsque l'unité tombe en état Dissonant
+    [Tooltip("Animation jouée juste après la téléportation.")]
+    public AnimationClip TPAnimation_Destination;
+
+    [Tooltip("Animation utilisée pour préparer la cible à subir un coup.")]
+    public AnimationClip prepareToUndergoAnimation;
+
+    [Header("Animations d'états spéciaux")]
+    [Tooltip("Animation Idle utilisée lorsque l'unité est en état Awake.")]
+    public AnimationClip awakenIdleAnimation;
+
+    [Tooltip("Animation Idle utilisée lorsque l'unité est dissonante.")]
+    public AnimationClip dissonantIdleAnimation;
 
     [Header("Timeline d'introduction")]
     [Tooltip("Timeline jouée lors de l'introduction du combat pour cette unité.")]
     public TimelineAsset introTimeline;
 
+    #endregion
+
+    #region Audio contextuel
+
     [Header("Sons de déplacement")]
+    [Tooltip("Clip joué au début d'un mouvement.")]
     public AudioClipSO moveStartClip;
+
+    [Tooltip("Clip joué à la fin d'un mouvement.")]
     public AudioClipSO moveEndClip;
 
-    [Header("Effets sonores d'interface")]
+    [Header("Interface & sélection")]
     [Tooltip("Clip joué lorsque cette unité devient active dans les menus de combat.")]
     public AudioClipSO menuSelectionClip;
 
-    [Header("Sons d'état")] // Clips joués lors des transitions entre les états majeurs de l'unité.
+    [Header("Transitions d'état")] // Clips joués lors des transitions entre les états majeurs de l'unité.
     [Tooltip("Clip joué lorsque l'unité entre automatiquement en éveil (Awake).")]
     public AudioClipSO awakeEnterClip;
+
     [Tooltip("Clip joué lorsque l'unité quitte l'éveil (Awake).")]
     public AudioClipSO awakeExitClip;
+
     [Tooltip("Clip joué lorsqu'une animation d'Idle démarre (tous états confondus).")]
     public AudioClipSO idleEnterClip;
+
     [Tooltip("Clip joué lorsqu'une animation d'Idle est interrompue.")]
     public AudioClipSO idleExitClip;
 
     [Header("Voix de deuil")]
-    [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt")]
+    [Tooltip("Lamentation jouée par ce personnage quand Lucian meurt.")]
     public AudioClipSO weepForLucianDeath;
-    [Tooltip("Lamentation jouée par ce personnage quand Thalia meurt")]
+
+    [Tooltip("Lamentation jouée par ce personnage quand Thalia meurt.")]
     public AudioClipSO weepForThaliaDeath;
-    [Tooltip("Lamentation jouée par ce personnage quand Kael meurt")]
+
+    [Tooltip("Lamentation jouée par ce personnage quand Kael meurt.")]
     public AudioClipSO weepForKaelDeath;
-    [Tooltip("Lamentation jouée par ce personnage quand Link meurt")]
+
+    [Tooltip("Lamentation jouée par ce personnage quand Link meurt.")]
     public AudioClipSO weepForLinkDeath;
-    [Tooltip("Lamentation jouée par ce personnage quand Luna meurt")]
+
+    [Tooltip("Lamentation jouée par ce personnage quand Luna meurt.")]
     public AudioClipSO weepForLunaDeath;
 
-    [Header("Gestion des Harmoniques")]
+    #endregion
+
+    #region Gestion harmonique & métadonnées
+
+    [Header("Gestion des harmoniques")]
     [FormerlySerializedAs("resonancePoint"), Tooltip("Quantité d'harmoniques du type signature à accumuler pour pouvoir déclencher l'état Awake.")]
     public int awakeHarmonicThreshold = 1;
-    [Tooltip("Seuil minimal d'harmoniques avant de sortir d'Awake")] public int dissonancePoint = 0;
+
+    [Tooltip("Seuil minimal d'harmoniques avant de sortir d'Awake.")]
+    public int dissonancePoint = 0;
+
     [Tooltip("Réserve d'harmoniques disponible au début d'un combat avant toute génération supplémentaire.")]
     public int baseHarmonicCharge = 1;
 
-    // Ajoute une référence au GameObject source
+    [Header("Référence runtime")]
+    [Tooltip("Composant possédant cette instance pour faciliter les recherches à chaud.")]
     public MonoBehaviour owner;
+
+    #endregion
 
     private void OnEnable()
     {


### PR DESCRIPTION
## Résumé
- regroupe les champs de `CharacterData` par grandes familles pour clarifier l’inspecteur Unity
- ajoute des tooltips détaillés et des commentaires afin de documenter chaque donnée

## Tests
- non exécutés (données uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68e02ef6efb48325ac0fd21943a61e33