### PR TITLE
Fix animation locomotion speed computation

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/ThirdPersonPlayerController.cs
@@ -477,8 +477,11 @@ public class ThirdPersonPlayerController : MonoBehaviour
         if (animator == null)
             return;
 
-        // Vitesse horizontale réelle calculée à partir du CharacterController (ignorant l'axe vertical).
-        float rawHorizontalSpeed = new Vector3(controller.velocity.x, 0f, controller.velocity.z).magnitude;
+        // Vitesse horizontale réelle calculée à partir de la dernière intention de déplacement.
+        // IMPORTANT : CharacterController.velocity ne peut pas être utilisé ici car Move() est appelé
+        // deux fois par frame (horizontal puis vertical). Sa valeur finale ne conserve donc plus la
+        // composante horizontale, ce qui donnait une vitesse mesurée à 0 et empêchait les transitions.
+        float rawHorizontalSpeed = horizontalVelocity.magnitude;
 
         // Convertit cette vitesse en valeur normalisée (0 = immobile, 1 = runSpeed ou plus).
         float targetNormalizedSpeed = 0f;


### PR DESCRIPTION
## Summary
- use the cached horizontal velocity to drive the locomotion speed pushed to the animator
- document why CharacterController.velocity could not be relied on due to consecutive Move calls

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fd2bb538548325aa8a75666653ca4f