### PR TITLE
Corrige l'échelle UV du sang

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -286,6 +286,9 @@
             "m_Id": "af20cef9ad784e0ea75cf89b7d63b2d8"
         },
         {
+            "m_Id": "c9d8c3c57f814f6d9b7b3a42f764a3a4"
+        },
+        {
             "m_Id": "8fb8a067f3ab4485b9d5b24ea45ce998"
         },
         {
@@ -1172,9 +1175,9 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "cf398c1f399a4ba09cd4ac3e5bc6490b"
+                    "m_Id": "5e49e79c01a94e74955c5402d48aed57"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 6
             },
             "m_InputSlot": {
                 "m_Node": {
@@ -1214,7 +1217,35 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "af20cef9ad784e0ea75cf89b7d63b2d8"
+                    "m_Id": "cf398c1f399a4ba09cd4ac3e5bc6490b"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c9d8c3c57f814f6d9b7b3a42f764a3a4"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "fbebb005acd842919d3296493016df79"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c9d8c3c57f814f6d9b7b3a42f764a3a4"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c9d8c3c57f814f6d9b7b3a42f764a3a4"
                 },
                 "m_SlotId": 2
             },
@@ -10133,6 +10164,113 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.AddNode",
+    "m_ObjectId": "c9d8c3c57f814f6d9b7b3a42f764a3a4",
+    "m_Group": {
+        "m_Id": "a7a73eb36289419d9e086380461472a8"
+    },
+    "m_Name": "Blood UV Offset",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -620.0,
+            "y": 1180.0,
+            "width": 126.0,
+            "height": 118.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "51cc243dd8c24b5587e0bcb69d4c2341"
+        },
+        {
+            "m_Id": "8b1cf7a2a560470e9e9cfd7e35f50c4c"
+        },
+        {
+            "m_Id": "cfce4e98270c4f25a25a1e5aa1b9bb3f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+},
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "51cc243dd8c24b5587e0bcb69d4c2341",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+},
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "8b1cf7a2a560470e9e9cfd7e35f50c4c",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+},
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "cfce4e98270c4f25a25a1e5aa1b9bb3f",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+},
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
     "m_ObjectId": "8fb8a067f3ab4485b9d5b24ea45ce998",
     "m_Group": {
@@ -11196,7 +11334,7 @@
     "m_Type": "UnityEditor.ShaderGraph.StickyNoteData",
     "m_ObjectId": "6fcd6cac36034a418e050ac291ce5a37",
     "m_Title": "Flux sanguin",
-    "m_Content": "Nouvelle texture animée pour visualiser le sang en mouvement dans le flux sanguin. Contrôles: vitesse de flow, Blood UV Scale et intensité d'émission sanguine.",
+    "m_Content": "Nouvelle texture animée pour visualiser le sang en mouvement dans le flux sanguin. Contrôles: vitesse de flow, Blood UV Scale et intensité d'émission sanguine.\nNote: Blood UV Scale agit uniquement sur la texture de sang via \"Blood UV Offset\" afin de préserver l'échelle du masque de veines.",
     "m_TextSize": 0,
     "m_Theme": 0,
     "m_Position": {


### PR DESCRIPTION
## Résumé
- ajoute un nœud "Blood UV Offset" dédié pour appliquer le Blood UV Scale uniquement au flux sanguin
- rebranche les UV de la texture de sang afin de préserver l'échelle du masque de veines
- documente dans la note du graph que l'échelle du sang est désormais isolée du masque

## Tests
- non exécutés (édition ShaderGraph)


------
https://chatgpt.com/codex/tasks/task_e_68fa5ad2e824832596fefb3fa6bfe213