### PR TITLE
Remplacer l'appel obsolète à FindObjectsOfType

### DIFF
--- a/Assets/Scripts/Editor/OptimizationTools.cs
+++ b/Assets/Scripts/Editor/OptimizationTools.cs
@@ -32,7 +32,9 @@ public static class OptimizationTools
     [MenuItem("Symphonie/Optimisation/Marquer les objets statiques de la sc\u00e8ne")]
     private static void MarkSceneObjectsStatic()
     {
-        GameObject[] allObjects = Object.FindObjectsOfType<GameObject>();
+        // Utilise la nouvelle API recommandée par Unity pour récupérer les objets de la scène
+        // sans coût supplémentaire de tri lorsque ce n'est pas nécessaire.
+        GameObject[] allObjects = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
         int count = 0;
         foreach (GameObject go in allObjects)
         {


### PR DESCRIPTION
## Summary
- remplacer l'utilisation de `Object.FindObjectsOfType` dans l'outil d'optimisation par `Object.FindObjectsByType`
- documenter le choix de l'API pour indiquer l'absence de tri nécessaire

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc9d2d7c388325882105f7a68dafae