### PR TITLE
Corriger l'influence de Blood UV Scale sur le masque de veines

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -1206,20 +1206,6 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "8fb8a067f3ab4485b9d5b24ea45ce998"
-                },
-                "m_SlotId": 2
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "af20cef9ad784e0ea75cf89b7d63b2d8"
-                },
-                "m_SlotId": 2
-            },
-            "m_InputSlot": {
-                "m_Node": {
                     "m_Id": "224ad8c6e34944fe9a1b6f0bc5595243"
                 },
                 "m_SlotId": 2
@@ -1643,6 +1629,20 @@
                     "m_Id": "d7cc08d7e7704122bbb25abb0e840b4a"
                 },
                 "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "5e49e79c01a94e74955c5402d48aed57"
+                },
+                "m_SlotId": 6
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8fb8a067f3ab4485b9d5b24ea45ce998"
+                },
+                "m_SlotId": 2
             }
         }
     ],


### PR DESCRIPTION
## Summary
- déconnecté la sortie UV décalée des veines pour qu'elle n'alimente plus l'échantillonnage du masque
- relié directement les coordonnées UV de base au masque de veines afin que Blood UV Scale n'affecte que la texture de sang

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa60d4539083259a63c3f5608a6138