### PR TITLE
Refonte du pilotage paramétrique des animations

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
@@ -1,0 +1,439 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Centralise toutes les interactions avec l'Animator des personnages jouables et non jouables.
+/// L'objectif est d'offrir un point d'entrée unique pour piloter les deux layers (corps / visage)
+/// à l'aide de paramètres, tout en conservant un système de secours lorsque le contrôleur n'est
+/// pas encore configuré pour ce pipeline.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Animator))]
+public class CharacterAnimationController : MonoBehaviour
+{
+    /// <summary>
+    /// Ensemble des états d'animation pilotés par le layer "Body".
+    /// Chaque valeur de l'énumération correspond à un entier qui pourra être envoyé
+    /// dans l'Animator afin d'alimenter un blend-tree ou un sous-graph.
+    /// </summary>
+    public enum BodyAnimationState
+    {
+        None = -1,
+        IdleWorld = 0,
+        Walk = 1,
+        Run = 2,
+        JumpStart = 3,
+        JumpLoop = 4,
+        Landing = 5,
+        LandingMoving = 6,
+        IdleBattle = 7,
+        Turn90 = 8,
+        DashBattle = 9,
+        RetreatBattle = 10,
+        ItemPrepare = 11,
+        Death = 12,
+        HitFront = 13,
+        HitBack = 14,
+        HitLeft = 15,
+        HitRight = 16
+    }
+
+    /// <summary>
+    /// États utilisables par le layer "Face". Les valeurs sont volontairement réduites
+    /// car la plupart des expressions seront gérées via des blend-shapes.
+    /// </summary>
+    public enum FaceAnimationState
+    {
+        Neutral = 0,
+        Speaking = 1,
+        Focused = 2,
+        Hurt = 3
+    }
+
+    /// <summary>
+    /// Triggers fréquemment exploités par les scripts de gameplay.
+    /// Ces triggers permettent de synchroniser des animations ponctuelles
+    /// (ex : sortie d'une action, rotation instantanée, etc.).
+    /// </summary>
+    public enum BodyAnimationTrigger
+    {
+        None = 0,
+        ExitAction = 1,
+        Turn = 2
+    }
+
+    [Serializable]
+    private struct BodyStateFallback
+    {
+        public BodyAnimationState state;
+        public string clipName;
+    }
+
+    [Serializable]
+    private struct FaceStateFallback
+    {
+        public FaceAnimationState state;
+        public string clipName;
+    }
+
+    [Serializable]
+    private struct BodyTriggerParameter
+    {
+        public BodyAnimationTrigger trigger;
+        public string parameterName;
+    }
+
+    [Header("Paramètres du Layer Body")]
+    [Tooltip("Nom du paramètre int qui sélectionne l'état principal du corps.")]
+    [SerializeField] private string bodyStateParameter = "BodyState";
+
+    [Tooltip("Nom du paramètre float qui décrit la durée de transition souhaitée.")]
+    [SerializeField] private string bodyTransitionDurationParameter = "BodyTransition";
+
+    [Tooltip("Paramètre float permettant d'indiquer la position de départ normalisée (0-1).")]
+    [SerializeField] private string bodyNormalizedTimeParameter = "BodyNormalizedTime";
+
+    [Tooltip("Trigger optionnel pour forcer une transition instantanée côté corps.")]
+    [SerializeField] private string bodyInstantTransitionParameter = "BodyInstant";
+
+    [Tooltip("Paramètre float servant à transmettre la vitesse actuelle (0 à 1).")]
+    [SerializeField] private string bodySpeedParameter = "BodySpeed";
+
+    [Header("Paramètres du Layer Face")]
+    [Tooltip("Nom du paramètre int qui sélectionne l'expression faciale active.")]
+    [SerializeField] private string faceStateParameter = "FaceState";
+
+    [Tooltip("Paramètre float pour ajuster la durée de transition du visage.")]
+    [SerializeField] private string faceTransitionDurationParameter = "FaceTransition";
+
+    [Tooltip("Trigger optionnel pour exiger une mise à jour immédiate du visage.")]
+    [SerializeField] private string faceInstantTransitionParameter = "FaceInstant";
+
+    [Header("Triggers connus du layer Body")]
+    [SerializeField] private BodyTriggerParameter[] bodyTriggers =
+    {
+        new BodyTriggerParameter { trigger = BodyAnimationTrigger.ExitAction, parameterName = "exitAction" },
+        new BodyTriggerParameter { trigger = BodyAnimationTrigger.Turn, parameterName = "isTurning" }
+    };
+
+    [Header("Clips de secours (Body)")]
+    [SerializeField] private BodyStateFallback[] bodyFallbackClips =
+    {
+        new BodyStateFallback { state = BodyAnimationState.IdleWorld, clipName = "Idle_World" },
+        new BodyStateFallback { state = BodyAnimationState.Walk, clipName = "Walk_Start" },
+        new BodyStateFallback { state = BodyAnimationState.Run, clipName = "Run Start" },
+        new BodyStateFallback { state = BodyAnimationState.JumpStart, clipName = "Jump_Start" },
+        new BodyStateFallback { state = BodyAnimationState.JumpLoop, clipName = "Jump_Loop" },
+        new BodyStateFallback { state = BodyAnimationState.Landing, clipName = "Landing" },
+        new BodyStateFallback { state = BodyAnimationState.LandingMoving, clipName = "Landing_OnMove" },
+        new BodyStateFallback { state = BodyAnimationState.IdleBattle, clipName = "Idle_Battle" },
+        new BodyStateFallback { state = BodyAnimationState.Turn90, clipName = "Turn_90" },
+        new BodyStateFallback { state = BodyAnimationState.DashBattle, clipName = "Dash_Battle" },
+        new BodyStateFallback { state = BodyAnimationState.RetreatBattle, clipName = "Retreat_Battle" },
+        new BodyStateFallback { state = BodyAnimationState.ItemPrepare, clipName = "Item_Prepare" },
+        new BodyStateFallback { state = BodyAnimationState.Death, clipName = "Death" },
+        new BodyStateFallback { state = BodyAnimationState.HitFront, clipName = "Hit_F" },
+        new BodyStateFallback { state = BodyAnimationState.HitBack, clipName = "Hit_B" },
+        new BodyStateFallback { state = BodyAnimationState.HitLeft, clipName = "Hit_L" },
+        new BodyStateFallback { state = BodyAnimationState.HitRight, clipName = "Hit_R" }
+    };
+
+    [Header("Clips de secours (Face)")]
+    [SerializeField] private FaceStateFallback[] faceFallbackClips =
+    {
+        new FaceStateFallback { state = FaceAnimationState.Neutral, clipName = string.Empty },
+        new FaceStateFallback { state = FaceAnimationState.Speaking, clipName = string.Empty },
+        new FaceStateFallback { state = FaceAnimationState.Focused, clipName = string.Empty },
+        new FaceStateFallback { state = FaceAnimationState.Hurt, clipName = string.Empty }
+    };
+
+    private Animator cachedAnimator;
+
+    private readonly Dictionary<BodyAnimationState, string> bodyFallbackLookup = new();
+    private readonly Dictionary<FaceAnimationState, string> faceFallbackLookup = new();
+    private readonly Dictionary<BodyAnimationTrigger, int> bodyTriggerHashes = new();
+
+    private bool bodyStateParameterAvailable;
+    private bool bodyTransitionParameterAvailable;
+    private bool bodyNormalizedTimeParameterAvailable;
+    private bool bodyInstantParameterAvailable;
+    private bool bodySpeedParameterAvailable;
+
+    private bool faceStateParameterAvailable;
+    private bool faceTransitionParameterAvailable;
+    private bool faceInstantParameterAvailable;
+
+    private int bodyStateHash;
+    private int bodyTransitionDurationHash;
+    private int bodyNormalizedTimeHash;
+    private int bodyInstantHash;
+    private int bodySpeedHash;
+
+    private int faceStateHash;
+    private int faceTransitionDurationHash;
+    private int faceInstantHash;
+
+    /// <summary>
+    /// Accès sécurisé à l'Animator piloté par ce contrôleur.
+    /// </summary>
+    public Animator Animator => cachedAnimator;
+
+    void Awake()
+    {
+        cachedAnimator = GetComponent<Animator>();
+        CacheFallbackDictionaries();
+        CacheParameterAvailability();
+    }
+
+    void OnValidate()
+    {
+        // Dès que l'on modifie une configuration dans l'inspecteur on régénère les caches.
+        if (cachedAnimator == null)
+            cachedAnimator = GetComponent<Animator>();
+
+        CacheFallbackDictionaries();
+        CacheParameterAvailability();
+    }
+
+    /// <summary>
+    /// Regénère explicitement les caches lorsque le composant est ajouté dynamiquement.
+    /// </summary>
+    public void RefreshCachedParameters()
+    {
+        CacheFallbackDictionaries();
+        CacheParameterAvailability();
+    }
+
+    private void CacheFallbackDictionaries()
+    {
+        bodyFallbackLookup.Clear();
+        faceFallbackLookup.Clear();
+
+        if (bodyFallbackClips != null)
+        {
+            foreach (var entry in bodyFallbackClips)
+            {
+                if (!bodyFallbackLookup.ContainsKey(entry.state))
+                    bodyFallbackLookup.Add(entry.state, entry.clipName);
+                else
+                    bodyFallbackLookup[entry.state] = entry.clipName;
+            }
+        }
+
+        if (faceFallbackClips != null)
+        {
+            foreach (var entry in faceFallbackClips)
+            {
+                if (!faceFallbackLookup.ContainsKey(entry.state))
+                    faceFallbackLookup.Add(entry.state, entry.clipName);
+                else
+                    faceFallbackLookup[entry.state] = entry.clipName;
+            }
+        }
+    }
+
+    private void CacheParameterAvailability()
+    {
+        bodyStateParameterAvailable = TryCacheParameter(bodyStateParameter, AnimatorControllerParameterType.Int, out bodyStateHash);
+        bodyTransitionParameterAvailable = TryCacheParameter(bodyTransitionDurationParameter, AnimatorControllerParameterType.Float, out bodyTransitionDurationHash);
+        bodyNormalizedTimeParameterAvailable = TryCacheParameter(bodyNormalizedTimeParameter, AnimatorControllerParameterType.Float, out bodyNormalizedTimeHash);
+        bodyInstantParameterAvailable = TryCacheParameter(bodyInstantTransitionParameter, AnimatorControllerParameterType.Trigger, out bodyInstantHash);
+        bodySpeedParameterAvailable = TryCacheParameter(bodySpeedParameter, AnimatorControllerParameterType.Float, out bodySpeedHash);
+
+        faceStateParameterAvailable = TryCacheParameter(faceStateParameter, AnimatorControllerParameterType.Int, out faceStateHash);
+        faceTransitionParameterAvailable = TryCacheParameter(faceTransitionDurationParameter, AnimatorControllerParameterType.Float, out faceTransitionDurationHash);
+        faceInstantParameterAvailable = TryCacheParameter(faceInstantTransitionParameter, AnimatorControllerParameterType.Trigger, out faceInstantHash);
+
+        bodyTriggerHashes.Clear();
+        if (bodyTriggers != null)
+        {
+            foreach (var trigger in bodyTriggers)
+            {
+                if (trigger.trigger == BodyAnimationTrigger.None)
+                    continue;
+
+                if (string.IsNullOrEmpty(trigger.parameterName))
+                    continue;
+
+                if (TryCacheParameter(trigger.parameterName, AnimatorControllerParameterType.Trigger, out int hash))
+                {
+                    bodyTriggerHashes[trigger.trigger] = hash;
+                }
+            }
+        }
+    }
+
+    private bool TryCacheParameter(string parameterName, AnimatorControllerParameterType expectedType, out int hash)
+    {
+        hash = 0;
+        if (cachedAnimator == null || string.IsNullOrEmpty(parameterName))
+            return false;
+
+        int candidateHash = Animator.StringToHash(parameterName);
+        foreach (var parameter in cachedAnimator.parameters)
+        {
+            if (parameter.nameHash == candidateHash && parameter.type == expectedType)
+            {
+                hash = candidateHash;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Définit l'état du corps via les paramètres prévus dans l'Animator.
+    /// Un système de secours rejoue le clip correspondant si les paramètres ne sont pas configurés.
+    /// </summary>
+    public void SetBodyState(BodyAnimationState state, float transitionDuration = 0.1f, float normalizedStartTime = 0f, bool forceInstantTransition = false, int layerIndex = 0)
+    {
+        if (cachedAnimator == null)
+            return;
+
+        bool parameterUsed = false;
+
+        if (bodyTransitionParameterAvailable)
+        {
+            cachedAnimator.SetFloat(bodyTransitionDurationHash, Mathf.Max(0f, transitionDuration));
+            parameterUsed = true;
+        }
+
+        if (bodyNormalizedTimeParameterAvailable)
+        {
+            cachedAnimator.SetFloat(bodyNormalizedTimeHash, Mathf.Clamp01(normalizedStartTime));
+            parameterUsed = true;
+        }
+
+        if (forceInstantTransition && bodyInstantParameterAvailable)
+        {
+            cachedAnimator.ResetTrigger(bodyInstantHash);
+            cachedAnimator.SetTrigger(bodyInstantHash);
+            parameterUsed = true;
+        }
+
+        if (bodyStateParameterAvailable)
+        {
+            cachedAnimator.SetInteger(bodyStateHash, (int)state);
+            parameterUsed = true;
+        }
+
+        if (!parameterUsed)
+        {
+            PlayFallbackClip(state, transitionDuration, normalizedStartTime, layerIndex);
+        }
+    }
+
+    /// <summary>
+    /// Ajuste une vitesse normalisée pour alimenter un blend tree de locomotion.
+    /// </summary>
+    public void SetBodySpeed(float normalizedSpeed)
+    {
+        if (!bodySpeedParameterAvailable || cachedAnimator == null)
+            return;
+
+        cachedAnimator.SetFloat(bodySpeedHash, Mathf.Clamp01(normalizedSpeed));
+    }
+
+    /// <summary>
+    /// Déclenche un trigger associé au layer Body.
+    /// </summary>
+    public void ActivateBodyTrigger(BodyAnimationTrigger trigger)
+    {
+        if (trigger == BodyAnimationTrigger.None || cachedAnimator == null)
+            return;
+
+        if (bodyTriggerHashes.TryGetValue(trigger, out int hash))
+        {
+            cachedAnimator.ResetTrigger(hash);
+            cachedAnimator.SetTrigger(hash);
+        }
+    }
+
+    /// <summary>
+    /// Définit l'expression faciale en exploitant les paramètres dédiés.
+    /// </summary>
+    public void SetFaceState(FaceAnimationState state, float transitionDuration = 0.1f, float normalizedStartTime = 0f, bool forceInstantTransition = false, int layerIndex = 1)
+    {
+        if (cachedAnimator == null)
+            return;
+
+        bool parameterUsed = false;
+
+        if (faceTransitionParameterAvailable)
+        {
+            cachedAnimator.SetFloat(faceTransitionDurationHash, Mathf.Max(0f, transitionDuration));
+            parameterUsed = true;
+        }
+
+        if (forceInstantTransition && faceInstantParameterAvailable)
+        {
+            cachedAnimator.ResetTrigger(faceInstantHash);
+            cachedAnimator.SetTrigger(faceInstantHash);
+            parameterUsed = true;
+        }
+
+        if (faceStateParameterAvailable)
+        {
+            cachedAnimator.SetInteger(faceStateHash, (int)state);
+            parameterUsed = true;
+        }
+
+        if (!parameterUsed)
+        {
+            PlayFallbackFaceClip(state, transitionDuration, normalizedStartTime, layerIndex);
+        }
+    }
+
+    /// <summary>
+    /// Force un Rebind complet de l'Animator afin de resynchroniser les paramètres
+    /// et de purger tout état transitoire lorsque l'on réinitialise le personnage.
+    /// </summary>
+    public void ForceAnimatorRebind()
+    {
+        if (cachedAnimator == null)
+            return;
+
+        cachedAnimator.Update(0f);
+        cachedAnimator.Rebind();
+    }
+
+    /// <summary>
+    /// Permet de jouer un clip spécifique en dehors du pipeline paramétré. À n'utiliser
+    /// que pour des besoins exceptionnels (tests, animations temporaires...).
+    /// </summary>
+    public void PlayFallbackClip(BodyAnimationState state, float transitionDuration = 0.1f, float normalizedStartTime = 0f, int layerIndex = 0)
+    {
+        if (cachedAnimator == null)
+            return;
+
+        if (bodyFallbackLookup.TryGetValue(state, out string clipName) && !string.IsNullOrEmpty(clipName))
+        {
+            cachedAnimator.CrossFade(clipName, Mathf.Max(0f, transitionDuration), layerIndex, Mathf.Clamp01(normalizedStartTime));
+        }
+    }
+
+    /// <summary>
+    /// Joue directement un clip nommé, utile pour des animations très spécifiques qui
+    /// n'ont pas encore d'équivalent dans le graphe paramétré.
+    /// </summary>
+    public void PlayRawClip(string clipName, float transitionDuration = 0.1f, int layerIndex = 0, float normalizedStartTime = 0f)
+    {
+        if (cachedAnimator == null || string.IsNullOrEmpty(clipName))
+            return;
+
+        cachedAnimator.CrossFade(clipName, Mathf.Max(0f, transitionDuration), layerIndex, Mathf.Clamp01(normalizedStartTime));
+    }
+
+    private void PlayFallbackFaceClip(FaceAnimationState state, float transitionDuration, float normalizedStartTime, int layerIndex)
+    {
+        if (cachedAnimator == null)
+            return;
+
+        if (faceFallbackLookup.TryGetValue(state, out string clipName) && !string.IsNullOrEmpty(clipName))
+        {
+            cachedAnimator.CrossFade(clipName, Mathf.Max(0f, transitionDuration), layerIndex, Mathf.Clamp01(normalizedStartTime));
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c23b0d149f8f4b4fb1aa6a4b9cb09acc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -36,6 +36,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
     [HideInInspector] public Animator animator;
+    private CharacterAnimationController animationController; // Contrôleur dédié pour orchestrer les layers Body/Face.
     // Indicateur évitant les multiples avertissements lorsque l'Animator enfant est introuvable.
     private bool hasLoggedMissingChildAnimator;
     // Indicateur évitant de répéter les avertissements lorsqu'on détecte plusieurs Animator valides chez les enfants.
@@ -352,6 +353,35 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         animator = null;
         return animator;
+    }
+
+    /// <summary>
+    /// Récupère (et met en cache) le <see cref="CharacterAnimationController"/> associé à l'Animator de l'unité.
+    /// Cette méthode centralise la création dynamique du composant lorsque les Prefabs existants ne l'ont
+    /// pas encore intégré, ce qui garantit une migration progressive du projet vers le nouveau pipeline.
+    /// </summary>
+    /// <param name="forceRefresh">Si vrai, le cache est réinitialisé avant la recherche.</param>
+    public CharacterAnimationController GetAnimationController(bool forceRefresh = false)
+    {
+        if (forceRefresh)
+            animationController = null; // Invalide explicitement le cache lorsque demandé.
+
+        if (animationController != null)
+            return animationController; // Composant déjà résolu, on le réutilise directement.
+
+        Animator casterAnimator = GetCasterAnimator(forceRefresh);
+        if (casterAnimator == null)
+            return null; // Impossible de piloter les animations sans Animator.
+
+        animationController = casterAnimator.GetComponent<CharacterAnimationController>();
+        if (animationController == null)
+        {
+            // Ajout dynamique pour maintenir la compatibilité des Prefabs existants sans retouche manuelle immédiate.
+            animationController = casterAnimator.gameObject.AddComponent<CharacterAnimationController>();
+        }
+
+        animationController.RefreshCachedParameters(); // Sécurise le recalcul des hashes après une éventuelle création dynamique.
+        return animationController;
     }
 
     /// <summary>
@@ -1348,7 +1378,12 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         }
         Animator animator = GetCasterAnimator();
         Debug.Log(this + " handleDeath called, playing death animation.");
-        if (animator != null)
+        CharacterAnimationController controller = GetAnimationController();
+        if (controller != null)
+        {
+            controller.SetBodyState(CharacterAnimationController.BodyAnimationState.Death, 0.05f, 0f, forceInstantTransition: true);
+        }
+        else if (animator != null)
         {
             animator.Play("Death");
         }
@@ -1545,22 +1580,32 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
     void PlayAnimationClip(AnimationClip clip)
     {
-        // Ne rien jouer si l'unité est morte
-        if (IsDead)
+        // Ne rien jouer si l'unité est morte ou si aucun clip n'est fourni.
+        if (IsDead || clip == null)
             return;
 
-        if (animator != null && clip != null)
+        // Utilise en priorité le nouveau contrôleur pour préserver la synchronisation des layers.
+        CharacterAnimationController controller = GetAnimationController();
+        if (controller != null)
         {
-            // CrossFade pour éviter d'interrompre brutalement l'animation en cours
+            controller.PlayRawClip(clip.name, 0.05f);
+            return;
+        }
+
+        // Garde un repli vers l'ancien comportement pour éviter toute régression si le contrôleur n'est pas disponible.
+        if (animator != null)
+        {
             animator.CrossFade(clip.name, 0.05f);
         }
     }
 
     public void PlayHurtAnimation(Transform attacker = null)
     {
-        // Si l'unité est morte ou qu'aucun Animator n'est disponible, on ne fait rien
-        if (IsDead || animator == null)
+        // Si l'unité est morte ou qu'aucun contrôleur n'est disponible, on ne fait rien
+        if (IsDead)
             return;
+
+        CharacterAnimationController controller = GetAnimationController();
 
         // Lorsque l'attaquant est connu, on calcule le côté touché
         if (attacker != null)
@@ -1575,35 +1620,58 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
             // Nom de l'état à jouer. Par défaut on considère une attaque de face.
             string state = "Hit_F";
+            CharacterAnimationController.BodyAnimationState mappedState = CharacterAnimationController.BodyAnimationState.HitFront;
 
             // Avant : angle proche de 0°
             if (Mathf.Abs(angle) <= 45f)
             {
                 state = "Hit_F";
+                mappedState = CharacterAnimationController.BodyAnimationState.HitFront;
             }
             // Arrière : angle > 135° ou < -135°
             else if (Mathf.Abs(angle) > 135f)
             {
                 state = "Hit_B";
+                mappedState = CharacterAnimationController.BodyAnimationState.HitBack;
             }
             // Droite : angle positif (attaque venant de la droite)
             else if (angle > 0f)
             {
                 state = "Hit_R";
+                mappedState = CharacterAnimationController.BodyAnimationState.HitRight;
             }
             // Gauche : angle négatif
             else
             {
                 state = "Hit_L";
+                mappedState = CharacterAnimationController.BodyAnimationState.HitLeft;
             }
 
-            // Lance l'animation correspondante dans l'Animator
-            animator.CrossFade(state, 0.05f);
+            if (controller != null)
+            {
+                controller.SetBodyState(mappedState, 0.05f, 0f, forceInstantTransition: true);
+            }
+            else if (animator != null)
+            {
+                // Fallback historique : garantit la lecture même si le nouveau contrôleur n'est pas encore configuré.
+                animator.CrossFade(state, 0.05f);
+            }
             return;
         }
 
         // Si aucun attaquant n'est fourni, on se rabat sur l'animation générique
-        PlayAnimationClip(Data?.hitAnimation ?? hurtAnimation);
+        AnimationClip fallback = Data?.hitAnimation ?? hurtAnimation;
+        if (fallback == null)
+            return;
+
+        if (controller != null)
+        {
+            controller.PlayRawClip(fallback.name, 0.05f);
+        }
+        else
+        {
+            PlayAnimationClip(fallback);
+        }
     }
     public void PlayInterceptedAnimation() => PlayAnimationClip(interceptedAnimation);
     public void PlayInterceptionAnimation() => PlayAnimationClip(interceptionAnimation);
@@ -1640,10 +1708,18 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         // Même si le cache renvoie null (absence d'Animator valide) on évite toute
         // NullReferenceException en contrôlant Data et le clip demandé.
-        if (anim != null && Data != null && Data.prepareToUndergoAnimation != null)
+        if (Data != null && Data.prepareToUndergoAnimation != null)
         {
-            // Utilise CrossFade pour garantir la bonne transition
-            anim.CrossFade(Data.prepareToUndergoAnimation.name, 0.05f);
+            CharacterAnimationController controller = GetAnimationController(forceRefresh: true);
+            if (controller != null)
+            {
+                controller.PlayRawClip(Data.prepareToUndergoAnimation.name, 0.05f);
+            }
+            else if (anim != null)
+            {
+                // Fallback minimal pour garantir la compatibilité tant que tous les personnages n'utilisent pas le nouveau système.
+                anim.CrossFade(Data.prepareToUndergoAnimation.name, 0.05f);
+            }
         }
     }
 
@@ -1924,6 +2000,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         {
             PlayStateClip(Data != null ? Data.idleEnterClip : null);
             isIdleActive = true;
+        }
+
+        CharacterAnimationController controller = GetAnimationController();
+        if (controller != null)
+        {
+            controller.SetBodyState(CharacterAnimationController.BodyAnimationState.IdleBattle, IdleCrossFadeDurationSeconds);
+            return;
         }
 
         if (animator != null)

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -807,7 +807,11 @@ public class InputsManager : MonoBehaviour
         if (IsSkillTargetSelectionState(bm.currentBattleState))
         {
             bm.OpenSkillsMenu();
-            bm.currentCharacterUnit.GetCasterAnimator()?.SetTrigger("exitAction");
+            CharacterAnimationController controller = bm.currentCharacterUnit != null ? bm.currentCharacterUnit.GetAnimationController() : null;
+            if (controller != null)
+                controller.ActivateBodyTrigger(CharacterAnimationController.BodyAnimationTrigger.ExitAction);
+            else
+                bm.currentCharacterUnit?.GetCasterAnimator()?.SetTrigger("exitAction");
         }
         else if (IsItemTargetSelectionState(bm.currentBattleState))
         {

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1874,8 +1874,14 @@ public class NewBattleManager : MonoBehaviour
             {
                 // Si l’angle est > 90°, on déclenche le trigger "isTurning" sur l’Animator enfant
                 Animator anim = unit.GetCasterAnimator();
-                if (anim != null)
+                CharacterAnimationController controller = unit.GetAnimationController();
+                if (controller != null)
                 {
+                    controller.ActivateBodyTrigger(CharacterAnimationController.BodyAnimationTrigger.Turn);
+                }
+                else if (anim != null)
+                {
+                    // Fallback direct : l'ancien pipeline reste disponible si la migration n'est pas complète.
                     anim.SetTrigger("isTurning");
                 }
             }
@@ -1922,7 +1928,12 @@ public class NewBattleManager : MonoBehaviour
             {
                 // Si > 90°, déclenche "isTurning" sur l’Animator enfant
                 Animator anim = unit.GetCasterAnimator();
-                if (anim != null)
+                CharacterAnimationController controller = unit.GetAnimationController();
+                if (controller != null)
+                {
+                    controller.ActivateBodyTrigger(CharacterAnimationController.BodyAnimationTrigger.Turn);
+                }
+                else if (anim != null)
                 {
                     anim.SetTrigger("isTurning");
                 }
@@ -2118,9 +2129,15 @@ public class NewBattleManager : MonoBehaviour
     private IEnumerator RotateUnitSmoothly(CharacterUnit unit, Quaternion targetRotation, float rotationSpeed)
     {
         Animator anim = unit.GetCasterAnimator();
-        if (anim != null)
+        CharacterAnimationController controller = unit.GetAnimationController();
+        if (controller != null)
         {
-            // Joue l'animation de rotation en boucle pendant la rotation
+            // Le nouveau pipeline se charge de piloter les sous-transitions du layer Body.
+            controller.SetBodyState(CharacterAnimationController.BodyAnimationState.Turn90, 0.05f, 0f, forceInstantTransition: true);
+        }
+        else if (anim != null)
+        {
+            // Fallback temporaire en attendant que tous les contrôleurs soient migrés.
             anim.Play("Turn_90");
         }
 
@@ -2144,7 +2161,11 @@ public class NewBattleManager : MonoBehaviour
         unit.transform.rotation = Quaternion.Euler(0, targetRotation.eulerAngles.y, 0);
 
         // Lecture instantanée de l'animation "Idle_Battle" une fois la rotation terminée
-        if (anim != null)
+        if (controller != null)
+        {
+            controller.SetBodyState(CharacterAnimationController.BodyAnimationState.IdleBattle, 0.1f);
+        }
+        else if (anim != null)
         {
             anim.Play("Idle_Battle");
         }
@@ -2763,8 +2784,13 @@ public class NewBattleManager : MonoBehaviour
 
         // Récupère l'Animator enfant du lanceur via l'utilitaire centralisé pour garantir un binding correct.
         Animator casterAnimator = currentCharacterUnit.GetCasterAnimator();
+        CharacterAnimationController casterController = currentCharacterUnit.GetAnimationController();
 
-        if (casterAnimator != null)
+        if (casterController != null)
+        {
+            casterController.SetBodyState(CharacterAnimationController.BodyAnimationState.ItemPrepare, 0.1f);
+        }
+        else if (casterAnimator != null)
         {
             // CrossFade permet d'éviter un cut sec lorsque l'on ouvre le menu après une autre animation.
             if (casterAnimator.HasState(0, AnimatorStateItemPrepare))
@@ -2830,7 +2856,12 @@ public class NewBattleManager : MonoBehaviour
         {
             // Même logique que dans Start : priorité au cache, puis recherche de secours.
             Animator casterAnimator = currentCharacterUnit.GetCasterAnimator();
-            if (casterAnimator != null)
+            CharacterAnimationController casterController = currentCharacterUnit.GetAnimationController();
+            if (casterController != null)
+            {
+                casterController.SetBodyState(CharacterAnimationController.BodyAnimationState.IdleBattle, 0.1f);
+            }
+            else if (casterAnimator != null)
             {
                 if (casterAnimator.HasState(0, AnimatorStateIdleBattle))
                     casterAnimator.CrossFade(AnimatorStateIdleBattle, 0.1f, 0, 0f);

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -1078,7 +1078,7 @@ public class RhythmQTEManager : MonoBehaviour
 
             // Animation de déplacement
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             // Cache le visuel le temps de la téléportation
             if (visualRoot != null)
@@ -1105,7 +1105,7 @@ public class RhythmQTEManager : MonoBehaviour
         {
             // Animation du dash
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             Vector3 startPos = caster.transform.position;
             float distance = Vector3.Distance(startPos, destination);
@@ -1160,7 +1160,7 @@ public class RhythmQTEManager : MonoBehaviour
                 Instantiate(item.tpVfx_Start, caster.transform.position, Quaternion.identity);
 
             if (!caster.IsDead)
-                animator?.Play("Retreat_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.RetreatBattle, "Retreat_Battle");
 
             // Cache le GameObject visuel pendant l'attente
             if (visualRoot != null)
@@ -1185,7 +1185,7 @@ public class RhythmQTEManager : MonoBehaviour
         else if (!isTeleport)
         {
             if (!caster.IsDead)
-                animator?.Play("Retreat_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.RetreatBattle, "Retreat_Battle");
 
             Vector3 startPos = caster.transform.position;
             float distance = Vector3.Distance(startPos, origin);
@@ -1263,7 +1263,7 @@ public class RhythmQTEManager : MonoBehaviour
                 Instantiate(move.tpVfx_Start, caster.transform.position, Quaternion.identity);
 
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             // Masque le visuel du lanceur pendant l'attente
             if (visualRoot != null)
@@ -1288,7 +1288,7 @@ public class RhythmQTEManager : MonoBehaviour
         else if (!isTeleport)
         {
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             Vector3 startPos = caster.transform.position;
             float distance = Vector3.Distance(startPos, targetPos);
@@ -1362,7 +1362,7 @@ public class RhythmQTEManager : MonoBehaviour
                 Instantiate(move.tpVfx_Start, caster.transform.position, Quaternion.identity);
 
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             // Cache temporairement le GameObject visuel
             if (visualRoot != null)
@@ -1393,7 +1393,7 @@ public class RhythmQTEManager : MonoBehaviour
         else if (!isTeleport)
         {
             if (!caster.IsDead)
-                animator?.Play("Dash_Battle");
+                PlayUnitBodyAnimation(caster, CharacterAnimationController.BodyAnimationState.DashBattle, "Dash_Battle");
 
             float distance = Vector3.Distance(startPos, initialPosition);
             ParticleSystem dashParticles = distance > 0.01f ? SpawnDashParticles(caster) : null;
@@ -1436,19 +1436,25 @@ public class RhythmQTEManager : MonoBehaviour
     {
         // Récupère une fois l’Animator plutôt que de l’appeler à chaque itération
         Animator animator = caster.GetCasterAnimator();
+        CharacterAnimationController controller = caster.GetAnimationController();
 
         foreach (string clip in animationClips)
         {
             // Lance le clip courant uniquement si l'unité est en vie
             if (!caster.IsDead)
-                animator.Play(clip);
+            {
+                if (controller != null)
+                    controller.PlayRawClip(clip, 0.05f);
+                else
+                    animator?.Play(clip);
+            }
             Debug.Log("Animation jouée : " + clip);
 
             // On attend un frame pour laisser l’Animator passer à l’état du clip
             yield return null;
 
             // Récupère la longueur de l’état actuel (le clip qui vient d'être joué)
-            float clipDuration = animator.GetCurrentAnimatorStateInfo(0).length;
+            float clipDuration = animator != null ? animator.GetCurrentAnimatorStateInfo(0).length : 0f;
 
             // Si tu veux être certain de prendre la longueur du AnimationClip lui-même,
             // tu peux aussi faire : float clipDuration = clip.length;
@@ -1883,6 +1889,28 @@ public class RhythmQTEManager : MonoBehaviour
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Centralise la lecture d'une animation de corps en utilisant en priorité le nouveau contrôleur paramétré.
+    /// </summary>
+    private void PlayUnitBodyAnimation(CharacterUnit unit, CharacterAnimationController.BodyAnimationState state, string legacyClipName, float transitionDuration = 0.05f)
+    {
+        if (unit == null)
+            return;
+
+        CharacterAnimationController controller = unit.GetAnimationController();
+        if (controller != null)
+        {
+            controller.SetBodyState(state, transitionDuration, 0f, forceInstantTransition: true);
+            return;
+        }
+
+        Animator animator = unit.GetCasterAnimator();
+        if (animator != null && !string.IsNullOrEmpty(legacyClipName))
+        {
+            animator.Play(legacyClipName);
+        }
     }
 
     #endregion

--- a/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/StartManager.cs
@@ -36,6 +36,30 @@ public class StartManager : MonoBehaviour
     /// </summary>
     void SetIdleInWorld()
     {
-        GameObject.FindGameObjectWithTag("Player").GetComponentInChildren<Animator>().Play("Idle_World");
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player == null)
+            return; // Aucun joueur dans la scène : rien à réinitialiser.
+
+        Animator playerAnimator = player.GetComponentInChildren<Animator>();
+        if (playerAnimator == null)
+            return; // L'avatar n'est pas prêt, on ne force pas l'animation.
+
+        CharacterAnimationController controller = player.GetComponentInChildren<CharacterAnimationController>();
+        if (controller == null)
+        {
+            // Ajout à la volée pour conserver la compatibilité des anciens prefabs.
+            controller = playerAnimator.GetComponent<CharacterAnimationController>() ?? playerAnimator.gameObject.AddComponent<CharacterAnimationController>();
+            controller.RefreshCachedParameters();
+        }
+
+        if (controller != null)
+        {
+            controller.SetBodyState(CharacterAnimationController.BodyAnimationState.IdleWorld, 0f, 0f, forceInstantTransition: true);
+        }
+        else
+        {
+            // Sécurité : on retombe sur l'ancien comportement si le contrôleur n'est pas disponible.
+            playerAnimator.Play("Idle_World");
+        }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -17,7 +17,21 @@ public class ThirdPersonPlayerController : MonoBehaviour
     public Transform cameraTransform;
 
     private CharacterController controller;                  // Référence au CharacterController Unity.
-    private Animator animator;                               // Référence à l'Animator pour déclencher les animations.
+    private Animator animator;                               // Référence à l'Animator utilisée comme source d'état.
+    private CharacterAnimationController animationController; // Nouveau chef d'orchestre des layers Body/Face.
+
+    // Hashes des paramètres Animator utilisés en secours lorsque le CharacterAnimationController n'est pas disponible.
+    private static readonly int bodyStateParamHash = Animator.StringToHash("BodyState");
+    private static readonly int bodyTransitionParamHash = Animator.StringToHash("BodyTransition");
+    private static readonly int bodyNormalizedTimeParamHash = Animator.StringToHash("BodyNormalizedTime");
+    private static readonly int bodyInstantParamHash = Animator.StringToHash("BodyInstant");
+    private static readonly int bodySpeedParamHash = Animator.StringToHash("BodySpeed");
+
+    private bool animatorHasBodyStateParam;           // Permet de savoir si l'on peut piloter l'état via un entier.
+    private bool animatorHasBodyTransitionParam;      // Permet de renseigner la durée de blend pour garder la cohérence.
+    private bool animatorHasBodyNormalizedTimeParam;  // Permet d'initialiser précisément la timeline d'un état.
+    private bool animatorHasBodyInstantParam;         // Permet de forcer une transition immédiate (landing notamment).
+    private bool animatorHasBodySpeedParam;           // Permet d'alimenter le blend tree de locomotion.
 
     private Vector3 horizontalVelocity;                      // Vitesse appliquée sur le plan XZ.
     private float verticalVelocity;                          // Vitesse verticale isolée pour un contrôle précis.
@@ -61,6 +75,7 @@ public class ThirdPersonPlayerController : MonoBehaviour
     }
 
     [SerializeField] private MovementAnimation currentAnimState = MovementAnimation.Idle;
+    private CharacterAnimationController.BodyAnimationState cachedBodyState = CharacterAnimationController.BodyAnimationState.IdleWorld;
 
     // États exposés si un AnimationHandler externe souhaite les lire.
     public bool isWalking;
@@ -166,9 +181,19 @@ public class ThirdPersonPlayerController : MonoBehaviour
 
         if (animator != null)
         {
+            animationController = animator.GetComponent<CharacterAnimationController>();
+            if (animationController == null)
+            {
+                // Ajout dynamique pour garantir la transition vers le nouveau pipeline sans retoucher tous les prefabs.
+                animationController = animator.gameObject.AddComponent<CharacterAnimationController>();
+            }
+
+            animationController.RefreshCachedParameters();
+            CacheAnimatorBodyParameters(); // On détermine dès maintenant si les paramètres attendus sont présents.
+
             // Déplacement géré par le code : animations in-place sans root motion.
             animator.applyRootMotion = false;
-            animator.Play("Idle_World");
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.IdleWorld, 0f, 0f, forceInstantTransition: true);
 
             // Pré-calcul des durées d'animations d'atterrissage pour verrouiller précisément les transitions.
             CacheLandingClipDurations();
@@ -304,21 +329,14 @@ public class ThirdPersonPlayerController : MonoBehaviour
             {
                 // Atterrissage : on applique une impulsion vers le bas et on déclenche l'animation dédiée.
                 bool moving = horizontalVelocity.sqrMagnitude > 0.01f;
-                if (animator != null)
-                {
-                    if (moving)
-                    {
-                        animator.Play("Landing_OnMove");
-                        activeLandingStateHash = landingOnMoveStateHash;
-                        landingAnimationEndTime = Time.time + landingOnMoveClipLength;
-                    }
-                    else
-                    {
-                        animator.Play("Landing");
-                        activeLandingStateHash = landingStateHash;
-                        landingAnimationEndTime = Time.time + landingClipLength;
-                    }
-                }
+                CharacterAnimationController.BodyAnimationState landingState = moving
+                    ? CharacterAnimationController.BodyAnimationState.LandingMoving
+                    : CharacterAnimationController.BodyAnimationState.Landing;
+
+                RequestBodyState(landingState, 0.05f, 0f, forceInstantTransition: true);
+
+                activeLandingStateHash = moving ? landingOnMoveStateHash : landingStateHash;
+                landingAnimationEndTime = Time.time + (moving ? landingOnMoveClipLength : landingClipLength);
 
                 // Mémorisation complète de la vitesse pour maintenir l'inertie durant la séquence.
                 landingVelocitySnapshot = horizontalVelocity;
@@ -462,6 +480,10 @@ public class ThirdPersonPlayerController : MonoBehaviour
 
         controller.Move(horizontalVelocity * Time.deltaTime);
 
+        // Normalise la vitesse actuelle pour alimenter le blend tree dédié dans l'Animator.
+        float normalizedSpeed = Mathf.Approximately(runSpeed, 0f) ? 0f : Mathf.Clamp01(currentSpeed / runSpeed);
+        RequestBodySpeed(normalizedSpeed);
+
         // Orientation (autorisé en l'air pour du contrôle visuel).
         Vector3 lookDirection = horizontalVelocity.sqrMagnitude > 0.0001f ? horizontalVelocity : effectiveDirection;
         if (lookDirection.sqrMagnitude > 0.001f)
@@ -487,10 +509,7 @@ public class ThirdPersonPlayerController : MonoBehaviour
             isFalling = false;
             lastJumpPressedTimestamp = float.NegativeInfinity;
 
-            if (animator != null)
-            {
-                animator.Play("Jump_Start");
-            }
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.JumpStart, 0f, 0f, forceInstantTransition: true);
         }
 
         if (groundedStable && verticalVelocity < 0f)
@@ -534,7 +553,7 @@ public class ThirdPersonPlayerController : MonoBehaviour
     /// </summary>
     private void UpdateMovementAnimation()
     {
-        if (animator == null || isJumping || landingAnimationLocked)
+        if ((animator == null && animationController == null) || isJumping || landingAnimationLocked)
             return;
 
         MovementAnimation targetState =
@@ -545,20 +564,23 @@ public class ThirdPersonPlayerController : MonoBehaviour
         if (targetState == currentAnimState)
             return;
 
+        CharacterAnimationController.BodyAnimationState targetBodyState = CharacterAnimationController.BodyAnimationState.IdleWorld;
+
         switch (targetState)
         {
             case MovementAnimation.Run:
-                animator.CrossFade("Run Start", locomotionCrossFadeDuration);
+                targetBodyState = CharacterAnimationController.BodyAnimationState.Run;
                 break;
             case MovementAnimation.Walk:
-                animator.CrossFade("Walk_Start", locomotionCrossFadeDuration);
+                targetBodyState = CharacterAnimationController.BodyAnimationState.Walk;
                 break;
             case MovementAnimation.Idle:
-                if (currentAnimState == MovementAnimation.Run) animator.CrossFade("Run Stop", locomotionCrossFadeDuration);
-                else if (currentAnimState == MovementAnimation.Walk) animator.CrossFade("Walk_Stop", locomotionCrossFadeDuration);
-                else animator.CrossFade("Idle_World", locomotionCrossFadeDuration);
+                targetBodyState = CharacterAnimationController.BodyAnimationState.IdleWorld;
                 break;
         }
+
+        // Le contrôleur se charge des transitions internes entre les sous-states (start/stop) définis dans l'Animator.
+        RequestBodyState(targetBodyState, locomotionCrossFadeDuration);
 
         currentAnimState = targetState;
     }
@@ -574,7 +596,7 @@ public class ThirdPersonPlayerController : MonoBehaviour
         AnimatorStateInfo state = animator.GetCurrentAnimatorStateInfo(0);
         if (state.IsName("Jump_Start") && state.normalizedTime >= 1f)
         {
-            animator.CrossFade("Jump_Loop", 0.1f);
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.JumpLoop, 0.1f);
         }
     }
 
@@ -583,18 +605,21 @@ public class ThirdPersonPlayerController : MonoBehaviour
     /// </summary>
     private void UpdateLandingLock()
     {
-        if (!landingAnimationLocked || animator == null)
+        if (!landingAnimationLocked)
             return;
 
-        AnimatorStateInfo state = animator.GetCurrentAnimatorStateInfo(0);
-
-        bool isCurrentLanding = state.shortNameHash == activeLandingStateHash;
         bool animationCompleted = Time.time >= landingAnimationEndTime;
 
-        // Si nous sommes toujours dans l'état d'atterrissage, on vérifie également l'avancement de la timeline.
-        if (isCurrentLanding && state.normalizedTime >= 1f)
+        if (animator != null)
         {
-            animationCompleted = true;
+            AnimatorStateInfo state = animator.GetCurrentAnimatorStateInfo(0);
+            bool isCurrentLanding = state.shortNameHash == activeLandingStateHash;
+
+            // Si nous sommes toujours dans l'état d'atterrissage, on vérifie également l'avancement de la timeline.
+            if (isCurrentLanding && state.normalizedTime >= 1f)
+            {
+                animationCompleted = true;
+            }
         }
 
         // Tant que l'animation dédiée n'est pas totalement achevée, aucune transition n'est autorisée.
@@ -607,17 +632,17 @@ public class ThirdPersonPlayerController : MonoBehaviour
         if (isRunning)
         {
             targetState = MovementAnimation.Run;
-            animator.Play("Run Start");
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.Run, 0.05f, 0f, forceInstantTransition: true);
         }
         else if (isWalking)
         {
             targetState = MovementAnimation.Walk;
-            animator.Play("Walk_Start");
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.Walk, 0.05f, 0f, forceInstantTransition: true);
         }
         else
         {
             targetState = MovementAnimation.Idle;
-            animator.Play("Idle_World");
+            RequestBodyState(CharacterAnimationController.BodyAnimationState.IdleWorld, 0.05f, 0f, forceInstantTransition: true);
         }
 
         currentAnimState = targetState;
@@ -652,6 +677,83 @@ public class ThirdPersonPlayerController : MonoBehaviour
 
         if (landingOnMoveClipLength <= 0f)
             landingOnMoveClipLength = landingClipLength;
+    }
+
+    /// <summary>
+    /// Cache la disponibilité des paramètres du layer corps pour pouvoir piloter l'Animator par entiers/float.
+    /// </summary>
+    private void CacheAnimatorBodyParameters()
+    {
+        animatorHasBodyStateParam = false;
+        animatorHasBodyTransitionParam = false;
+        animatorHasBodyNormalizedTimeParam = false;
+        animatorHasBodyInstantParam = false;
+        animatorHasBodySpeedParam = false;
+
+        if (animator == null)
+            return;
+
+        foreach (var parameter in animator.parameters)
+        {
+            if (parameter.nameHash == bodyStateParamHash && parameter.type == AnimatorControllerParameterType.Int)
+                animatorHasBodyStateParam = true;
+            else if (parameter.nameHash == bodyTransitionParamHash && parameter.type == AnimatorControllerParameterType.Float)
+                animatorHasBodyTransitionParam = true;
+            else if (parameter.nameHash == bodyNormalizedTimeParamHash && parameter.type == AnimatorControllerParameterType.Float)
+                animatorHasBodyNormalizedTimeParam = true;
+            else if (parameter.nameHash == bodyInstantParamHash && parameter.type == AnimatorControllerParameterType.Trigger)
+                animatorHasBodyInstantParam = true;
+            else if (parameter.nameHash == bodySpeedParamHash && parameter.type == AnimatorControllerParameterType.Float)
+                animatorHasBodySpeedParam = true;
+        }
+    }
+
+    /// <summary>
+    /// Centralise l'envoi d'un état de corps en privilégiant le CharacterAnimationController
+    /// puis, en dernier recours, en écrivant directement dans les paramètres de l'Animator.
+    /// </summary>
+    private void RequestBodyState(CharacterAnimationController.BodyAnimationState state, float transitionDuration, float normalizedStartTime = 0f, bool forceInstantTransition = false)
+    {
+        if (animationController != null)
+        {
+            animationController.SetBodyState(state, transitionDuration, normalizedStartTime, forceInstantTransition);
+        }
+        else if (animator != null)
+        {
+            if (animatorHasBodyTransitionParam)
+                animator.SetFloat(bodyTransitionParamHash, Mathf.Max(0f, transitionDuration));
+
+            if (animatorHasBodyNormalizedTimeParam)
+                animator.SetFloat(bodyNormalizedTimeParamHash, Mathf.Clamp01(normalizedStartTime));
+
+            if (forceInstantTransition && animatorHasBodyInstantParam)
+            {
+                animator.ResetTrigger(bodyInstantParamHash);
+                animator.SetTrigger(bodyInstantParamHash);
+            }
+
+            if (animatorHasBodyStateParam)
+                animator.SetInteger(bodyStateParamHash, (int)state);
+        }
+
+        cachedBodyState = state; // On conserve un cache local pour les autres systèmes (landing, transitions logiques...).
+    }
+
+    /// <summary>
+    /// Informe le blend tree de la vitesse actuelle via le pipeline paramétrique.
+    /// </summary>
+    private void RequestBodySpeed(float normalizedSpeed)
+    {
+        float clampedSpeed = Mathf.Clamp01(normalizedSpeed);
+
+        if (animationController != null)
+        {
+            animationController.SetBodySpeed(clampedSpeed);
+        }
+        else if (animator != null && animatorHasBodySpeedParam)
+        {
+            animator.SetFloat(bodySpeedParamHash, clampedSpeed);
+        }
     }
 
     public void ToggleMuninLink()


### PR DESCRIPTION
## Résumé
- création d’un `CharacterAnimationController` qui pilote les layers corps/visage via des paramètres et fournit des fallbacks sécurisés.
- migration des unités jouables, du contrôleur TPS et des gestionnaires de combat vers ce nouveau pipeline d’animation.
- mise à jour des systèmes d’input, de menus d’objets et de QTE pour déclencher les transitions par paramètres au lieu de `Play()`.
- suppression des appels `animator.Play/CrossFade` restants dans `ThirdPersonPlayerController` afin d’imposer l’usage des paramètres `BodyState`, même en mode secours.

## Tests
- Aucun test automatisé disponible pour ce projet Unity.


------
https://chatgpt.com/codex/tasks/task_e_68e94bb5d5dc83259cfe964ce1840f72