### PR TITLE
Expose le contrôle d'émission de la veinFlowTexture

### DIFF
--- a/Assets/Materials/GlassLucian/Bark_HDRP_v2.shadergraph
+++ b/Assets/Materials/GlassLucian/Bark_HDRP_v2.shadergraph
@@ -328,6 +328,9 @@
             "m_Id": "b187ef9ff2da44599e2da79b1b9795db"
         },
         {
+            "m_Id": "2aa5e2c0c2144f7c9fd22209bbe36eff"
+        },
+        {
             "m_Id": "e32e3e1662344219abac7ad5318a2cfd"
         },
         {
@@ -1653,6 +1656,34 @@
             "m_OutputSlot": {
                 "m_Node": {
                     "m_Id": "47ecebc07b8b4ee39c4c0ca67fd3648f"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2aa5e2c0c2144f7c9fd22209bbe36eff"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "82d56ad849fe4a70b76b89171c624511"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "2aa5e2c0c2144f7c9fd22209bbe36eff"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "2aa5e2c0c2144f7c9fd22209bbe36eff"
                 },
                 "m_SlotId": 2
             },
@@ -11220,10 +11251,192 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "2aa5e2c0c2144f7c9fd22209bbe36eff",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vein Flow Emission Scale",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 200.0,
+            "y": 1480.0,
+            "width": 208.0,
+            "height": 302.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c524016edee04882a768d1eff653f9e9"
+        },
+        {
+            "m_Id": "17bba675311745ca851a5c2f4c58ce0a"
+        },
+        {
+            "m_Id": "1901bb5cddf4444788d2f6c3a6eb7484"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "c524016edee04882a768d1eff653f9e9",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "17bba675311745ca851a5c2f4c58ce0a",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "1901bb5cddf4444788d2f6c3a6eb7484",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.StickyNoteData",
     "m_ObjectId": "6fcd6cac36034a418e050ac291ce5a37",
     "m_Title": "Flux sanguin",
-    "m_Content": "Nouvelle texture animée pour visualiser le sang en mouvement dans les veines. Reliée aux UV animés et à l'intensité.",
+    "m_Content": "Nouvelle texture animée pour visualiser le sang en mouvement dans les veines. Contrôles: vitesse de flow, UV Scale et intensité d'émission.",
     "m_TextSize": 0,
     "m_Theme": 0,
     "m_Position": {


### PR DESCRIPTION
## Summary
- Ajout d'un nœud Multiply "Vein Flow Emission Scale" pour appliquer le paramètre d'intensité d'émission au flux sanguin animé.
- Connexion de la propriété d'intensité et mise à jour de la note explicative pour rappeler les contrôles de vitesse, d'échelle UV et d'émission.

## Testing
- Non applicable (modification ShaderGraph)


------
https://chatgpt.com/codex/tasks/task_e_68f68ffd71ec832585f64c3775ea574d