### PR TITLE
Désactiver le Render Graph HDRP en édition

### DIFF
--- a/Assets/Settings/HDRPDefaultResources/Symphonie_HDRenderPipelineAsset.asset
+++ b/Assets/Settings/HDRPDefaultResources/Symphonie_HDRenderPipelineAsset.asset
@@ -349,7 +349,7 @@ MonoBehaviour:
     streamingGpuCacheSettings:
     - format: 0
       sizeInMegaBytes: 128
-  m_UseRenderGraph: 1
+  m_UseRenderGraph: 0
   m_CompositorCustomVolumeComponentsList:
     m_InjectionPoint: 1
     m_CustomPostProcessTypesAsString: []


### PR DESCRIPTION
## Summary
- désactivation de l'utilisation du Render Graph sur l'actif HDRP du projet pour éviter les exceptions lors de l'ouverture de l'éditeur

## Testing
- aucun test automatisé exécuté (modification de configuration uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68efc4eabf988325aba8a4a9452c6aab