### PR TITLE
Réduction des timelines de combat

### DIFF
--- a/Assets/Characters/Squad/Lucian/Character_Lucian.asset
+++ b/Assets/Characters/Squad/Lucian/Character_Lucian.asset
@@ -66,6 +66,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 370617c19b664f29839d25a4955dacf9, type: 2}
     - {fileID: 11400000, guid: fd8086605fb14e81a0e94c639309929f, type: 2}
   defaultItemSetIndex: -1
+  combatAnimations: {fileID: 11400000, guid: 3a6577b918c72784eb8fe8b4965c5db2, type: 2}
   currentInitiative: 1
   currentRange: 24.55
   currentHP: 10

--- a/Assets/Scripts/Classes/CharacterData.cs
+++ b/Assets/Scripts/Classes/CharacterData.cs
@@ -149,6 +149,10 @@ public class CharacterData : ScriptableObject, ITargetable
     [Tooltip("Index utilisé au chargement pour activer un set d'objets spécifique. -1 pour aucun.")]
     public int defaultItemSetIndex = -1;
 
+    [Header("Animations de combat (Animator)")]
+    [Tooltip("Mapping vers les states Animator et timelines de secours utilisés pendant les combats.")]
+    public CombatAnimationGroups combatAnimations;
+
     #endregion
 
     #region Etats runtime

--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -105,6 +105,16 @@ public class ItemData : ScriptableObject
     [Tooltip("Timeline jouée lors du repli après utilisation")]
     public TimelineAsset retreatTimeline;
 
+    [Header("Animator – Clés partagées")]
+    [Tooltip("State Animator utilisé si aucune timeline de préparation n'est définie.")]
+    public CombatAnimationKey preparingAnimationKey = CombatAnimationKey.None;
+
+    [Tooltip("State Animator lancé durant l'utilisation lorsque la timeline est absente.")]
+    public CombatAnimationKey performingAnimationKey = CombatAnimationKey.None;
+
+    [Tooltip("State Animator de repli si aucune timeline n'est disponible.")]
+    public CombatAnimationKey retreatAnimationKey = CombatAnimationKey.None;
+
     [Header("Caméras par phase")]
     [Tooltip("Plan cinématique utilisé lors de la préparation (None = conserver la vue actuelle, OverShoulderCasterLookTarget = ancre Camera_Shoulder_Stay, OverShoulderCasterToTarget = ancre Camera_Shoulder_Moving).")]
     public BattleCameraRole preparingCameraRole = BattleCameraRole.MainMenuIdle;
@@ -177,6 +187,36 @@ public class ItemData : ScriptableObject
         {
             ApplySingleEffect(criticalEffectType, caster, target, criticalEffectValue);
         }
+    }
+
+    /// <summary>
+    /// Détermine l'animation de préparation à jouer lorsque l'objet n'utilise pas de timeline.
+    /// </summary>
+    public CombatAnimationKey ResolvePreparingAnimationKey()
+    {
+        return preparingAnimationKey != CombatAnimationKey.None
+            ? preparingAnimationKey
+            : CombatAnimationKey.AimItem;
+    }
+
+    /// <summary>
+    /// Sélectionne la pose Animator principale de l'objet en l'absence de timeline dédiée.
+    /// </summary>
+    public CombatAnimationKey ResolvePerformingAnimationKey()
+    {
+        return performingAnimationKey != CombatAnimationKey.None
+            ? performingAnimationKey
+            : CombatAnimationKey.ItemUseDynamic;
+    }
+
+    /// <summary>
+    /// Identifie la pose de repli standard lorsque l'objet ne propose pas de timeline de sortie.
+    /// </summary>
+    public CombatAnimationKey ResolveRetreatAnimationKey()
+    {
+        return retreatAnimationKey != CombatAnimationKey.None
+            ? retreatAnimationKey
+            : CombatAnimationKey.RetreatBlendTree;
     }
 
     /// <summary>

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -174,6 +174,16 @@ public class MusicalMoveSO : ScriptableObject
     [Header("Animation")]
     public AnimationClip preparingAnimation;
 
+    [Header("Animator – Clés partagées")]
+    [Tooltip("State Animator à jouer si aucune timeline n'est fournie pour la préparation du move.")]
+    public CombatAnimationKey preparingAnimationKey = CombatAnimationKey.None;
+
+    [Tooltip("State Animator à utiliser pour l'exécution principale lorsque la timeline est absente.")]
+    public CombatAnimationKey performingAnimationKey = CombatAnimationKey.None;
+
+    [Tooltip("State Animator jouée lors du repli si l'on n'utilise pas de timeline dédiée.")]
+    public CombatAnimationKey retreatAnimationKey = CombatAnimationKey.None;
+
     [Header("Timeline")]
     [Tooltip("Timeline jouée lors de la préparation du move")]
     public TimelineAsset preparingTimeline;
@@ -297,6 +307,41 @@ public class MusicalMoveSO : ScriptableObject
         {
             ApplySingleEffect(criticalEffectType, caster, target, criticalEffectValue, criticalFatigueCost, false);
         }
+    }
+
+    /// <summary>
+    /// Identifie le state Animator le plus pertinent pour la phase de préparation.
+    /// Un fallback générique est fourni pour éviter toute posture figée si aucune valeur n'est saisie.
+    /// </summary>
+    public CombatAnimationKey ResolvePreparingAnimationKey()
+    {
+        return preparingAnimationKey != CombatAnimationKey.None
+            ? preparingAnimationKey
+            : CombatAnimationKey.PrepareHit;
+    }
+
+    /// <summary>
+    /// Détermine l'animation principale à utiliser lorsqu'on préfère l'Animator aux timelines.
+    /// Les attaques se rabattent sur la première chaîne A, les autres moves utilisent une posture utilitaire.
+    /// </summary>
+    public CombatAnimationKey ResolvePerformingAnimationKey()
+    {
+        if (performingAnimationKey != CombatAnimationKey.None)
+            return performingAnimationKey;
+
+        return moveType == MoveType.Attack
+            ? CombatAnimationKey.AttackChainA_Light
+            : CombatAnimationKey.SkillUseDynamic;
+    }
+
+    /// <summary>
+    /// Choisit l'animation de repli standard lorsque aucune timeline n'est configurée.
+    /// </summary>
+    public CombatAnimationKey ResolveRetreatAnimationKey()
+    {
+        return retreatAnimationKey != CombatAnimationKey.None
+            ? retreatAnimationKey
+            : CombatAnimationKey.RetreatBlendTree;
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -1779,13 +1779,20 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     /// AnimationClip fourni par le move en cours de sélection. Peut être nul
     /// si le move ne définit pas d'animation personnalisée.
     /// </param>
-    public void PlayPreparingAnimation(AnimationClip clip)
+    public void PlayPreparingAnimation(AnimationClip clip, CombatAnimationKey fallbackKey = CombatAnimationKey.None)
     {
         // Les moves d'entrée de gamme n'ont pas toujours de pose dédiée :
         // on ignore simplement l'appel lorsque le clip est absent pour
         // éviter toute erreur et conserver un feedback cohérent.
         if (clip == null)
+        {
+            if (fallbackKey != CombatAnimationKey.None)
+            {
+                // En l'absence de clip dédié, on s'appuie sur la configuration Animator partagée.
+                TryPlayCombatAnimation(fallbackKey);
+            }
             return;
+        }
 
         // On s'assure de disposer de l'Animator enfant adéquat avant de
         // lancer la transition, notamment lorsque l'unité vient juste
@@ -1795,6 +1802,68 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         // Réutilise la méthode centralisée afin de bénéficier de tous les
         // garde-fous existants (vérification d'état mort, CrossFade, etc.).
         PlayAnimationClip(clip);
+    }
+
+    /// <summary>
+    /// Tente de jouer une animation décrite dans les <see cref="CombatAnimationGroups"/> associés au personnage.
+    /// </summary>
+    /// <param name="key">Identifiant de l'animation à jouer.</param>
+    /// <param name="allowTimelineFallback">True pour autoriser le recours à la timeline de secours lorsque nécessaire.</param>
+    /// <returns>Vrai si une animation a bien été déclenchée.</returns>
+    public bool TryPlayCombatAnimation(CombatAnimationKey key, bool allowTimelineFallback = true)
+    {
+        if (key == CombatAnimationKey.None || Data == null)
+            return false;
+
+        CombatAnimationGroups groups = Data.combatAnimations;
+        if (groups == null || !groups.TryGetAnimation(key, out var definition) || definition == null)
+            return false;
+
+        Animator anim = GetCasterAnimator(forceRefresh: true);
+        bool hasAnimatorState = anim != null && !string.IsNullOrEmpty(definition.animatorStateName);
+        int layerIndex = Mathf.Max(0, definition.layerIndex);
+        int stateHash = 0;
+
+        if (hasAnimatorState)
+        {
+            stateHash = Animator.StringToHash(definition.animatorStateName);
+            if (!anim.HasState(layerIndex, stateHash))
+                hasAnimatorState = false;
+        }
+
+        bool timelineAvailable = definition.timeline != null;
+        bool preferTimeline = definition.useTimelineByDefault;
+        bool timelineAllowed = allowTimelineFallback || preferTimeline;
+        bool shouldUseTimeline = timelineAvailable && timelineAllowed && (preferTimeline || !hasAnimatorState);
+
+        if (shouldUseTimeline)
+        {
+            NotifyIdleStateExit();
+            PlayBattleTimeline(definition.timeline, GetCasterBindingTarget());
+            return true;
+        }
+
+        if (!hasAnimatorState)
+        {
+            if (!timelineAvailable)
+            {
+                Debug.LogWarning($"[CharacterUnit] Aucun state Animator ni timeline pour la clé '{key}' sur '{name}'.");
+            }
+            return false;
+        }
+
+        NotifyIdleStateExit();
+        FadeOutBattleTimelineInfluence();
+
+        ApplyAnimatorParameterOverrides(anim, definition.parameterOverrides);
+
+        float duration = Mathf.Max(0f, definition.crossFadeDuration);
+        if (duration > 0f)
+            anim.CrossFade(stateHash, duration, layerIndex, 0f);
+        else
+            anim.Play(stateHash, layerIndex, 0f);
+
+        return true;
     }
 
     public void PlayHurtAnimation(Transform attacker = null)
@@ -1899,6 +1968,38 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         StartCoroutine(PlayDamageFlash());
         StartCoroutine(PlayShake());
         StartCoroutine(PlayKnockback(Vector3.zero)); // Tu peux adapter la direction
+    }
+
+    /// <summary>
+    /// Applique la liste d'overrides Animator fournie par la définition d'animation.
+    /// </summary>
+    private static void ApplyAnimatorParameterOverrides(Animator animator, AnimatorParameterOverride[] overrides)
+    {
+        if (animator == null || overrides == null)
+            return;
+
+        foreach (var parameter in overrides)
+        {
+            if (parameter == null || string.IsNullOrEmpty(parameter.parameterName))
+                continue;
+
+            switch (parameter.parameterType)
+            {
+                case AnimatorParameterType.Float:
+                    animator.SetFloat(parameter.parameterName, parameter.floatValue);
+                    break;
+                case AnimatorParameterType.Int:
+                    animator.SetInteger(parameter.parameterName, parameter.intValue);
+                    break;
+                case AnimatorParameterType.Bool:
+                    animator.SetBool(parameter.parameterName, parameter.boolValue);
+                    break;
+                case AnimatorParameterType.Trigger:
+                    animator.ResetTrigger(parameter.parameterName);
+                    animator.SetTrigger(parameter.parameterName);
+                    break;
+            }
+        }
     }
 
     public MusicalMoveSO GetRandomMusicalAttack()

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -3177,7 +3177,10 @@ public class NewBattleManager : MonoBehaviour
         // soulignant l'intention tactique du move pour les joueurs chevronnés.
         if (currentCharacterUnit != null)
         {
-            currentCharacterUnit.PlayPreparingAnimation(move?.preparingAnimation);
+            CombatAnimationKey fallbackKey = move != null
+                ? move.ResolvePreparingAnimationKey()
+                : CombatAnimationKey.PrepareHit;
+            currentCharacterUnit.PlayPreparingAnimation(move?.preparingAnimation, fallbackKey);
         }
     }
 

--- a/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/RhythmQTEManager.cs
@@ -187,17 +187,36 @@ public class RhythmQTEManager : MonoBehaviour
         bool autoRestore,
         Quaternion initialRotation,
         BattleCameraRole cameraRole = BattleCameraRole.None,
-        float cameraSwitchDelay = 0f)
+        float cameraSwitchDelay = 0f,
+        CombatAnimationKey fallbackAnimation = CombatAnimationKey.None)
     {
-        if (timeline == null || BattleTimelineManager.Instance == null || caster == null)
+        if (caster == null)
             return;
 
-        ConfigureCameraForPhase(caster, animatorGO, cameraTarget, initialRotation, cameraRole, cameraSwitchDelay);
+        BattleTimelineManager manager = BattleTimelineManager.Instance;
+        bool timelineAvailable = timeline != null && manager != null;
+        bool animationAvailable = fallbackAnimation != CombatAnimationKey.None;
 
-        // Lecture de la timeline via le PlayableDirector de l'unité concernée.
-        GameObject defaultCasterTarget = caster.GetCasterBindingTarget();
-        GameObject binding = animatorGO ?? defaultCasterTarget;
-        BattleTimelineManager.Instance.PlayCasterTimeline(timeline, caster, binding);
+        if (!timelineAvailable && !animationAvailable)
+            return;
+
+        if (manager != null)
+        {
+            ConfigureCameraForPhase(caster, animatorGO, cameraTarget, initialRotation, cameraRole, cameraSwitchDelay);
+        }
+
+        if (timelineAvailable)
+        {
+            // Lecture de la timeline via le PlayableDirector de l'unité concernée.
+            GameObject defaultCasterTarget = caster.GetCasterBindingTarget();
+            GameObject binding = animatorGO ?? defaultCasterTarget;
+            manager.PlayCasterTimeline(timeline, caster, binding);
+        }
+        else if (animationAvailable)
+        {
+            // Aucun timeline fournie : on se replie sur l'Animator partagé pour limiter les assets spécifiques.
+            caster.TryPlayCombatAnimation(fallbackAnimation);
+        }
     }
 
     /// <summary>
@@ -425,6 +444,16 @@ public class RhythmQTEManager : MonoBehaviour
         // Ce système est remplacé par l'utilisation de caméras Cinemachine dédiées.
         bool useOverlay = false;
 
+        CombatAnimationKey preparingKey = move != null
+            ? move.ResolvePreparingAnimationKey()
+            : CombatAnimationKey.PrepareHit;
+        CombatAnimationKey performingKey = move != null
+            ? move.ResolvePerformingAnimationKey()
+            : CombatAnimationKey.SkillUseDynamic;
+        CombatAnimationKey retreatKey = move != null
+            ? move.ResolveRetreatAnimationKey()
+            : CombatAnimationKey.RetreatBlendTree;
+
         // Configure le rig caméra avec les cibles du move avant de démarrer la mise en scène.
         BattleCameraManager.Instance?.ConfigureActionTargets(
             caster,
@@ -455,7 +484,9 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             move.performingTimeline == null && move.retreatTimeline == null,
             initialRotation,
-            move.preparingCameraRole);
+            move.preparingCameraRole,
+            0f,
+            preparingKey);
         yield return WaitForTimelinePhase(move.preparingTimeline, useOverlay, caster);
 
         // 🎬 Si une timeline de préparation vient de s'achever, on enchaîne maintenant
@@ -495,7 +526,8 @@ public class RhythmQTEManager : MonoBehaviour
             move.retreatTimeline == null,
             initialRotation,
             move.performingCameraRole,
-            move.preparingToPerformingCameraDelay);
+            move.preparingToPerformingCameraDelay,
+            performingKey);
 
         if (pendingNotes == 0)
         {
@@ -549,7 +581,9 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             true,
             initialRotation,
-            move.retreatCameraRole);
+            move.retreatCameraRole,
+            0f,
+            retreatKey);
         yield return WaitForTimelinePhase(move.retreatTimeline, useOverlay, caster);
 
         isActive = false;
@@ -642,6 +676,16 @@ public class RhythmQTEManager : MonoBehaviour
         bool useOverlay = false;
         // Lancement de timeline globale désactivé.
 
+        CombatAnimationKey itemPreparingKey = item != null
+            ? item.ResolvePreparingAnimationKey()
+            : CombatAnimationKey.AimItem;
+        CombatAnimationKey itemPerformingKey = item != null
+            ? item.ResolvePerformingAnimationKey()
+            : CombatAnimationKey.ItemUseDynamic;
+        CombatAnimationKey itemRetreatKey = item != null
+            ? item.ResolveRetreatAnimationKey()
+            : CombatAnimationKey.RetreatBlendTree;
+
         BattleCameraManager.Instance?.ConfigureActionTargets(
             caster,
             target,
@@ -658,7 +702,9 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             item.performingTimeline == null && item.retreatTimeline == null,
             initialRotation,
-            item.preparingCameraRole);
+            item.preparingCameraRole,
+            0f,
+            itemPreparingKey);
         yield return WaitForTimelinePhase(item.preparingTimeline, useOverlay, caster);
 
         // Déplacement ou téléportation éventuel vers la cible.
@@ -689,7 +735,8 @@ public class RhythmQTEManager : MonoBehaviour
             item.retreatTimeline == null,
             initialRotation,
             item.performingCameraRole,
-            item.preparingToPerformingCameraDelay);
+            item.preparingToPerformingCameraDelay,
+            itemPerformingKey);
 
         // QTE associé à l'objet durant l'utilisation.
         LastItemSuccess = true;
@@ -730,7 +777,9 @@ public class RhythmQTEManager : MonoBehaviour
             casterCameraTarget,
             true,
             initialRotation,
-            item.retreatCameraRole);
+            item.retreatCameraRole,
+            0f,
+            itemRetreatKey);
         yield return WaitForTimelinePhase(item.retreatTimeline, useOverlay, caster);
 
         isActive = false;

--- a/Assets/Scripts/ScriptableObjets/CombatAnimationGroups.cs
+++ b/Assets/Scripts/ScriptableObjets/CombatAnimationGroups.cs
@@ -1,67 +1,191 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Timeline;
 
+/// <summary>
+/// Décrit l'ensemble des animations utilisables par un personnage en combat.
+/// L'objectif est de privilégier l'Animator pour la majorité des actions afin
+/// de limiter le recours aux timelines coûteuses à maintenir.
+/// </summary>
 [CreateAssetMenu(menuName = "Symphonie/Combat/Animation Groups", fileName = "CombatAnimationGroups")]
 public class CombatAnimationGroups : ScriptableObject
 {
-    [Header("Idle (1D: IdleVar)")]
-    public AnimationClip[] idleVariations = new AnimationClip[3];
+    [SerializeField, Tooltip("Liste sérialisée des animations disponibles triées par identifiant logique.")]
+    private CombatAnimationSlot[] animations = Array.Empty<CombatAnimationSlot>();
 
-    [Header("Move (2D: SpeedX,SpeedY)  L/R/F/B")]
-    public AnimationClip strafeL;
-    public AnimationClip strafeR;
-    public AnimationClip forwardShuffle;
-    public AnimationClip backShuffle;
+    private readonly Dictionary<CombatAnimationKey, CombatAnimationDefinition> lookup =
+        new Dictionary<CombatAnimationKey, CombatAnimationDefinition>();
 
-    [Header("Approach (1D: DistanceNorm)")]
-    public AnimationClip walkApproach;
-    public AnimationClip runApproach;
-    public AnimationClip shortLunge;
+    /// <summary>
+    /// Fournit un accès en lecture à toutes les animations déclarées, utile pour les outils éditeur.
+    /// </summary>
+    public IReadOnlyList<CombatAnimationSlot> Animations => animations;
 
-    [Header("Retreat (1D: DistanceNorm)")]
-    public AnimationClip walkRetreat;
-    public AnimationClip runRetreat;
-    public AnimationClip shortRetreatLunge;
+    private void OnEnable()
+    {
+        BuildLookup();
+    }
 
-    [Header("Hit React (Directional 2D: F/B/L/R)")]
-    public AnimationClip hitF_small;
-    public AnimationClip hitB_small;
-    public AnimationClip hitL_small;
-    public AnimationClip hitR_small;
+    private void OnValidate()
+    {
+        BuildLookup();
+    }
 
-    [Header("Evade (SSM)")]
-    public AnimationClip evadeF;
-    public AnimationClip evadeB;
-    public AnimationClip evadeL;
-    public AnimationClip evadeR;
+    /// <summary>
+    /// Reconstitue le dictionnaire interne à partir du tableau sérialisé.
+    /// </summary>
+    private void BuildLookup()
+    {
+        lookup.Clear();
 
-    [Header("Cast (1D: CastIntensity)")]
-    public AnimationClip castLow;
-    public AnimationClip castMid;
-    public AnimationClip castMax;
+        if (animations == null)
+            return;
 
-    [Header("Item Use")]
-    public AnimationClip itemUse;
+        foreach (var slot in animations)
+        {
+            if (slot.definition == null)
+                continue;
 
-    [Header("Attacks A (1D: AttackStyle)")]
-    public AnimationClip atk_light_A;
-    public AnimationClip atk_heavy_A;
-    public AnimationClip atk_thrust_A;
-    public AnimationClip atk_cleave_A;
-    public AnimationClip atk_projectile_start;
+            lookup[slot.key] = slot.definition;
+        }
+    }
 
-    [Header("Attacks B (1D: AttackStyle)")]
-    public AnimationClip atk_light_B;
-    public AnimationClip atk_heavy_B;
-    public AnimationClip atk_finisher_B;
-    public AnimationClip atk_projectile_release;
+    /// <summary>
+    /// Recherche la définition associée à une clé d'animation donnée.
+    /// </summary>
+    public bool TryGetAnimation(CombatAnimationKey key, out CombatAnimationDefinition definition)
+    {
+        if (lookup.Count == 0)
+            BuildLookup();
 
-    [Header("KO / GetUp / Death")]
-    public AnimationClip knockdown;
-    public AnimationClip getUp;
-    public AnimationClip death;
+        return lookup.TryGetValue(key, out definition) && definition != null;
+    }
 
-    [Header("Turn In Place")]
-    public AnimationClip turn90L;
-    public AnimationClip turn90R;
-    public AnimationClip turn180;
+    /// <summary>
+    /// Retourne la définition associée à la clé demandée ou <c>null</c> si elle n'existe pas.
+    /// </summary>
+    public CombatAnimationDefinition GetAnimationOrDefault(CombatAnimationKey key)
+    {
+        TryGetAnimation(key, out var def);
+        return def;
+    }
+
+    [Serializable]
+    public struct CombatAnimationSlot
+    {
+        [Tooltip("Identifiant logique de l'animation.")]
+        public CombatAnimationKey key;
+
+        [Tooltip("Données décrivant l'animation à lancer (state Animator, paramètres et fallback Timeline).")]
+        public CombatAnimationDefinition definition;
+    }
+}
+
+/// <summary>
+/// Liste des animations supportées par l'Animator de combat.
+/// </summary>
+public enum CombatAnimationKey
+{
+    None = 0,
+    Idle,
+    IdleVariantA,
+    IdleVariantB,
+    MoveBlendTree,
+    ApproachBlendTree,
+    RetreatBlendTree,
+    GuardHold,
+    PrepareHit,
+    Defend,
+    AimSkill,
+    AimItem,
+    SkillUseDynamic,
+    ItemUseDynamic,
+    AttackChainA_Light,
+    AttackChainA_Heavy,
+    AttackChainA_Thrust,
+    AttackChainA_Cleave,
+    AttackProjectile_Start,
+    AttackChainB_Light,
+    AttackChainB_Heavy,
+    AttackChainB_Finisher,
+    AttackProjectile_Release,
+    CastLow,
+    CastMid,
+    CastMax,
+    EvadeForward,
+    EvadeBackward,
+    EvadeLeft,
+    EvadeRight,
+    HitFront,
+    HitBack,
+    HitLeft,
+    HitRight,
+    Knockdown,
+    GetUp,
+    Death,
+    Turn90Left,
+    Turn90Right,
+    Turn180,
+    EnterCombat,
+    BattlePose,
+    ItemUseStatic,
+}
+
+/// <summary>
+/// Paramétrage détaillé d'une animation de combat.
+/// </summary>
+[Serializable]
+public class CombatAnimationDefinition
+{
+    [Tooltip("Nom du state Animator à jouer (chemin complet si contenu dans un sous-state machine).")]
+    public string animatorStateName;
+
+    [Tooltip("Index de layer Animator sur lequel l'état est déclaré (0 = base layer).")]
+    public int layerIndex = 0;
+
+    [Tooltip("Durée du crossfade appliqué lors de la transition vers cet état.")]
+    public float crossFadeDuration = 0.08f;
+
+    [Tooltip("Forcer l'utilisation de la Timeline fournie même si un state Animator est renseigné.")]
+    public bool useTimelineByDefault = false;
+
+    [Tooltip("Timeline alternative à jouer lorsque l'Animator ne dispose pas de l'état demandé.")]
+    public TimelineAsset timeline;
+
+    [Tooltip("Liste des paramètres Animator à appliquer avant de lancer le state.")]
+    public AnimatorParameterOverride[] parameterOverrides = Array.Empty<AnimatorParameterOverride>();
+}
+
+/// <summary>
+/// Type de paramètre Animator supporté par les overrides.
+/// </summary>
+public enum AnimatorParameterType
+{
+    Float,
+    Int,
+    Bool,
+    Trigger,
+}
+
+/// <summary>
+/// Valeur à appliquer sur un paramètre Animator avant de déclencher l'animation.
+/// </summary>
+[Serializable]
+public class AnimatorParameterOverride
+{
+    [Tooltip("Nom exact du paramètre Animator à modifier.")]
+    public string parameterName;
+
+    [Tooltip("Type de paramètre (Float, Int, Bool ou Trigger).")]
+    public AnimatorParameterType parameterType = AnimatorParameterType.Float;
+
+    [Tooltip("Valeur flottante à appliquer lorsque le type est Float.")]
+    public float floatValue;
+
+    [Tooltip("Valeur entière utilisée pour les paramètres Int.")]
+    public int intValue;
+
+    [Tooltip("Valeur booléenne pour les paramètres Bool.")]
+    public bool boolValue;
 }

--- a/Assets/Scripts/ScriptableObjets/Lucian_Animations_Battle.asset
+++ b/Assets/Scripts/ScriptableObjets/Lucian_Animations_Battle.asset
@@ -12,44 +12,435 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b4cb36825df6514c895d5bb3891965c, type: 3}
   m_Name: Lucian_Animations_Battle
   m_EditorClassIdentifier: Assembly-CSharp::CombatAnimationGroups
-  idleVariations:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  strafeL: {fileID: 0}
-  strafeR: {fileID: 0}
-  forwardShuffle: {fileID: 0}
-  backShuffle: {fileID: 0}
-  walkApproach: {fileID: 0}
-  runApproach: {fileID: 0}
-  shortLunge: {fileID: 0}
-  walkRetreat: {fileID: 0}
-  runRetreat: {fileID: 0}
-  shortRetreatLunge: {fileID: 0}
-  hitF_small: {fileID: 0}
-  hitB_small: {fileID: 0}
-  hitL_small: {fileID: 0}
-  hitR_small: {fileID: 0}
-  evadeF: {fileID: 0}
-  evadeB: {fileID: 0}
-  evadeL: {fileID: 0}
-  evadeR: {fileID: 0}
-  castLow: {fileID: 0}
-  castMid: {fileID: 0}
-  castMax: {fileID: 0}
-  itemUse: {fileID: 0}
-  atk_light_A: {fileID: 0}
-  atk_heavy_A: {fileID: 0}
-  atk_thrust_A: {fileID: 0}
-  atk_cleave_A: {fileID: 0}
-  atk_projectile_start: {fileID: 0}
-  atk_light_B: {fileID: 0}
-  atk_heavy_B: {fileID: 0}
-  atk_finisher_B: {fileID: 0}
-  atk_projectile_release: {fileID: 0}
-  knockdown: {fileID: 0}
-  getUp: {fileID: 0}
-  death: {fileID: 0}
-  turn90L: {fileID: 0}
-  turn90R: {fileID: 0}
-  turn180: {fileID: 0}
+  animations:
+  - key: 1
+    definition:
+      animatorStateName: Idle_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: IdleVar
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 2
+    definition:
+      animatorStateName: Idle_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: IdleVar
+        parameterType: 0
+        floatValue: 0.5
+        intValue: 0
+        boolValue: 0
+  - key: 3
+    definition:
+      animatorStateName: Idle_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: IdleVar
+        parameterType: 0
+        floatValue: 1
+        intValue: 0
+        boolValue: 0
+  - key: 4
+    definition:
+      animatorStateName: Move_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: SpeedX
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+      - parameterName: SpeedY
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 5
+    definition:
+      animatorStateName: Approach_BT
+      layerIndex: 0
+      crossFadeDuration: 0.1
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: DistanceNorm
+        parameterType: 0
+        floatValue: 1
+        intValue: 0
+        boolValue: 0
+  - key: 6
+    definition:
+      animatorStateName: Retreat_BT
+      layerIndex: 0
+      crossFadeDuration: 0.1
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: DistanceNorm
+        parameterType: 0
+        floatValue: 0.5
+        intValue: 0
+        boolValue: 0
+  - key: 7
+    definition:
+      animatorStateName: GuardHold
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 8
+    definition:
+      animatorStateName: PrepareHit
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 9
+    definition:
+      animatorStateName: Defend
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 10
+    definition:
+      animatorStateName: Aim_Skill
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 11
+    definition:
+      animatorStateName: Aim_Item
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 12
+    definition:
+      animatorStateName: Skill_Use_Dynamic
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 13
+    definition:
+      animatorStateName: Item_Use_Dynamic
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 14
+    definition:
+      animatorStateName: Attack_BT_A
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 15
+    definition:
+      animatorStateName: Attack_BT_A
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 0.33
+        intValue: 0
+        boolValue: 0
+  - key: 16
+    definition:
+      animatorStateName: Attack_BT_A
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 0.66
+        intValue: 0
+        boolValue: 0
+  - key: 17
+    definition:
+      animatorStateName: Attack_BT_A
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 1
+        intValue: 0
+        boolValue: 0
+  - key: 19
+    definition:
+      animatorStateName: Attack_BT_B
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 20
+    definition:
+      animatorStateName: Attack_BT_B
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 0.5
+        intValue: 0
+        boolValue: 0
+  - key: 21
+    definition:
+      animatorStateName: Attack_BT_B
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: AttackStyle
+        parameterType: 0
+        floatValue: 1
+        intValue: 0
+        boolValue: 0
+  - key: 23
+    definition:
+      animatorStateName: Cast_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: CastIntensity
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 24
+    definition:
+      animatorStateName: Cast_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: CastIntensity
+        parameterType: 0
+        floatValue: 0.5
+        intValue: 0
+        boolValue: 0
+  - key: 25
+    definition:
+      animatorStateName: Cast_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: CastIntensity
+        parameterType: 0
+        floatValue: 1
+        intValue: 0
+        boolValue: 0
+  - key: 26
+    definition:
+      animatorStateName: Evade_F
+      layerIndex: 0
+      crossFadeDuration: 0.05
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 27
+    definition:
+      animatorStateName: Evade_B
+      layerIndex: 0
+      crossFadeDuration: 0.05
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 28
+    definition:
+      animatorStateName: Evade_L
+      layerIndex: 0
+      crossFadeDuration: 0.05
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 29
+    definition:
+      animatorStateName: Evade_R
+      layerIndex: 0
+      crossFadeDuration: 0.05
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 30
+    definition:
+      animatorStateName: HitReact_BT
+      layerIndex: 0
+      crossFadeDuration: 0.06
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: HitAngle
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+      - parameterName: HitAngleY
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 31
+    definition:
+      animatorStateName: HitReact_BT
+      layerIndex: 0
+      crossFadeDuration: 0.06
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: HitAngle
+        parameterType: 0
+        floatValue: 180
+        intValue: 0
+        boolValue: 0
+      - parameterName: HitAngleY
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 32
+    definition:
+      animatorStateName: HitReact_BT
+      layerIndex: 0
+      crossFadeDuration: 0.06
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: HitAngle
+        parameterType: 0
+        floatValue: -90
+        intValue: 0
+        boolValue: 0
+      - parameterName: HitAngleY
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 33
+    definition:
+      animatorStateName: HitReact_BT
+      layerIndex: 0
+      crossFadeDuration: 0.06
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: HitAngle
+        parameterType: 0
+        floatValue: 90
+        intValue: 0
+        boolValue: 0
+      - parameterName: HitAngleY
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 34
+    definition:
+      animatorStateName: Knockdown
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 35
+    definition:
+      animatorStateName: GetUp
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 36
+    definition:
+      animatorStateName: Death
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 40
+    definition:
+      animatorStateName: EnterCombat
+      layerIndex: 0
+      crossFadeDuration: 0.12
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []
+  - key: 41
+    definition:
+      animatorStateName: BattlePose_BT
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides:
+      - parameterName: BattleState
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+      - parameterName: Speed
+        parameterType: 0
+        floatValue: 0
+        intValue: 0
+        boolValue: 0
+  - key: 42
+    definition:
+      animatorStateName: ItemUse
+      layerIndex: 0
+      crossFadeDuration: 0.08
+      useTimelineByDefault: 0
+      timeline: {fileID: 0}
+      parameterOverrides: []


### PR DESCRIPTION
## Résumé
- centralisation des animations de combat dans un ScriptableObject structuré avec des clés explicites
- ajout de clés Animator sur les MusicalMoves et Items puis exploitation de ces clés côté CharacterUnit et RhythmQTEManager
- mise à jour du set Lucian_Animations_Battle et liaison dans Character_Lucian pour piloter l'Animator "Lucian_Human_Battle"

## Tests
- non réalisés (exécution Unity indisponible dans l’environnement courant)


------
https://chatgpt.com/codex/tasks/task_e_690a7caa52a08325bdcfbb56209a4cff