### PR TITLE
Corriger le format JSON du ShaderGraph global

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -1764,6 +1764,7 @@
                 },
                 "m_SlotId": 0
             }
+        },
         {
             "m_OutputSlot": {
                 "m_Node": {
@@ -2611,7 +2612,7 @@
         "x": 0.0,
         "y": 1.0
     }
-},
+}
 
 {
     "m_SGVersion": 1,
@@ -12885,7 +12886,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -12920,7 +12921,7 @@
     "m_Property": {
         "m_Id": "0d9035eb3e024f29b64ed317bc2a2a5f"
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -12958,7 +12959,7 @@
         "m_SerializableColors": []
     },
     "m_Value": 0.10000000149011612
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -12973,7 +12974,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -12988,7 +12989,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13026,7 +13027,7 @@
         "m_SerializableColors": []
     },
     "m_Value": 3.0
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13041,7 +13042,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13056,7 +13057,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 1,
@@ -13095,7 +13096,7 @@
         "m_SerializableColors": []
     },
     "m_HashType": 1
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13117,7 +13118,7 @@
     },
     "m_Labels": [],
     "m_Channel": 0
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13132,7 +13133,7 @@
     "m_Value": 1.0,
     "m_DefaultValue": 1.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13147,7 +13148,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13185,7 +13186,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13209,7 +13210,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13233,7 +13234,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13257,7 +13258,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13295,7 +13296,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13319,7 +13320,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13343,7 +13344,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13367,7 +13368,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13405,7 +13406,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13429,7 +13430,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13453,7 +13454,7 @@
         "z": 1.0,
         "w": 1.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13477,7 +13478,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13518,7 +13519,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13542,7 +13543,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13566,7 +13567,7 @@
         "z": 1.0,
         "w": 1.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13590,7 +13591,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13614,7 +13615,7 @@
         "z": 0.0,
         "w": 0.0
     }
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13652,7 +13653,7 @@
         "m_SerializableColors": []
     },
     "m_Value": 0.0
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13667,7 +13668,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13682,7 +13683,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13720,7 +13721,7 @@
         "m_SerializableColors": []
     },
     "m_Value": 1.0
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13735,7 +13736,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13750,7 +13751,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13788,7 +13789,7 @@
         "m_SerializableColors": []
     },
     "m_Value": 0.5
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13803,7 +13804,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13818,7 +13819,7 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-},
+}
 
 {
     "m_SGVersion": 0,
@@ -13851,7 +13852,7 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
-},
+}
 
 {
     "m_SGVersion": 0,


### PR DESCRIPTION
## Résumé
- ajouter la virgule manquante dans la définition des connexions du ShaderGraph
- supprimer les virgules terminales qui rendaient les objets JSON invalides

## Tests
- python - <<'PY'
from pathlib import Path
import json
text = Path('Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph').read_text()
dec = json.JSONDecoder()
idx = 0
count = 0
while idx < len(text):
    while idx < len(text) and text[idx].isspace():
        idx += 1
    if idx >= len(text):
        break
    obj, end = dec.raw_decode(text, idx)
    idx = end
    count += 1
print('parsed objects', count)
PY

------
https://chatgpt.com/codex/tasks/task_e_68f919f983a4832594d093210ffad18b