### PR TITLE
Fix: relier l'émission des veines dans Bark_HDRP_v2

### DIFF
--- a/Assets/Realistic Tree/Shader/HDRP/Bark_HDRP_v2.shadergraph
+++ b/Assets/Realistic Tree/Shader/HDRP/Bark_HDRP_v2.shadergraph
@@ -1614,7 +1614,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0130ce0ef5dd42069f12eb63fc160fa0"
+                    "m_Id": "65a00bb431434ee3b696d94cf6240e4b"
                 },
                 "m_SlotId": 0
             }


### PR DESCRIPTION
## Résumé
- reconnecte la sortie Vein Emission Color au bloc d'émission du shader Bark_HDRP_v2
- supprime la liaison directe précédente qui écrasait la couleur de base

## Tests
- non exécutés (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f521ddee7c8325912a0430b09f750d