### PR TITLE
Corriger le déclenchement du VFX DebrisBurst

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/TriggerVFX.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TriggerVFX.cs
@@ -1,15 +1,16 @@
+using System; // Nécessaire pour comparer proprement les noms d'évènements.
 using UnityEngine;
 using UnityEngine.VFX;
 
 [RequireComponent(typeof(VisualEffect))]
 public class TriggerVFX : MonoBehaviour
 {
-    [Header("Nom de l'�v�nement � envoyer au VFX Graph")]
+    [Header("Nom de l'événement à envoyer au VFX Graph")]
     [Tooltip("Doit correspondre au nom d'un Event dans ton VFX Graph (ex: OnBurst)")]
     public string eventName = "OnBurst";
 
-    [Header("D�clenchement automatique")]
-    [Tooltip("Lance automatiquement le VFX au d�marrage")]
+    [Header("Déclenchement automatique")]
+    [Tooltip("Lance automatiquement le VFX au démarrage")]
     public bool playOnStart = false;
 
     [Tooltip("Relancer automatiquement si le VFX a fini ?")]
@@ -31,16 +32,43 @@ public class TriggerVFX : MonoBehaviour
     }
 
     /// <summary>
-    /// Lance le VFX avec l'�v�nement d�fini.
+    /// Lance le VFX avec l'événement défini.
     /// </summary>
     public void TriggerEffect()
     {
-        if (vfx == null) return;
+        if (vfx == null)
+        {
+            // On journalise pour ne pas laisser un appel silencieux, cela facilite le débogage en scène.
+            Debug.LogWarning("TriggerVFX n'a trouvé aucun VisualEffect à déclencher.", this);
+            return;
+        }
 
-        if (!string.IsNullOrEmpty(eventName))
-            vfx.SendEvent(eventName);
-        else
+        // Lorsque l'évènement n'est pas renseigné (cas par défaut) on lance simplement le Play classique du VFX.
+        if (string.IsNullOrEmpty(eventName))
+        {
             vfx.Play();
+            return;
+        }
+
+        // Beaucoup de graph VFX, comme DebrisBurst, attendent l'évènement par défaut "OnPlay".
+        // On simplifie donc la configuration en traitant ce cas comme un appel direct à Play.
+        if (eventName.Equals("OnPlay", StringComparison.OrdinalIgnoreCase))
+        {
+            vfx.Play();
+            return;
+        }
+
+        // Si l'évènement personnalisé existe vraiment dans le graph, on le lance comme prévu.
+        if (vfx.HasEvent(eventName))
+        {
+            vfx.SendEvent(eventName);
+        }
+        else
+        {
+            // En dernier recours (cas de DebrisBurst paramétré en "OnBurst"), on repasse sur Play afin de garantir l'effet.
+            Debug.LogWarning($"L'évènement '{eventName}' n'existe pas sur le graph VFX attaché à '{vfx.visualEffectAsset?.name}'. Utilisation de Play à la place.", this);
+            vfx.Play();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- journaliser lorsqu'aucun VisualEffect n'est trouvé par TriggerVFX
- basculer automatiquement sur VisualEffect.Play pour les évènements par défaut ou inconnus
- utiliser HasEvent afin de déclencher uniquement les évènements réellement exposés

## Tests
- Aucun (environnement Unity indisponible dans le conteneur)


------
https://chatgpt.com/codex/tasks/task_e_68ffd936fc40832596f7b137a5bcbfb4