### PR TITLE
Replace deprecated camera lookup

### DIFF
--- a/CC5 - AutoSetup/Character_Creator_and_iClone_Auto_Setup_1.4.6_for_Unity_HDRP12/Editor/PreviewScene.cs
+++ b/CC5 - AutoSetup/Character_Creator_and_iClone_Auto_Setup_1.4.6_for_Unity_HDRP12/Editor/PreviewScene.cs
@@ -52,7 +52,11 @@ namespace Reallusion.Import
 
             if (!camera)
             {
-                Camera[] cams = GameObject.FindObjectsOfType<Camera>();
+                // Utilisation de la nouvelle API FindObjectsByType afin d'éviter l'avertissement
+                // de dépréciation généré par FindObjectsOfType. Nous ne demandons aucun tri
+                // supplémentaire pour des raisons de performances, car le premier rendu actif
+                // trouvé est suffisant pour récupérer la caméra d'aperçu.
+                Camera[] cams = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None);
                 foreach (Camera cam in cams)
                 {
                     if (cam.isActiveAndEnabled)


### PR DESCRIPTION
## Summary
- remplacer l'appel obsolète à `FindObjectsOfType` dans `PreviewScene` par la nouvelle API `FindObjectsByType`
- ajouter un commentaire expliquant l'utilisation de la nouvelle API pour la maintenance future

## Testing
- non applicable

------
https://chatgpt.com/codex/tasks/task_e_68fca0fb70608325866cbb88a137913f