### PR TITLE
Fix: sortie écran victoire et remise à zéro du dissolve

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/BattleTransitionManager.cs
@@ -13,6 +13,11 @@ public class BattleTransitionManager : MonoBehaviour
 
     private PlayerDetection playerDetection;
 
+    /// <summary>
+    /// Identifiant shader mis en cache pour remettre à zéro les dissolves appliqués via MaterialPropertyBlock.
+    /// </summary>
+    private static readonly int DissolveStrengthId = Shader.PropertyToID("_DissolveStrength");
+
     [Header("Ressources Visuals")]
     [SerializeField] private Image worldFadeOverlay;
     [SerializeField] private ParticleSystem maskRingParticles;
@@ -587,6 +592,9 @@ public class BattleTransitionManager : MonoBehaviour
             maskRingParticles.Play();
         }
 
+        // Réinitialise les effets de dissolve ayant pu rester figés après le combat
+        ResetDissolveShaderValues();
+
         HideVictoryPanel();
         HideGameOverPanel();
 
@@ -722,6 +730,46 @@ public class BattleTransitionManager : MonoBehaviour
 
         Time.timeScale = to;
         Time.fixedDeltaTime = 0.02f;
+    }
+
+    /// <summary>
+    /// Parcourt tous les renderers présents dans la scène afin de remettre à zéro la propriété
+    /// de dissolve utilisée durant les transitions de combat. Sans cette étape, certains éléments
+    /// restaient visuellement désintégrés après le retour à l'exploration.
+    /// </summary>
+    private void ResetDissolveShaderValues()
+    {
+        // Inclut les renderers inactifs car certains décors peuvent être masqués pendant le combat
+        Renderer[] renderers = FindObjectsOfType<Renderer>(true);
+        var propertyBlock = new MaterialPropertyBlock();
+
+        foreach (Renderer renderer in renderers)
+        {
+            if (renderer == null)
+                continue;
+
+            Material[] materials = renderer.sharedMaterials;
+            if (materials == null || materials.Length == 0)
+                continue;
+
+            for (int i = 0; i < materials.Length; i++)
+            {
+                Material material = materials[i];
+                bool materialSupportsDissolve = material != null && material.HasProperty(DissolveStrengthId);
+
+                // On récupère la valeur courante stockée dans le MaterialPropertyBlock
+                propertyBlock.Clear();
+                renderer.GetPropertyBlock(propertyBlock, i);
+                float currentBlockValue = propertyBlock.GetFloat(DissolveStrengthId);
+
+                if (!materialSupportsDissolve && Mathf.Approximately(currentBlockValue, 0f))
+                    continue; // Rien à réinitialiser sur ce sous-matériau
+
+                // Remet à zéro le MPB (et donc la valeur effective affichée par le renderer)
+                propertyBlock.SetFloat(DissolveStrengthId, 0f);
+                renderer.SetPropertyBlock(propertyBlock, i);
+            }
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -377,19 +377,24 @@ public class InputsManager : MonoBehaviour
     /// </summary>
     private void OnConfirm(InputAction.CallbackContext ctx)
     {
+        // Tant que la BattleIntro est active, on ne valide aucune action de menu pour éviter les chevauchements.
+        if (!TryGetBattleManagerWhileMenusUnlocked(out NewBattleManager bm))
+            return;
+
+        bool isVictoryOrGameOverScreen = bm.currentBattleState == BattleState.VictoryScreen_CanContinue
+            || bm.currentBattleState == BattleState.GameOverScreen_CanContinue;
+
         // Si une sélection vient juste d'être effectuée, on ignore cette validation
         // pour éviter d'exécuter immédiatement le mouvement sans choix de cible.
-        if (ignorerProchaineValidation)
+        // On autorise néanmoins la validation lorsqu'on se trouve sur l'écran de victoire/game over
+        // afin de ne jamais bloquer le joueur sur ce panneau.
+        if (!isVictoryOrGameOverScreen && ignorerProchaineValidation)
         {
             // Le joueur vient de sélectionner une compétence ou un objet
             // avec la même touche que la validation. On ignore donc toute
             // tentative de confirmation tant que la touche n'a pas été relâchée.
             return;
         }
-
-        // Tant que la BattleIntro est active, on ne valide aucune action de menu pour éviter les chevauchements.
-        if (!TryGetBattleManagerWhileMenusUnlocked(out NewBattleManager bm))
-            return;
 
         if (bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongEnemiesForSkill
             || bm.currentBattleState == BattleState.SquadUnit_TargetSelectionAmongSquadForSkill
@@ -459,8 +464,7 @@ public class InputsManager : MonoBehaviour
             bm.ToggleMenuContainers(false, false, false);
         }
 
-        if (bm.currentBattleState == BattleState.VictoryScreen_CanContinue ||
-            bm.currentBattleState == BattleState.GameOverScreen_CanContinue)
+        if (isVictoryOrGameOverScreen)
         {
             bm.ChangeBattleState(BattleState.None);
             BattleTransitionManager.Instance.StartCoroutine(

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -10,6 +10,7 @@ using TMPro;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
 using Unity.Cinemachine;
+using UnityEngine.EventSystems;
 
 #region TargetType
 public enum TargetType
@@ -2336,11 +2337,50 @@ public class NewBattleManager : MonoBehaviour
 
         GameObject continueButton = FindChildRecursive(victoryScreen.transform.GetChild(0), "BattleScene_UI_VictoryPanel_Continue").gameObject;
 
+        // ➡️ Branche un listener explicite sur le bouton Continue pour permettre la sortie via la souris/manette
+        if (continueButton != null)
+        {
+            Button uiButton = continueButton.GetComponent<Button>();
+            if (uiButton != null)
+            {
+                // On s'assure de ne pas empiler les callbacks si le panneau est affiché plusieurs fois d'affilée
+                uiButton.onClick.RemoveListener(HandleVictoryContinueRequested);
+                uiButton.onClick.AddListener(HandleVictoryContinueRequested);
+            }
+
+            // Sélectionne le bouton dans l'EventSystem afin que la manette/le clavier puisse valider immédiatement
+            if (EventSystem.current != null)
+            {
+                EventSystem.current.SetSelectedGameObject(continueButton);
+            }
+        }
+
         // Les unités restent désormais en place durant l'écran de victoire afin
         // que le joueur puisse admirer le champ de bataille tel qu'il était au
         // moment de la victoire. Leur suppression se fera plus tard, au retour
         // dans le monde.
         ChangeBattleState(BattleState.VictoryScreen_CanContinue);
+    }
+
+    /// <summary>
+    /// Callback déclenché par le bouton "Continuer" de l'écran de victoire.
+    /// Permet d'appliquer exactement la même logique que la touche de validation.
+    /// </summary>
+    private void HandleVictoryContinueRequested()
+    {
+        // Évite les validations intempestives si l'état du combat n'est pas prêt.
+        if (currentBattleState != BattleState.VictoryScreen_CanContinue
+            && currentBattleState != BattleState.GameOverScreen_CanContinue)
+            return;
+
+        ChangeBattleState(BattleState.None);
+
+        // Lancement sécurisé de la transition de sortie de combat
+        if (BattleTransitionManager.Instance != null)
+        {
+            BattleTransitionManager.Instance.StartCoroutine(
+                BattleTransitionManager.Instance.ExitVictoryScreenAndBattle());
+        }
     }
 
     IEnumerator ShowGameOverPanel()


### PR DESCRIPTION
## Summary
- permet au bouton Continuer de déclencher la sortie d'un combat et sélectionne automatiquement ce bouton
- autorise la validation de l'écran de victoire même si la confirmation précédente a été ignorée
- réinitialise les valeurs de dissolve après un combat pour éviter les matériaux figés à 1

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_690bbffc8c78832589b6b31b7f7a384e