### PR TITLE
Aligner le pont harmonique sous la cible

### DIFF
--- a/Assets/Prefabs/BattleGroundTile.prefab
+++ b/Assets/Prefabs/BattleGroundTile.prefab
@@ -43,9 +43,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a30a20661737496da060243229926737, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   spawnOnTarget: 1
+  spawnOffset: {x: 0, y: -0.05, z: 0}
+  alignToTargetGround: 1
 --- !u!1 &732579883773915201
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InstantiateGameObject.cs
@@ -33,8 +33,11 @@ public class InstantiateGameObject : MonoBehaviour
     {
         // Par défaut, on instancie sur le lanceur. Ce comportement peut être
         // redéfini par la présence d'un composant TimelineInstantiationParameters
-        // sur le prefab fourni.
+        // sur le prefab fourni. On met également en cache un offset et une
+        // éventuelle contrainte d'alignement vertical pour les plateformes.
         bool spawnOnTarget = false;
+        Vector3 spawnOffset = Vector3.zero;
+        bool alignToTargetGround = false;
 
         if (gameObjectToInstantiate != null)
         {
@@ -43,12 +46,14 @@ public class InstantiateGameObject : MonoBehaviour
             if (parameters != null)
             {
                 spawnOnTarget = parameters.spawnOnTarget;
+                spawnOffset = parameters.spawnOffset;
+                alignToTargetGround = parameters.alignToTargetGround;
             }
         }
 
         // Appel à la variante détaillée permettant d'instancier en tenant compte
-        // de la cible désirée.
-        InstantiateFromTimeline(gameObjectToInstantiate, spawnOnTarget);
+        // de la cible désirée ainsi que des différents offsets demandés.
+        InstantiateFromTimeline(gameObjectToInstantiate, spawnOnTarget, spawnOffset, alignToTargetGround);
     }
 
     /// <summary>
@@ -63,7 +68,7 @@ public class InstantiateGameObject : MonoBehaviour
     ///     Si <c>true</c>, l'objet est instancié sur la cible actuelle.
     ///     Sinon, il apparaît sur le lanceur de l'action.
     /// </param>
-    public void InstantiateFromTimeline(GameObject gameObjectToInstantiate, bool spawnOnTarget)
+    public void InstantiateFromTimeline(GameObject gameObjectToInstantiate, bool spawnOnTarget, Vector3 spawnOffset = default, bool alignToTargetGround = false)
     {
         // Détermination de la position d'apparition en fonction du paramètre
         // "spawnOnTarget". On tente d'abord de récupérer les unités impliquées
@@ -82,6 +87,15 @@ public class InstantiateGameObject : MonoBehaviour
             {
                 // Instanciation au niveau de la cible actuelle
                 spawnPosition = target.transform.position;
+
+                if (alignToTargetGround)
+                {
+                    // Aligne la position verticale sur la base visuelle de l'unité.
+                    // On utilise les bounds agrégés pour prendre en compte les
+                    // échelles ou animations éventuelles.
+                    Bounds targetBounds = target.GetVisualBounds();
+                    spawnPosition.y = targetBounds.min.y;
+                }
             }
             else if (!spawnOnTarget && caster != null)
             {
@@ -101,6 +115,9 @@ public class InstantiateGameObject : MonoBehaviour
             // Pas de gestionnaire de combat : contexte non prévu (ex. cinématique).
             Debug.LogWarning("[InstantiateGameObject] NewBattleManager introuvable, instanciation sur le porteur de script.");
         }
+
+        // Applique les offsets souhaités une fois la position de base déterminée.
+        spawnPosition += spawnOffset;
 
         // Instancie finalement le prefab si fourni.
         if (gameObjectToInstantiate != null)

--- a/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/TimelineInstantiationParameters.cs
@@ -10,4 +10,11 @@ public class TimelineInstantiationParameters : MonoBehaviour
 {
     [Tooltip("Si vrai, le prefab sera instancié sur la cible (target) actuelle. Sinon il apparaîtra sur le lanceur (caster).")]
     public bool spawnOnTarget = false;
+
+    [Header("Offsets d'apparition")]
+    [Tooltip("Décalage supplémentaire appliqué après le choix caster/target afin d'ajuster finement la position finale.")]
+    public Vector3 spawnOffset = Vector3.zero;
+
+    [Tooltip("Force l'alignement sur la base de la cible lorsque l'on instancie dessus (idéal pour les plates-formes comme le Pont Harmonique).")]
+    public bool alignToTargetGround = false;
 }


### PR DESCRIPTION
## Summary
- enrichir les paramètres d’instanciation des prefabs contrôlés par les timelines avec un offset et un alignement au sol de la cible
- ajuster l’utilitaire d’instanciation afin de positionner correctement les prefabs sur la cible en appliquant ces nouveaux paramètres
- configurer le prefab du Pont Harmonique pour qu’il se cale au niveau du sol de l’ennemi avec un léger décalage vertical

## Testing
- Non exécuté (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_69092e5bfcb083259d96d211071dcb2f