### PR TITLE
Fix ShaderGraph meta GUID to resolve HDRP render errors

### DIFF
--- a/Assets/Shaders/ShaderGraph_Symphonie_Unit_Toys.shadergraph.meta
+++ b/Assets/Shaders/ShaderGraph_Symphonie_Unit_Toys.shadergraph.meta
@@ -1,9 +1,10 @@
 fileFormatVersion: 2
-guid: f703a1da-845b-408b-a86c-bc67eaf72d4d
+guid: f703a1da845b408ba86cbc67eaf72d4d
 ScriptedImporter:
   internalIDToNameTable: []
   externalObjects: {}
   serializedVersion: 2
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}


### PR DESCRIPTION
## Summary
- corrige le GUID du fichier ShaderGraph_Symphonie_Unit_Toys.shadergraph.meta pour qu'il respecte le format Unity
- rétablit la référence vers l'importer ShaderGraph afin que l'actif soit correctement chargé par l'éditeur

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690b8aab1cf0832599fb8419c53b4f40