### PR TITLE
Ajuste du rendu CC5 dans Unity

### DIFF
--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Arm.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Arm.mat
@@ -161,7 +161,7 @@ Material:
     - _DetailNormalScale: 0.5
     - _DetailSmoothnessScale: 0
     - _DiffusionProfile: 0
-    - _DiffusionProfileHash: 3.6477203
+    - _DiffusionProfileHash: 3.1808436
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
     - _DisplacementMode: 0
@@ -253,7 +253,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.99999994, g: 0.99999994, b: 0.99999994, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _DiffusionProfileAsset: {r: 0.000007811633, g: -1.6874267e-36, b: -4.0477928e+21, a: 8.3947815e+11}
+    - _DiffusionProfileAsset: {r: -13244770, g: -6.82629e-17, b: 5.2749405e+26, a: 117.32985}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
@@ -268,6 +268,21 @@ Material:
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!114 &136772332568991140
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa486462e6be1764e89c788ba30e61f7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_DiffusionProfileReferences:
+  - {fileID: 11400000, guid: 9eda9f3c424b44f58d536408fc376d9b, type: 2}
+  m_MaterialReferences: []
 --- !u!114 &8146751097545491817
 MonoBehaviour:
   m_ObjectHideFlags: 11

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Body.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Body.mat
@@ -161,7 +161,7 @@ Material:
     - _DetailNormalScale: 0.5
     - _DetailSmoothnessScale: 0
     - _DiffusionProfile: 0
-    - _DiffusionProfileHash: 3.6477203
+    - _DiffusionProfileHash: 3.1808436
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
     - _DisplacementMode: 0
@@ -253,7 +253,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.99999994, g: 0.99999994, b: 0.99999994, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _DiffusionProfileAsset: {r: 0.000007811633, g: -1.6874267e-36, b: -4.0477928e+21, a: 8.3947815e+11}
+    - _DiffusionProfileAsset: {r: -13244770, g: -6.82629e-17, b: 5.2749405e+26, a: 117.32985}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
@@ -268,6 +268,21 @@ Material:
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!114 &915300229421506381
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa486462e6be1764e89c788ba30e61f7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_DiffusionProfileReferences:
+  - {fileID: 11400000, guid: 9eda9f3c424b44f58d536408fc376d9b, type: 2}
+  m_MaterialReferences: []
 --- !u!114 &1758709451935496058
 MonoBehaviour:
   m_ObjectHideFlags: 11

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Head.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Head.mat
@@ -161,7 +161,7 @@ Material:
     - _DetailNormalScale: 0.5
     - _DetailSmoothnessScale: 0
     - _DiffusionProfile: 0
-    - _DiffusionProfileHash: 3.6477203
+    - _DiffusionProfileHash: 3.1808436
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
     - _DisplacementMode: 0
@@ -253,7 +253,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.99999994, g: 0.99999994, b: 0.99999994, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _DiffusionProfileAsset: {r: 0.000007811633, g: -1.6874267e-36, b: -4.0477928e+21, a: 8.3947815e+11}
+    - _DiffusionProfileAsset: {r: -13244770, g: -6.82629e-17, b: 5.2749405e+26, a: 117.32985}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
@@ -268,6 +268,21 @@ Material:
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!114 &442184843307212500
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa486462e6be1764e89c788ba30e61f7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_DiffusionProfileReferences:
+  - {fileID: 11400000, guid: 9eda9f3c424b44f58d536408fc376d9b, type: 2}
+  m_MaterialReferences: []
 --- !u!114 &6445644489103469406
 MonoBehaviour:
   m_ObjectHideFlags: 11

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Leg.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Ga_Skin_Leg.mat
@@ -161,7 +161,7 @@ Material:
     - _DetailNormalScale: 0.5
     - _DetailSmoothnessScale: 0
     - _DiffusionProfile: 0
-    - _DiffusionProfileHash: 3.6477203
+    - _DiffusionProfileHash: 3.1808436
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
     - _DisplacementMode: 0
@@ -253,7 +253,7 @@ Material:
     m_Colors:
     - _BaseColor: {r: 0.99999994, g: 0.99999994, b: 0.99999994, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _DiffusionProfileAsset: {r: 0.000007811633, g: -1.6874267e-36, b: -4.0477928e+21, a: 8.3947815e+11}
+    - _DiffusionProfileAsset: {r: -13244770, g: -6.82629e-17, b: 5.2749405e+26, a: 117.32985}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
@@ -268,6 +268,21 @@ Material:
     - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!114 &622445981545366503
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa486462e6be1764e89c788ba30e61f7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_DiffusionProfileReferences:
+  - {fileID: 11400000, guid: 9eda9f3c424b44f58d536408fc376d9b, type: 2}
+  m_MaterialReferences: []
 --- !u!114 &786282491010818767
 MonoBehaviour:
   m_ObjectHideFlags: 11

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency.mat
@@ -89,11 +89,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -119,7 +121,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -132,16 +134,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1
@@ -163,7 +165,7 @@ Material:
     - _TransparentWritingMotionVec: 1
     - _TransparentZWrite: 0
     - _UseShadowThreshold: 1
-    - _VertexColorStrength: 0.875
+    - _VertexColorStrength: 0.5
     - _ZTestDepthEqualForOpaque: 4
     - _ZTestTransparent: 4
     - _ZWrite: 0

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency_1st_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency_1st_Pass.mat
@@ -90,11 +90,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.5
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -118,7 +120,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -131,16 +133,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 1
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency_2nd_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair1_Transparency_2nd_Pass.mat
@@ -93,11 +93,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -121,7 +123,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -134,16 +136,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency.mat
@@ -105,11 +105,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -135,7 +137,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -148,16 +150,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.06855181
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.06715231
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.24553005
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1
@@ -179,7 +181,7 @@ Material:
     - _TransparentWritingMotionVec: 1
     - _TransparentZWrite: 0
     - _UseShadowThreshold: 1
-    - _VertexColorStrength: 0.875
+    - _VertexColorStrength: 0.5
     - _ZTestDepthEqualForOpaque: 4
     - _ZTestTransparent: 4
     - _ZWrite: 0

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency_1st_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency_1st_Pass.mat
@@ -90,11 +90,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.5
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -118,7 +120,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -131,16 +133,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 1
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.06855181
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.06715231
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.24553005
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency_2nd_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair2_Transparency_2nd_Pass.mat
@@ -93,11 +93,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -121,7 +123,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -134,16 +136,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.06855181
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.06715231
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.24553005
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency.mat
@@ -89,11 +89,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -119,7 +121,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -132,16 +134,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.049251877
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.054858606
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.38480002
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.18785873
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1
@@ -163,7 +165,7 @@ Material:
     - _TransparentWritingMotionVec: 1
     - _TransparentZWrite: 0
     - _UseShadowThreshold: 1
-    - _VertexColorStrength: 0.834
+    - _VertexColorStrength: 0.5
     - _ZTestDepthEqualForOpaque: 4
     - _ZTestTransparent: 4
     - _ZWrite: 0

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency_1st_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency_1st_Pass.mat
@@ -90,11 +90,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.5
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -118,7 +120,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -131,16 +133,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 1
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.049251877
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.054858606
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.38480002
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.18785873
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency_2nd_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair3_Transparency_2nd_Pass.mat
@@ -109,11 +109,13 @@ Material:
     - _AOOccludeAll: 0
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -137,7 +139,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -150,16 +152,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.049251877
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.054858606
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.38480002
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.18785873
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency.mat
@@ -105,11 +105,13 @@ Material:
     - _AOOccludeAll: 0.5
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -135,7 +137,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -148,16 +150,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1
@@ -179,7 +181,7 @@ Material:
     - _TransparentWritingMotionVec: 1
     - _TransparentZWrite: 0
     - _UseShadowThreshold: 1
-    - _VertexColorStrength: 0.875
+    - _VertexColorStrength: 0.5
     - _ZTestDepthEqualForOpaque: 4
     - _ZTestTransparent: 4
     - _ZWrite: 0

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency_1st_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency_1st_Pass.mat
@@ -106,11 +106,13 @@ Material:
     - _AOOccludeAll: 0.5
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.5
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 0
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -134,7 +136,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -147,16 +149,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 1
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency_2nd_Pass.mat
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Materials/Lucian_Human_Model/Hair_Transparency_2nd_Pass.mat
@@ -109,11 +109,13 @@ Material:
     - _AOOccludeAll: 0.5
     - _AOStrength: 1
     - _AddPrecomputedVelocity: 0
-    - _AlphaClip: 0.666
+    - _AlphaClip: 0.05
     - _AlphaCutoffEnable: 1
     - _AlphaDstBlend: 10
     - _AlphaPower: 0.7
     - _AlphaRemap: 1
+    - _AlphaToMask: 1
+    - _AlphaToMaskInspectorValue: 1
     - _AlphaSrcBlend: 1
     - _BaseColorStrength: 1
     - _BlendMode: 0
@@ -137,7 +139,7 @@ Material:
     - _GlobalStrength: 1
     - _HighlightAOverlapEnd: 1
     - _HighlightAOverlapInvert: 1
-    - _HighlightAStrength: 0.543
+    - _HighlightAStrength: 1
     - _HighlightBOverlapEnd: 0
     - _HighlightBOverlapInvert: 0
     - _HighlightBStrength: 0
@@ -150,16 +152,16 @@ Material:
     - _ReceivesSSRTransparent: 0
     - _RenderQueueType: 4
     - _RequireSplitLighting: 0
-    - _RimTransmissionIntensity: 0.08714213
+    - _RimTransmissionIntensity: 0.05
     - _RootColorStrength: 1
     - _SecondarySmoothness: 0.625
-    - _SecondarySpecularMultiplier: 0.07411879
+    - _SecondarySpecularMultiplier: 0.05
     - _SecondarySpecularShift: 0
-    - _ShadowClip: 0.5
+    - _ShadowClip: 0.35
     - _SmoothnessMax: 0.8
     - _SmoothnessMin: 0.3808
     - _SmoothnessPower: 1
-    - _SpecularMultiplier: 0.27045408
+    - _SpecularMultiplier: 0.5
     - _SpecularShiftMax: 0
     - _SpecularShiftMin: 0
     - _SrcBlend: 1

--- a/Assets/Settings/DiffusionProfiles.meta
+++ b/Assets/Settings/DiffusionProfiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8216210b5b904e1cb9a095b8f32fb3e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Settings/DiffusionProfiles/CharacterSkinDiffusionProfile.asset
+++ b/Assets/Settings/DiffusionProfiles/CharacterSkinDiffusionProfile.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2686e09ec7aef44bad2843e4416f057, type: 3}
+  m_Name: CharacterSkinDiffusionProfile
+  m_EditorClassIdentifier:
+  profile:
+    scatteringDistance: {r: 0.7490196, g: 0.2761092, b: 0.22323722, a: 1}
+    scatteringDistanceMultiplier: 1.3350785
+    transmissionTint: {r: 1, g: 0.36862746, b: 0.29803923, a: 1}
+    texturingMode: 0
+    smoothnessMultipliers: {x: 1, y: 1}
+    lobeMix: 0.5
+    diffuseShadingPower: 1
+    borderAttenuationColor: {r: 0, g: 0, b: 0, a: 0}
+    transmissionMode: 0
+    thicknessRemap: {x: 0, y: 33}
+    worldScale: 1
+    ior: 1.36
+    hash: 1080652864
+  m_Version: 2

--- a/Assets/Settings/DiffusionProfiles/CharacterSkinDiffusionProfile.asset.meta
+++ b/Assets/Settings/DiffusionProfiles/CharacterSkinDiffusionProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9eda9f3c424b44f58d536408fc376d9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/RenduPersonnages.md
+++ b/Docs/RenduPersonnages.md
@@ -1,0 +1,26 @@
+# Rendu des personnages CC5 dans Unity
+
+Ce document récapitule les ajustements effectués pour rapprocher le rendu Unity de celui observé dans Character Creator 5 (CC5).
+
+## Origine de l'écart visuel
+
+* **Profils de diffusion manquants** : les matériaux de peau n'étaient pas associés à un profil de diffusion HDRP. Sans subsurface scattering cohérent, la peau devenait plus mate et cireuse que dans CC5.
+* **Seuils de découpe des cheveux trop élevés** : plusieurs matériaux capillaires utilisaient une valeur d'`AlphaClip` à 0.666, éliminant une grande partie des mèches fines et produisant un aspect « crénelé » très visible sous l'éclairage neigeux de la scène Unity.
+* **Spéculaire atténué sur les cheveux** : les paramètres de réflexion secondaire étaient trop faibles par rapport aux préréglages HQ fournis par l'Auto Setup, ce qui délavant les reflets et donnait l'impression d'une chevelure sans profondeur.
+
+## Actions réalisées
+
+1. **Création d'un profil de diffusion dédié** (`CharacterSkinDiffusionProfile.asset`) afin d'uniformiser le comportement du subsurface scattering sur toutes les matières corporelles.
+2. **Référence explicite du profil de diffusion** dans les matériaux de peau (tête, corps, bras, jambes) pour garantir la même réponse lumineuse qu'en sortie CC5.
+3. **Réalignement des paramètres capillaires** (AlphaClip, AlphaToMask, forces spéculaires, ombres) sur les valeurs recommandées des templates HQ fournis par Reallusion, pour restituer les mèches fines et les reflets doux attendus.
+
+## Effets attendus
+
+* Des volumes cutanés plus doux et translucides, notamment sur le visage et les mains.
+* Une chevelure plus dense, sans effet de « peigne blanc » dans les zones éclairées de face.
+* Une meilleure cohérence entre le rendu studio de CC5 et l'intégration HDRP Unity.
+
+## Points de vigilance
+
+* Le profil de diffusion doit être référencé dans les volumes HDRP utilisés par vos scènes (profil de volume principal ou volumes locaux) pour être disponible au rendu.
+* Si d'autres personnages CC5 sont importés, répétez l'association du profil de diffusion et appliquez les mêmes réglages capillaires afin de conserver une cohérence visuelle.


### PR DESCRIPTION
## Summary
- ajoute un profil de diffusion HDRP dédié et le référence sur toutes les matières de peau de Lucian pour restaurer le subsurface scattering de CC5
- rééquilibre les matières capillaires (alpha clip, spéculaire, transmission) afin de retrouver la densité et les reflets attendus
- documente les écarts et les étapes de correction pour les futurs imports de personnages CC5

## Testing
- non applicable (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_68ed4d32cebc8325a89b3f626799a624