### PR TITLE
Ajout de Vein Flow Direction au ShaderGraph global

### DIFF
--- a/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
+++ b/Assets/Materials/GlassLucian/ShaderGraph_Symphonie_Global_Lit.shadergraph
@@ -58,6 +58,9 @@
             "m_Id": "c498d62df82147abb458e3533211f4a6"
         },
         {
+            "m_Id": "c0c4f6d6825e48ed81d9ec6bb79ede15"
+        },
+        {
             "m_Id": "259b8898fa1d4488ad6246b620d4e241"
         },
         {
@@ -401,6 +404,9 @@
         },
         {
             "m_Id": "230a2697eca2467283ab7f5492adb912"
+        },
+        {
+            "m_Id": "2f1e2f25b8a146c2ab96d2b37c5c2b5c"
         }
     ],
     "m_Edges": [
@@ -3497,7 +3503,7 @@
         "m_SerializableColors": []
     },
     "m_Property": {
-        "m_Id": "c498d62df82147abb458e3533211f4a6"
+        "m_Id": "c0c4f6d6825e48ed81d9ec6bb79ede15"
     }
 }
 
@@ -5372,6 +5378,9 @@
             "m_Id": "c498d62df82147abb458e3533211f4a6"
         },
         {
+            "m_Id": "c0c4f6d6825e48ed81d9ec6bb79ede15"
+        },
+        {
             "m_Id": "259b8898fa1d4488ad6246b620d4e241"
         },
         {
@@ -6645,6 +6654,26 @@
         "y": 1080.0,
         "width": 360.0,
         "height": 160.0
+    },
+    "m_Group": {
+        "m_Id": ""
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.StickyNoteData",
+    "m_ObjectId": "2f1e2f25b8a146c2ab96d2b37c5c2b5c",
+    "m_Title": "Direction du flux des veines",
+    "m_Content": "Vein Flow Direction définit le vecteur UV qui détermine le sens de défilement du masque de veines. Combinez ce réglage avec Vein Flow Speed et Vein Flow Offset pour créer des veines diagonales ou inversées selon les besoins narratifs.",
+    "m_TextSize": 0,
+    "m_Theme": 0,
+    "m_Position": {
+        "serializedVersion": "2",
+        "x": -1500.0,
+        "y": 1240.0,
+        "width": 380.0,
+        "height": 180.0
     },
     "m_Group": {
         "m_Id": ""
@@ -10763,6 +10792,36 @@
     "m_DefaultRefNameVersion": 0,
     "m_RefNameGeneratedByDisplayName": "",
     "m_DefaultReferenceName": "Vector2_c498d62df82147abb458e3533211f4a6",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_PerRendererData": false,
+    "m_customAttributes": [],
+    "m_Value": {
+        "x": 0.0,
+        "y": 1.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector2ShaderProperty",
+    "m_ObjectId": "c0c4f6d6825e48ed81d9ec6bb79ede15",
+    "m_Guid": {
+        "m_GuidSerialized": "d3a3f2cb-ef47-4f34-8d51-7dcd9300e329"
+    },
+    "m_Name": "Vein Flow Direction",
+    "m_DefaultRefNameVersion": 0,
+    "m_RefNameGeneratedByDisplayName": "",
+    "m_DefaultReferenceName": "Vector2_c0c4f6d6825e48ed81d9ec6bb79ede15",
     "m_OverrideReferenceName": "",
     "m_GeneratePropertyBlock": true,
     "m_UseCustomSlotLabel": false,


### PR DESCRIPTION
## Résumé
- ajouter la propriété vectorielle **Vein Flow Direction** au ShaderGraph_Symphonie_Global_Lit et lier le nœud de flux des veines à ce nouveau paramètre
- documenter la nouvelle propriété via un sticky note pour guider l'équilibrage des flux de veines et leurs usages narratifs

## Tests
- non exécutés (modification de graphisme uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68fd0c4f35248325a039f6236f70e233