### PR TITLE
Assurer l'expression neutre du modèle Lucian CC5

### DIFF
--- a/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Prefabs/Lucian_Human_Model.prefab
+++ b/Assets/Characters/Squad/Lucian/Lucian_CC5_NonEmbed/Prefabs/Lucian_Human_Model.prefab
@@ -1285,6 +1285,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d919b26404a8df643b93ebdae5a1772c, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8571400978623058012}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: d919b26404a8df643b93ebdae5a1772c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6023456789012345678}
   m_SourcePrefab: {fileID: 100100000, guid: d919b26404a8df643b93ebdae5a1772c, type: 3}
 --- !u!4 &452633631002264889 stripped
 Transform:
@@ -1612,3 +1615,32 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2168394226173205682, guid: d919b26404a8df643b93ebdae5a1772c, type: 3}
   m_PrefabInstance: {fileID: 7160647249410681817}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6023456789012345678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8043098453578700424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ad8a304e6c94f44ad388790273cc70d, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  blendShapeOverrides:
+  - blendShapeName: Eye_Blink_L
+    weight: 45
+  - blendShapeName: Eye_Blink_R
+    weight: 45
+  - blendShapeName: Jaw_Open
+    weight: 0
+  - blendShapeName: Jaw_Open_Extreme
+    weight: 0
+  - blendShapeName: Mouth_Lips_Together_UL
+    weight: 0
+  - blendShapeName: Mouth_Lips_Together_UR
+    weight: 0
+  - blendShapeName: Mouth_Lips_Together_DL
+    weight: 0
+  - blendShapeName: Mouth_Lips_Together_DR
+    weight: 0

--- a/Assets/Scripts/MonoBehavioursUsed/LucianFaceNeutralizer.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LucianFaceNeutralizer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Composant chargé de garantir que le visage de Lucian démarre avec une expression neutre.
+/// L'objectif est d'éviter les variations indésirables sur les yeux et la bouche lorsque le modèle est instancié.
+/// L'expression neutre correspond à des paupières à demi fermées et à une bouche complètement close.
+/// </summary>
+[DisallowMultipleComponent]
+public class LucianFaceNeutralizer : MonoBehaviour
+{
+    /// <summary>
+    /// Structure décrivant une commande de blend shape à appliquer.
+    /// On stocke le nom du blend shape tel qu'il existe dans le mesh ainsi que le poids désiré.
+    /// </summary>
+    [System.Serializable]
+    private struct BlendShapeOverride
+    {
+        [Tooltip("Nom exact du blend shape à forcer sur le mesh cible.")]
+        public string blendShapeName; // Nom du blend shape tel qu'il apparaît dans l'import CC5
+
+        [Tooltip("Poids souhaité pour ce blend shape afin de définir la pose neutre.")]
+        [Range(0f, 100f)]
+        public float weight; // Valeur en pourcentage envoyée au SkinnedMeshRenderer
+    }
+
+    [Header("Configuration du visage neutre")]
+    [Tooltip("Liste des blend shapes à verrouiller pour garantir la pose neutre (paupières mi-closes, bouche fermée).")]
+    [SerializeField]
+    private BlendShapeOverride[] blendShapeOverrides = new BlendShapeOverride[]
+    {
+        // Les blend shapes d'yeux sont poussés à ~45 pour obtenir un regard détendu sans fermeture complète.
+        new BlendShapeOverride { blendShapeName = "Eye_Blink_L", weight = 45f },
+        new BlendShapeOverride { blendShapeName = "Eye_Blink_R", weight = 45f },
+
+        // Les contrôles de mâchoire sont remis à zéro pour empêcher toute ouverture de la bouche au démarrage.
+        new BlendShapeOverride { blendShapeName = "Jaw_Open", weight = 0f },
+        new BlendShapeOverride { blendShapeName = "Jaw_Open_Extreme", weight = 0f },
+
+        // On verrouille les blend shapes de lèvres qui peuvent introduire une ouverture résiduelle.
+        new BlendShapeOverride { blendShapeName = "Mouth_Lips_Together_UL", weight = 0f },
+        new BlendShapeOverride { blendShapeName = "Mouth_Lips_Together_UR", weight = 0f },
+        new BlendShapeOverride { blendShapeName = "Mouth_Lips_Together_DL", weight = 0f },
+        new BlendShapeOverride { blendShapeName = "Mouth_Lips_Together_DR", weight = 0f }
+    };
+
+    // Buffer réutilisé pour éviter des allocations lorsque l'on récupère les SkinnedMeshRenderer.
+    private readonly List<SkinnedMeshRenderer> rendererBuffer = new List<SkinnedMeshRenderer>();
+
+    private void Reset()
+    {
+        // Reset est appelé dans l'éditeur : on prépare d'emblée la liste des renderers et on applique la pose.
+        CacheRenderers();
+        ApplyNeutralPose();
+    }
+
+    private void Awake()
+    {
+        // Awake garantit que les références sont prêtes avant que d'autres scripts puissent manipuler les blend shapes.
+        CacheRenderers();
+        ApplyNeutralPose();
+    }
+
+    private void OnEnable()
+    {
+        // Lors d'une réactivation du prefab (ex : instanciation ou réutilisation d'un pool), on réapplique les valeurs neutres.
+        ApplyNeutralPose();
+    }
+
+    /// <summary>
+    /// Construit ou reconstruit la liste des SkinnedMeshRenderer présents sous le personnage.
+    /// On active la recherche en profondeur pour inclure les meshes des yeux, dents, etc.
+    /// </summary>
+    private void CacheRenderers()
+    {
+        rendererBuffer.Clear(); // On nettoie la liste pour éviter les doublons.
+        GetComponentsInChildren(true, rendererBuffer); // true inclut les objets désactivés qui pourraient porter des meshes de visage.
+    }
+
+    /// <summary>
+    /// Parcourt tous les SkinnedMeshRenderer détectés et force les blend shapes configurés.
+    /// Si un blend shape n'existe pas sur un mesh donné, on l'ignore silencieusement.
+    /// </summary>
+    private void ApplyNeutralPose()
+    {
+        if (rendererBuffer.Count == 0)
+        {
+            // Sécurité : si la liste est vide (premier appel depuis OnEnable par exemple), on regénère la liste.
+            CacheRenderers();
+        }
+
+        foreach (var renderer in rendererBuffer)
+        {
+            if (renderer == null)
+            {
+                // Les GameObjects peuvent être désactivés ou détruits, on saute dans ce cas.
+                continue;
+            }
+
+            var mesh = renderer.sharedMesh; // sharedMesh pour éviter de dupliquer le mesh en mémoire.
+            if (mesh == null)
+            {
+                // Certains SkinnedMeshRenderer peuvent être configurés sans mesh (ex : placeholders), on les ignore.
+                continue;
+            }
+
+            foreach (var blendShapeOverride in blendShapeOverrides)
+            {
+                if (string.IsNullOrWhiteSpace(blendShapeOverride.blendShapeName))
+                {
+                    // Permet d'avoir des entrées optionnelles dans l'inspecteur sans provoquer d'erreurs.
+                    continue;
+                }
+
+                int blendShapeIndex = mesh.GetBlendShapeIndex(blendShapeOverride.blendShapeName);
+                if (blendShapeIndex >= 0)
+                {
+                    // Le blend shape est présent sur ce mesh : on applique le poids voulu pour figer l'expression.
+                    renderer.SetBlendShapeWeight(blendShapeIndex, blendShapeOverride.weight);
+                }
+                else
+                {
+                    // Si le blend shape est absent de ce renderer, on ne fait rien : cela permet de gérer plusieurs meshes (corps, cils...).
+                    continue;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/LucianFaceNeutralizer.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/LucianFaceNeutralizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ad8a304e6c94f44ad388790273cc70d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Résumé
- ajoute le composant `LucianFaceNeutralizer` pour verrouiller les blend shapes critiques des yeux et de la bouche
- attache le script au prefab `Lucian_Human_Model` afin que Lucian apparaisse avec des paupières mi-closes et la bouche fermée par défaut

## Tests
- non exécutés (environnement Unity indisponible ici)


------
https://chatgpt.com/codex/tasks/task_e_68f2a6d4b9b48325baa3b318437ecc9f