### PR TITLE
Corriger l'initialisation du testeur d'animations

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterAnimationController.cs
@@ -201,6 +201,16 @@ public class CharacterAnimationController : MonoBehaviour
     /// </summary>
     public void RefreshCachedParameters()
     {
+        // Lorsqu'un personnage est instancié pour la prévisualisation depuis l'éditeur,
+        // Unity n'exécute pas systématiquement Awake(). Sans cet appel, le cache de
+        // l'Animator reste vide et aucun paramètre n'est détecté par le testeur
+        // d'animations. On récupère donc explicitement la référence pour garantir que
+        // les méthodes de prévisualisation puissent piloter correctement le layer Body.
+        if (cachedAnimator == null)
+        {
+            cachedAnimator = GetComponent<Animator>();
+        }
+
         CacheFallbackDictionaries();
         CacheParameterAvailability();
     }


### PR DESCRIPTION
## Résumé
- garantit que le `CharacterAnimationController` retrouve son `Animator` lors d'une instanciation d'aperçu
- permet au testeur d'animations d'appliquer immédiatement les paramètres du layer corps en mode éditeur

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68ea260367208325a0c09225c8825e89