### PR TITLE
Fix DissolveParticles_v2 mesh output

### DIFF
--- a/Assets/VFX/DissolveParticles_v2.vfx
+++ b/Assets/VFX/DissolveParticles_v2.vfx
@@ -285,7 +285,7 @@ MonoBehaviour:
       m_Type:
         m_SerializableType: UnityEngine.Mesh, UnityEngine.CoreModule, Version=0.0.0.0,
           Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"obj":{"fileID":10207,"guid":"0000000000000000e000000000000000","type":0}}'
+      m_SerializableObject: '{"obj":{"fileID":4300000,"guid":"4f949ae83a043c64d9ee5d95fc9db193","type":3}}'
     min: -Infinity
     max: Infinity
     enumValues: []
@@ -2553,7 +2553,7 @@ MonoBehaviour:
       m_Type:
         m_SerializableType: UnityEngine.Mesh, UnityEngine.CoreModule, Version=0.0.0.0,
           Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"obj":{"fileID":10207,"guid":"0000000000000000e000000000000000","type":0}}'
+      m_SerializableObject: '{"obj":{"fileID":4300000,"guid":"4f949ae83a043c64d9ee5d95fc9db193","type":3}}'
     m_Space: -1
   m_Property:
     name: o
@@ -6741,7 +6741,7 @@ MonoBehaviour:
       m_Type:
         m_SerializableType: UnityEngine.Mesh, UnityEngine.CoreModule, Version=0.0.0.0,
           Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"obj":{"fileID":10207,"guid":"0000000000000000e000000000000000","type":0}}'
+      m_SerializableObject: '{"obj":{"fileID":4300000,"guid":"4f949ae83a043c64d9ee5d95fc9db193","type":3}}'
     m_Space: -1
   m_Property:
     name: mesh


### PR DESCRIPTION
## Summary
- replace the default quad mesh used by the DissolveParticles_v2 effect with the DEMOSphereMesh asset so particles render as 3D spheres

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_e_690799d782808325a05700784a253698