### PR TITLE
Réorganise ShaderGraph_Symphonie_Global_Lit pour veines et sang

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -4,9 +4,6 @@
     "m_ObjectId": "b89c1b60959d40c59be19b6cd3b2205c",
     "m_Properties": [
         {
-            "m_Id": "a26a7c25e19e407eb588ec6eab02b9ae"
-        },
-        {
             "m_Id": "0849f000bf184f02b7d8759fb31f82fb"
         },
         {
@@ -25,34 +22,25 @@
             "m_Id": "a55d7d26f69949da8af08357b914a59d"
         },
         {
-            "m_Id": "8c877c35ec3b4fa3abc8c82f0b9f0f3b"
-        },
-        {
-            "m_Id": "b8c4ede752b343f58c51b2354cb259a5"
-        },
-        {
-            "m_Id": "f569cdbb9fc847f5b7bc3b350f632a0f"
-        },
-        {
-            "m_Id": "15425b8b103a4e46acb8796d0a7d47b9"
-        },
-        {
-            "m_Id": "34e700545e0d490f80c92f2d12e2a093"
-        },
-        {
             "m_Id": "649f0e8a49ad4cfd91729f4082f80c06"
         },
         {
             "m_Id": "9fd3215e954844f3bfcebed762ec7389"
         },
         {
-            "m_Id": "12884a70eb5e4349983f67df422b648f"
-        },
-        {
-            "m_Id": "56d461ea21b54dd2aa528830143705b9"
-        },
-        {
             "m_Id": "dd3ebea1c8a14c9eab9ccc9ee3f5b2e2"
+        },
+        {
+            "m_Id": "a26a7c25e19e407eb588ec6eab02b9ae"
+        },
+        {
+            "m_Id": "5b72296967714b29a00e14aaefa6ac91"
+        },
+        {
+            "m_Id": "34e700545e0d490f80c92f2d12e2a093"
+        },
+        {
+            "m_Id": "737937b2eb1a40c69a37eee653cada77"
         },
         {
             "m_Id": "bf06f45a9f5343bb94df3d22574b3b4b"
@@ -61,22 +49,16 @@
             "m_Id": "52dd10c9b3cb4e70bb7406c2a3f6f71f"
         },
         {
+            "m_Id": "6c828c422b9c4c938bc80dcb2d9ebdef"
+        },
+        {
             "m_Id": "754d0192e57f494ba11b15bab4b357f3"
         },
         {
             "m_Id": "c498d62df82147abb458e3533211f4a6"
         },
         {
-            "m_Id": "6c828c422b9c4c938bc80dcb2d9ebdef"
-        },
-        {
             "m_Id": "259b8898fa1d4488ad6246b620d4e241"
-        },
-        {
-            "m_Id": "5b72296967714b29a00e14aaefa6ac91"
-        },
-        {
-            "m_Id": "737937b2eb1a40c69a37eee653cada77"
         },
         {
             "m_Id": "f1c387f477ca4e1f8e7aceb116791391"
@@ -139,9 +121,6 @@
             "m_Id": "71e2f544175f4754acdc0ec2aa38a252"
         },
         {
-            "m_Id": "d2ef4179af7546e0b74ce60f193d78db"
-        },
-        {
             "m_Id": "7e8d6a3323e44eec8a3787adf48c7ef6"
         },
         {
@@ -196,9 +175,6 @@
             "m_Id": "131f1c76d8a041558a9d90fa8b83736a"
         },
         {
-            "m_Id": "914f70f2e985470eab223f3bc6ef60a3"
-        },
-        {
             "m_Id": "90ee88e6e821482dbfa83af5c3246fde"
         },
         {
@@ -206,9 +182,6 @@
         },
         {
             "m_Id": "df742883f19549edad10b63bad605ad1"
-        },
-        {
-            "m_Id": "e44f4a89a83848c3936e7b034e58fb01"
         },
         {
             "m_Id": "ccf6690d04504108abb4b88dc3544f13"
@@ -259,9 +232,6 @@
             "m_Id": "9019ba70da624811ad147b30d185f9ee"
         },
         {
-            "m_Id": "24f91c9030904919ae88d5ca3c3cb803"
-        },
-        {
             "m_Id": "194c5190c29341c8a709126e36b581de"
         },
         {
@@ -269,12 +239,6 @@
         },
         {
             "m_Id": "a0785f46498c4788ac9b219765bd7bf9"
-        },
-        {
-            "m_Id": "d0c6b8d4ee234d5a987014bc5fdd7f1b"
-        },
-        {
-            "m_Id": "adfc999a100d4ffaa0b1808b47d52990"
         },
         {
             "m_Id": "9dc2dbf1848e40da88794c1f5d9d320e"
@@ -531,20 +495,6 @@
                     "m_Id": "df742883f19549edad10b63bad605ad1"
                 },
                 "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "24f91c9030904919ae88d5ca3c3cb803"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "9019ba70da624811ad147b30d185f9ee"
-                },
-                "m_SlotId": 2
             }
         },
         {
@@ -816,20 +766,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "914f70f2e985470eab223f3bc6ef60a3"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "90ee88e6e821482dbfa83af5c3246fde"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "9651081caec64b0ca15804f7e8f7575e"
                 },
                 "m_SlotId": 0
@@ -1040,20 +976,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "d2ef4179af7546e0b74ce60f193d78db"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "b194793a9a4647e99785353fa95179c4"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "dcf7d7a3c39045f5b9e8a8817bd935f8"
                 },
                 "m_SlotId": 2
@@ -1075,34 +997,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "fd88c70fb5394a98b049800af3acf048"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "e44f4a89a83848c3936e7b034e58fb01"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ad9e76ff9ec24a65925581ed090a7359"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "e44f4a89a83848c3936e7b034e58fb01"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "ccf6690d04504108abb4b88dc3544f13"
                 },
                 "m_SlotId": 0
             }
@@ -1194,35 +1088,7 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "d0c6b8d4ee234d5a987014bc5fdd7f1b"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "591855588ebd42f0ab71196b3f6567bf"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "1a492cc86e64497291acd4ad51af561e"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "e46dd7cc4b3148ec8553c2eaae096f75"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "adfc999a100d4ffaa0b1808b47d52990"
                 },
                 "m_SlotId": 0
             },
@@ -2074,7 +1940,7 @@
     "m_Guid": {
         "m_GuidSerialized": "2927be04-12d6-493b-90b1-52a4f2f9387b"
     },
-    "m_Name": "Bark",
+    "m_Name": "Main Texture",
     "m_DefaultReferenceName": "Texture2D_0849f000bf184f02b7d8759fb31f82fb",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -2334,29 +2200,6 @@
 {
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "15425b8b103a4e46acb8796d0a7d47b9",
-    "m_Guid": {
-        "m_GuidSerialized": "f97a435d-0db1-4c99-ab91-d043af1b390e"
-    },
-    "m_Name": "Bend Strength",
-    "m_DefaultReferenceName": "Vector1_15425b8b103a4e46acb8796d0a7d47b9",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.0,
-    "m_FloatType": 0,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "649f0e8a49ad4cfd91729f4082f80c06",
     "m_Guid": {
         "m_GuidSerialized": "d1a6a2a5-50bf-4305-abc6-1df9c1c92e5f"
@@ -2401,52 +2244,6 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "12884a70eb5e4349983f67df422b648f",
-    "m_Guid": {
-        "m_GuidSerialized": "ebba94bc-fc2c-4b34-a9fa-35fe4221204a"
-    },
-    "m_Name": "Metallic Cristallin",
-    "m_DefaultReferenceName": "Vector1_12884a70eb5e4349983f67df422b648f",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.8,
-    "m_FloatType": 0,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "56d461ea21b54dd2aa528830143705b9",
-    "m_Guid": {
-        "m_GuidSerialized": "d555f4c2-a310-4f5a-b6fb-9e3e399f0b73"
-    },
-    "m_Name": "Lissage Cristallin",
-    "m_DefaultReferenceName": "Vector1_56d461ea21b54dd2aa528830143705b9",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.9,
-    "m_FloatType": 0,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "1609a577463a41f3a8050aba49cbf52a",
@@ -2466,21 +2263,6 @@
         "y": 0.0,
         "z": 0.0
     },
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "167c6524cac74016807fcf44e4aa8f7d",
-    "m_Id": 0,
-    "m_DisplayName": "Bend Strength",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
     "m_Labels": []
 }
 
@@ -2823,41 +2605,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "24f91c9030904919ae88d5ca3c3cb803",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 119.0,
-            "y": 560.0,
-            "width": 147.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "65bf80e104d443af941a57e58bdff938"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "f569cdbb9fc847f5b7bc3b350f632a0f"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "25870dcb4e3d49bf852bbad7134c2785",
     "m_Id": 1,
@@ -2865,21 +2612,6 @@
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "R",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "2652f99b7fa54b0cb9d608cdfedc898f",
-    "m_Id": 0,
-    "m_DisplayName": "Moss Threshold",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
     "m_StageCapability": 3,
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
@@ -2923,7 +2655,7 @@
     "m_Guid": {
         "m_GuidSerialized": "d57c519d-9a2a-4b34-b103-08d5f1501d73"
     },
-    "m_Name": "Moss",
+    "m_Name": "Add Texture",
     "m_DefaultReferenceName": "Texture2D_293a4ff1725045559f81e565700ff485",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -3159,7 +2891,7 @@
     "m_Guid": {
         "m_GuidSerialized": "0ef18683-038b-4e62-a1cc-084b99774e67"
     },
-    "m_Name": "Direction",
+    "m_Name": "Vein UV Scale",
     "m_DefaultReferenceName": "Vector2_34e700545e0d490f80c92f2d12e2a093",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -3206,7 +2938,7 @@
     "m_Guid": {
         "m_GuidSerialized": "69758b76-3250-4fd1-b768-8c1a78aac1de"
     },
-    "m_Name": "Moss Normal",
+    "m_Name": "Add Texture Normal",
     "m_DefaultReferenceName": "Texture2D_36c526d0e2c54cc183d740888f6f8c01",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -4130,7 +3862,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "4c156f38fcee47c0a590a460917aa07c",
     "m_Id": 0,
-    "m_DisplayName": "Bark Normal",
+    "m_DisplayName": "Main Texture Normal",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -4340,21 +4072,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "ba55984530554369b53197fcbec534d3",
-    "m_Id": 0,
-    "m_DisplayName": "Metallic Cristallin",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.8,
-    "m_DefaultValue": 0.8,
-    "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "b97d283af4a240e1a7b5c1711cf814e5",
     "m_Id": 0,
     "m_DisplayName": "Metallic",
@@ -4404,41 +4121,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "d0c6b8d4ee234d5a987014bc5fdd7f1b",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Metallic Cristallin",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -402.0,
-            "y": -86.0,
-            "width": 210.0,
-            "height": 36.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "ba55984530554369b53197fcbec534d3"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "12884a70eb5e4349983f67df422b648f"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "598600dc43364abf9eb7aa8b42dfc99d",
     "m_Id": 2,
@@ -4459,7 +4141,7 @@
     "m_Guid": {
         "m_GuidSerialized": "3a413a83-8088-4c8d-9a0c-a2a4a8b38e6f"
     },
-    "m_Name": "Bark Normal",
+    "m_Name": "Main Texture Normal",
     "m_DefaultReferenceName": "Texture2D_5c609ec3bcdf4b7da6b379bbcfeb5608",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -4720,7 +4402,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "64ef953db4a74e0682b3ea4774625bab",
     "m_Id": 0,
-    "m_DisplayName": "Bark Normal Strength",
+    "m_DisplayName": "Main Texture Normal Strength",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -4761,21 +4443,6 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Emission"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "65bf80e104d443af941a57e58bdff938",
-    "m_Id": 0,
-    "m_DisplayName": "Fresnel Moss",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 
 {
@@ -5447,7 +5114,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "7f284c131ef64619b2a0a3f2d9c57041",
     "m_Id": 0,
-    "m_DisplayName": "Direction",
+    "m_DisplayName": "Vein UV Scale",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -5641,7 +5308,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "84ea078df36b493aba44cd56822b6a3a",
     "m_Id": 0,
-    "m_DisplayName": "Color",
+    "m_DisplayName": "Vein Color",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -5732,29 +5399,6 @@
         "z": 0.0
     },
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "8c877c35ec3b4fa3abc8c82f0b9f0f3b",
-    "m_Guid": {
-        "m_GuidSerialized": "59acc5fc-24b2-45c5-99a4-465ef8c3b40d"
-    },
-    "m_Name": "Moss Height",
-    "m_DefaultReferenceName": "Vector1_8c877c35ec3b4fa3abc8c82f0b9f0f3b",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.0,
-    "m_FloatType": 0,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
 }
 
 {
@@ -6102,41 +5746,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "914f70f2e985470eab223f3bc6ef60a3",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 58.0,
-            "y": -42.0,
-            "width": 162.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "2652f99b7fa54b0cb9d608cdfedc898f"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "b8c4ede752b343f58c51b2354cb259a5"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "93ae43618caf40c9a20280ed29ef86ad",
     "m_Id": 3,
@@ -6181,21 +5790,6 @@
     },
     "m_Labels": [],
     "m_Space": 0
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "953607d5da094f2f8149930a5532a323",
-    "m_Id": 0,
-    "m_DisplayName": "Moss Height",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.0,
-    "m_DefaultValue": 0.0,
-    "m_Labels": []
 }
 
 {
@@ -6611,7 +6205,7 @@
     "m_Guid": {
         "m_GuidSerialized": "a80c2ee1-03ff-44e9-9cc5-241b5710a896"
     },
-    "m_Name": "Color",
+    "m_Name": "Vein Color",
     "m_DefaultReferenceName": "Color_a26a7c25e19e407eb588ec6eab02b9ae",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -6750,7 +6344,7 @@
     "m_Guid": {
         "m_GuidSerialized": "bbc82b83-4b83-452e-a46c-23ba514a1680"
     },
-    "m_Name": "Moss Normal Strength",
+    "m_Name": "Add Texture Normal Strength",
     "m_DefaultReferenceName": "Vector1_a55d7d26f69949da8af08357b914a59d",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -7232,29 +6826,6 @@
 {
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "b8c4ede752b343f58c51b2354cb259a5",
-    "m_Guid": {
-        "m_GuidSerialized": "6e3c05d6-3c82-4f36-be25-d066dae5a055"
-    },
-    "m_Name": "Moss Threshold",
-    "m_DefaultReferenceName": "Vector1_b8c4ede752b343f58c51b2354cb259a5",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.0,
-    "m_FloatType": 1,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
-}
-
-{
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "f1c387f477ca4e1f8e7aceb116791391",
     "m_Guid": {
         "m_GuidSerialized": "7508b1ef-cf95-4b8a-a09c-a9ba9d185935"
@@ -7589,7 +7160,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "c9968d4b49344280bfd39f8f6587fbab",
     "m_Id": 0,
-    "m_DisplayName": "Bark",
+    "m_DisplayName": "Main Texture",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -7893,7 +7464,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "d1c1ca9083e145d4991172cdb695d1ec",
     "m_Id": 0,
-    "m_DisplayName": "Moss Normal",
+    "m_DisplayName": "Add Texture Normal",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -7908,7 +7479,7 @@
     "m_Guid": {
         "m_GuidSerialized": "a255e882-7668-4b2e-81b1-27410fe095b7"
     },
-    "m_Name": "Bark Normal Strength",
+    "m_Name": "Main Texture Normal Strength",
     "m_DefaultReferenceName": "Vector1_d28f418bf18340b99f3f0199330c19ba",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -7926,45 +7497,10 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "d2ef4179af7546e0b74ce60f193d78db",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -2200.000244140625,
-            "y": -181.0,
-            "width": 150.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "167c6524cac74016807fcf44e4aa8f7d"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "15425b8b103a4e46acb8796d0a7d47b9"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
     "m_ObjectId": "d3c3a53c95c64e369695a06e4e1e9e9d",
     "m_Id": 0,
-    "m_DisplayName": "Moss",
+    "m_DisplayName": "Add Texture",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -8235,41 +7771,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "e44f4a89a83848c3936e7b034e58fb01",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Property",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -764.9999389648438,
-            "y": 64.99993896484375,
-            "width": 143.0,
-            "height": 34.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "953607d5da094f2f8149930a5532a323"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "8c877c35ec3b4fa3abc8c82f0b9f0f3b"
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "e46dd7cc4b3148ec8553c2eaae096f75",
     "m_Group": {
@@ -8299,21 +7800,6 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
-    "m_ObjectId": "306e7f98cd904c1e9a7143f36fcac885",
-    "m_Id": 0,
-    "m_DisplayName": "Lissage Cristallin",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": 0.9,
-    "m_DefaultValue": 0.9,
-    "m_Labels": []
 }
 
 {
@@ -8363,41 +7849,6 @@
     },
     "m_Property": {
         "m_Id": "9fd3215e954844f3bfcebed762ec7389"
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
-    "m_ObjectId": "adfc999a100d4ffaa0b1808b47d52990",
-    "m_Group": {
-        "m_Id": ""
-    },
-    "m_Name": "Lissage Cristallin",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": -404.0,
-            "y": 54.0,
-            "width": 210.0,
-            "height": 36.0
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "306e7f98cd904c1e9a7143f36fcac885"
-        }
-    ],
-    "synonyms": [],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    },
-    "m_Property": {
-        "m_Id": "56d461ea21b54dd2aa528830143705b9"
     }
 }
 
@@ -8746,29 +8197,6 @@
 }
 
 {
-    "m_SGVersion": 1,
-    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
-    "m_ObjectId": "f569cdbb9fc847f5b7bc3b350f632a0f",
-    "m_Guid": {
-        "m_GuidSerialized": "7f2002fa-fc32-4ed7-b0ea-2cc548cdcbd2"
-    },
-    "m_Name": "Fresnel Moss",
-    "m_DefaultReferenceName": "Vector1_f569cdbb9fc847f5b7bc3b350f632a0f",
-    "m_OverrideReferenceName": "",
-    "m_GeneratePropertyBlock": true,
-    "m_Precision": 0,
-    "overrideHLSLDeclaration": false,
-    "hlslDeclarationOverride": 0,
-    "m_Hidden": false,
-    "m_Value": 0.0,
-    "m_FloatType": 0,
-    "m_RangeValues": {
-        "x": 0.0,
-        "y": 1.0
-    }
-}
-
-{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
     "m_ObjectId": "f5fbf0dd57734e42ad8755646858e516",
@@ -8821,7 +8249,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "f7f596da5d2848c28f55f2efb4a415d7",
     "m_Id": 0,
-    "m_DisplayName": "Moss Normal Strength",
+    "m_DisplayName": "Add Texture Normal Strength",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -9048,7 +8476,6 @@
     "m_DefaultType": 0
 }
 
-
 {
     "m_SGVersion": 3,
     "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
@@ -9080,7 +8507,7 @@
     "m_Guid": {
         "m_GuidSerialized": "1c1bffe9-0cb3-4ae4-944e-2d262da1fd06"
     },
-    "m_Name": "Blood Emission Strength",
+    "m_Name": "Blood Base Intensity",
     "m_DefaultReferenceName": "Vector1_52dd10c9b3cb4e70bb7406c2a3f6f71f",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -9103,7 +8530,7 @@
     "m_Guid": {
         "m_GuidSerialized": "0507c386-02e4-49d5-9c42-d14c5b6937f5"
     },
-    "m_Name": "Vein Flow Speed",
+    "m_Name": "Blood Flow Speed",
     "m_DefaultReferenceName": "Vector1_754d0192e57f494ba11b15bab4b357f3",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
@@ -9307,7 +8734,6 @@
     "m_BareResource": false
 }
 
-
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
@@ -9408,7 +8834,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "105443f094a1439dba7d0d4af8fdf298",
     "m_Id": 0,
-    "m_DisplayName": "Blood Emission Strength",
+    "m_DisplayName": "Blood Base Intensity",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -9458,7 +8884,7 @@
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "68b017311b164106a44ba2bfff94894f",
     "m_Id": 0,
-    "m_DisplayName": "Vein Flow Speed",
+    "m_DisplayName": "Blood Flow Speed",
     "m_SlotType": 1,
     "m_Hidden": false,
     "m_ShaderOutputName": "Out",
@@ -11091,7 +10517,6 @@
     "m_BareResource": false
 }
 
-
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SplitNode",
@@ -11785,8 +11210,6 @@
         "m_Id": ""
     }
 }
-
-
 
 {
     "m_SGVersion": 0,


### PR DESCRIPTION
## Summary
- renomme les propriétés d'écorce et de mousse en textures principales et secondaires
- supprime les propriétés cristallines et mousse obsolètes du shader
- réordonne et renomme les paramètres veines/sang (Vein Mask, Vein Color, Vein UV Scale, Blood Base Intensity, Blood Flow Speed, etc.)

## Testing
- non applicable


------
https://chatgpt.com/codex/tasks/task_e_68f92d14bc648325a908d1966bd071da