### PR TITLE
Corriger l'utilisation de KeyValuePair dans DissonantState

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/DissonantState.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/DissonantState.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic; // Permet d'utiliser les structures de données génériques telles que KeyValuePair.
 using UnityEngine;
 
 /// <summary>


### PR DESCRIPTION
## Summary
- ajouter l'espace de noms System.Collections.Generic pour pouvoir utiliser KeyValuePair dans DissonantState

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03093b5808325bc3b75e8c53b7e49