### PR TITLE
Connecter Vein UV Scale au Vein Mask

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -274,6 +274,9 @@
             "m_Id": "5e49e79c01a94e74955c5402d48aed57"
         },
         {
+            "m_Id": "50894728107b4bb4be392de8987aebb8"
+        },
+        {
             "m_Id": "cf398c1f399a4ba09cd4ac3e5bc6490b"
         },
         {
@@ -354,6 +357,9 @@
     "m_StickyNoteDatas": [
         {
             "m_Id": "6fcd6cac36034a418e050ac291ce5a37"
+        },
+        {
+            "m_Id": "39585e646b3a498385e3725b4cd63fb7"
         }
     ],
     "m_Edges": [
@@ -1640,6 +1646,34 @@
             },
             "m_InputSlot": {
                 "m_Node": {
+                    "m_Id": "50894728107b4bb4be392de8987aebb8"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "ff1e3e3ee4304613b74f865cc7f482e9"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "50894728107b4bb4be392de8987aebb8"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "50894728107b4bb4be392de8987aebb8"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
                     "m_Id": "8fb8a067f3ab4485b9d5b24ea45ce998"
                 },
                 "m_SlotId": 2
@@ -2900,8 +2934,8 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
+        "x": 1.0,
+        "y": 1.0,
         "z": 0.0,
         "w": 0.0
     }
@@ -9474,6 +9508,164 @@
     },
     "m_Labels": []
 }
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "50894728107b4bb4be392de8987aebb8",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Vein Mask UV Scale",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -460.0,
+            "y": 980.0,
+            "width": 208.0,
+            "height": 302.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "27e70e1c44ca487e823166e071c37858"
+        },
+        {
+            "m_Id": "80c8a9a0bae84fccb796c4f625255177"
+        },
+        {
+            "m_Id": "ce2b3506c3204a1a898becc32974c71d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+},
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "27e70e1c44ca487e823166e071c37858",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+},
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "80c8a9a0bae84fccb796c4f625255177",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+},
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "ce2b3506c3204a1a898becc32974c71d",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+},
+
 
 {
     "m_SGVersion": 0,
@@ -11205,6 +11397,26 @@
         "y": 1280.0,
         "width": 260.0,
         "height": 120.0
+    },
+    "m_Group": {
+        "m_Id": ""
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.StickyNoteData",
+    "m_ObjectId": "39585e646b3a498385e3725b4cd63fb7",
+    "m_Title": "Vein Mask UV Scale",
+    "m_Content": "Vein UV Scale multiplie désormais directement l'UV du Vein Mask afin d'ajuster sa taille. Ajuster ce paramètre permet d'agrandir ou de réduire le motif veineux sans impacter les autres effets.",
+    "m_TextSize": 0,
+    "m_Theme": 0,
+    "m_Position": {
+        "serializedVersion": "2",
+        "x": -520.0,
+        "y": 960.0,
+        "width": 300.0,
+        "height": 140.0
     },
     "m_Group": {
         "m_Id": ""


### PR DESCRIPTION
# Résumé
- relie la propriété **Vein UV Scale** au nouvel opérateur de mise à l’échelle afin que le Vein Mask réagisse à l’ajustement du paramètre
- ajoute les nœuds, connexions et documentation interne (sticky note) décrivant la nouvelle logique d’UV

# Tests
- non exécutés (modifications de graphe ShaderGraph uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68fa647caa5c8325bd2567c9a2dde550