### PR TITLE
Fix animator parameter type usage in editor helper

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
@@ -464,14 +464,16 @@ public class CharacterAnimationController : MonoBehaviour
         }
 
         // Création sécurisée de chaque paramètre attendu par le pipeline.
-        EnsureAnimatorParameter(animatorController, bodyStateParameter, UnityEditor.Animations.AnimatorControllerParameterType.Int);
-        EnsureAnimatorParameter(animatorController, bodyTransitionDurationParameter, UnityEditor.Animations.AnimatorControllerParameterType.Float);
-        EnsureAnimatorParameter(animatorController, bodyNormalizedTimeParameter, UnityEditor.Animations.AnimatorControllerParameterType.Float);
-        EnsureAnimatorParameter(animatorController, bodyInstantTransitionParameter, UnityEditor.Animations.AnimatorControllerParameterType.Trigger);
-        EnsureAnimatorParameter(animatorController, bodySpeedParameter, UnityEditor.Animations.AnimatorControllerParameterType.Float);
-        EnsureAnimatorParameter(animatorController, faceStateParameter, UnityEditor.Animations.AnimatorControllerParameterType.Int);
-        EnsureAnimatorParameter(animatorController, faceTransitionDurationParameter, UnityEditor.Animations.AnimatorControllerParameterType.Float);
-        EnsureAnimatorParameter(animatorController, faceInstantTransitionParameter, UnityEditor.Animations.AnimatorControllerParameterType.Trigger);
+        // Nous utilisons explicitement le type UnityEngine.AnimatorControllerParameterType pour garantir la compatibilité
+        // avec les assemblies runtime, même si la configuration n'est accessible qu'en mode éditeur.
+        EnsureAnimatorParameter(animatorController, bodyStateParameter, AnimatorControllerParameterType.Int);
+        EnsureAnimatorParameter(animatorController, bodyTransitionDurationParameter, AnimatorControllerParameterType.Float);
+        EnsureAnimatorParameter(animatorController, bodyNormalizedTimeParameter, AnimatorControllerParameterType.Float);
+        EnsureAnimatorParameter(animatorController, bodyInstantTransitionParameter, AnimatorControllerParameterType.Trigger);
+        EnsureAnimatorParameter(animatorController, bodySpeedParameter, AnimatorControllerParameterType.Float);
+        EnsureAnimatorParameter(animatorController, faceStateParameter, AnimatorControllerParameterType.Int);
+        EnsureAnimatorParameter(animatorController, faceTransitionDurationParameter, AnimatorControllerParameterType.Float);
+        EnsureAnimatorParameter(animatorController, faceInstantTransitionParameter, AnimatorControllerParameterType.Trigger);
 
         if (bodyTriggers != null)
         {
@@ -480,7 +482,7 @@ public class CharacterAnimationController : MonoBehaviour
                 if (trigger.trigger == BodyAnimationTrigger.None || string.IsNullOrEmpty(trigger.parameterName))
                     continue;
 
-                EnsureAnimatorParameter(animatorController, trigger.parameterName, UnityEditor.Animations.AnimatorControllerParameterType.Trigger);
+                EnsureAnimatorParameter(animatorController, trigger.parameterName, AnimatorControllerParameterType.Trigger);
             }
         }
 
@@ -516,7 +518,7 @@ public class CharacterAnimationController : MonoBehaviour
     /// <summary>
     /// Ajoute un paramètre à l'Animator s'il est absent ou si son type est incorrect.
     /// </summary>
-    private void EnsureAnimatorParameter(UnityEditor.Animations.AnimatorController controller, string parameterName, UnityEditor.Animations.AnimatorControllerParameterType type)
+    private void EnsureAnimatorParameter(UnityEditor.Animations.AnimatorController controller, string parameterName, AnimatorControllerParameterType type)
     {
         if (controller == null || string.IsNullOrEmpty(parameterName))
             return;


### PR DESCRIPTION
## Summary
- remplace les références à UnityEditor.Animations.AnimatorControllerParameterType par le type UnityEngine afin d'assurer la compilation côté runtime
- documente le choix du type dans la configuration automatique de l'Animator

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea0a4a7284832584ee301dabdfcf8b