### PR TITLE
Améliorer la détection de l'Animator du joueur

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -140,7 +140,20 @@ public class ThirdPersonPlayerController : MonoBehaviour
     void Awake()
     {
         controller = GetComponent<CharacterController>();
-        animator = transform.GetChild(0).GetComponent<Animator>();
+
+        // --- Récupération robuste de l'Animator -------------------------------------------------------
+        // Dans certaines scènes Lucian peut être directement porteur de l'Animator, tandis que dans
+        // d'autres le composant est situé plus profondément dans la hiérarchie (préfab réorganisé,
+        // effets temporaires, etc.). Le code précédent se contentait de prendre le tout premier enfant,
+        // ce qui échouait silencieusement si la structure différait (Animator introuvable ⇒ aucune
+        // animation jouée). On cherche donc dans l'ordre : sur l'objet lui-même, puis dans tous les
+        // descendants actifs ou non. Cette approche garantit que les animations restent fonctionnelles
+        // même après un remaniement du prefab.
+        animator = GetComponent<Animator>();
+        if (animator == null)
+        {
+            animator = GetComponentInChildren<Animator>(includeInactive: true);
+        }
 
         if (animator != null)
         {
@@ -158,6 +171,12 @@ public class ThirdPersonPlayerController : MonoBehaviour
             animator.SetFloat(pMoveY, 0f);
 
             CacheLandingClipDurations();
+        }
+        else
+        {
+            Debug.LogWarning(
+                "[ThirdPersonPlayerController] Aucun Animator trouvé dans la hiérarchie du joueur. " +
+                "Les animations de déplacement resteront figées tant qu'un Animator valide ne sera pas associé.");
         }
 
         if (cameraTransform == null)


### PR DESCRIPTION
## Summary
- rechercher l'Animator directement sur Lucian puis dans toute sa hiérarchie pour éviter les références manquantes
- ajouter un message d'avertissement explicite quand aucun Animator n'est trouvé afin de faciliter le diagnostic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd011cc2ac83259e61599a755cdb26