### PR TITLE
Réparer l'inspector RemoveChildColliders

### DIFF
--- a/Assets/RemoveChildColliders.cs
+++ b/Assets/RemoveChildColliders.cs
@@ -53,33 +53,78 @@ public class RemoveChildCollidersEditor : Editor
         DrawDefaultInspector();
 
         EditorGUILayout.Space();
-// ----------- Menu Tools (historique) -----------------
-// NB : Le menu Tools original vivait dans ce fichier mais entrait en
-// conflit avec la nouvelle implmentation d'outils d'diteur dans
-// `Assets/Editor/RemoveChildColliderUtility.cs`. Pour viter le message
-// "Cannot add validate method ... because a menu item with the same
-// name already has a validate method" signal par Unity, le menu a t
-// entirement dplac dans le script d'diteur. Nous conservons cette note
-// afin que les futurs contributeurs sachent que le menu existe toujours
-// (mme commande, mme fonctionnalit) mais se trouve dsormais dans le
-// dossier Editor o Unity s'attend  le trouver.
-            for (int i = 0; i < selection.Length; i++)
-            {
-                float p = (i + 1f) / selection.Length;
-                EditorUtility.DisplayProgressBar("Suppression des colliders",
-                    $"Traitement: {selection[i].name}", p);
-
-                total += RemoveChildColliders.RemoveCollidersUnder(selection[i], includeParent, includeInactive);
-            }
-        }
-        finally
+        // ----------- Actions disponibles dans l'inspector -----------
+        // Le bouton ci-dessous reproduit le comportement du menu Tools historique
+        // (détaillé dans la note plus bas) mais fonctionne directement depuis
+        // l'inspector avec la multi-sélection. Cela évite à l'utilisateur
+        // d'ouvrir un menu supplémentaire lorsque l'outil est déjà attaché sur
+        // un GameObject dans la hiérarchie.
+        if (GUILayout.Button("Supprimer les colliders des enfants"))
         {
-            EditorUtility.ClearProgressBar();
+            // Récupère les composants sélectionnés (multi-sélection supportée)
+            // afin de traiter chaque GameObject individuellement avec ses
+            // propres options includeParent/includeInactive.
+            var components = targets
+                .Cast<RemoveChildColliders>()
+                .Distinct()
+                .ToArray();
+
+            if (components.Length == 0)
+            {
+                // Cas de figure improbable mais plus sûr : si aucun composant
+                // n'est trouvé, on prévient l'utilisateur pour éviter un Undo
+                // inutile.
+                EditorUtility.DisplayDialog(
+                    "Aucun objet",
+                    "Sélectionnez au moins un objet possédant le composant RemoveChildColliders.",
+                    "OK");
+                return;
+            }
+
+            int undoGroup = Undo.GetCurrentGroup();
+            Undo.SetCurrentGroupName("Supprimer les colliders des enfants");
+
+            int total = 0;
+            try
+            {
+                for (int i = 0; i < components.Length; i++)
+                {
+                    var component = components[i];
+                    var go = component.gameObject;
+
+                    // Affiche une barre de progression pour informer l'utilisateur
+                    // du GameObject actuellement traité, particulièrement utile
+                    // lorsque de nombreuses entrées sont sélectionnées.
+                    float progress = (i + 1f) / components.Length;
+                    EditorUtility.DisplayProgressBar("Suppression des colliders",
+                        $"Traitement : {go.name}", progress);
+
+                    total += RemoveChildColliders.RemoveCollidersUnder(
+                        go,
+                        component.includeParent,
+                        component.includeInactive);
+                }
+            }
+            finally
+            {
+                EditorUtility.ClearProgressBar();
+            }
+
+            Undo.CollapseUndoOperations(undoGroup);
+            EditorUtility.DisplayDialog("Terminé",
+                $"Colliders supprimés : {total}\nObjets traités : {components.Length}", "OK");
         }
 
-        Undo.CollapseUndoOperations(undoGroup);
-        EditorUtility.DisplayDialog("Terminé",
-            $"Colliders supprimés: {total}\nObjets traités: {selection.Length}", "OK");
+        // ----------- Menu Tools (historique) -----------------
+        // NB : Le menu Tools original vivait dans ce fichier mais entrait en
+        // conflit avec la nouvelle implémentation d'outils d'éditeur dans
+        // `Assets/Editor/RemoveChildColliderUtility.cs`. Pour éviter le message
+        // "Cannot add validate method ... because a menu item with the same
+        // name already has a validate method" signalé par Unity, le menu a été
+        // entièrement déplacé dans le script d'éditeur. Nous conservons cette note
+        // afin que les futurs contributeurs sachent que le menu existe toujours
+        // (même commande, même fonctionnalité) mais se trouve désormais dans le
+        // dossier Editor où Unity s'attend à le trouver.
     }
 
     [MenuItem("Tools/Colliders/Supprimer sur la sélection (enfants)", true)]


### PR DESCRIPTION
## Résumé
- Restaurer la logique de suppression de colliders depuis l'inspector en mode multi-sélection
- Ajouter une barre de progression, un regroupement Undo et des boîtes de dialogue informatives pour chaque action
- Documenter dans le code le déplacement du menu Tools historique vers le dossier Editor

## Tests
- Non exécutés (scripts éditeur uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68fc8ffde2c083259410f48cc642ada9