### PR TITLE
Corrige la fermeture de l'écran de victoire et l'animation Pulse

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -2362,11 +2362,21 @@ public class NewBattleManager : MonoBehaviour
             Debug.LogWarning("Pas de RawImage sur le VictoryScreen child(0)");
         }
 
-        GameObject continueButton = FindChildRecursive(victoryScreen.transform.GetChild(0), "BattleScene_UI_VictoryPanel_Continue").gameObject;
+        Transform continueButtonTransform = FindChildRecursive(victoryScreen.transform.GetChild(0), "BattleScene_UI_VictoryPanel_Continue");
 
-        // ➡️ Branche un listener explicite sur le bouton Continue pour permettre la sortie via la souris/manette
-        if (continueButton != null)
+        if (continueButtonTransform == null)
         {
+            // Avertit immédiatement si la hiérarchie UI ne contient plus le bouton attendu :
+            // sans cette vérification, un NullReferenceException interrompait la coroutine et
+            // empêchait la transition vers l'état VictoryScreen_CanContinue, bloquant ainsi
+            // la touche Confirm.
+            Debug.LogWarning("[BattleTurnManager] Bouton 'Continue' introuvable dans le panneau de victoire.");
+        }
+        else
+        {
+            GameObject continueButton = continueButtonTransform.gameObject;
+
+            // ➡️ Branche un listener explicite sur le bouton Continue pour permettre la sortie via la souris/manette
             Button uiButton = continueButton.GetComponent<Button>();
             if (uiButton != null)
             {

--- a/Assets/Scripts/MonoBehavioursUsed/Pulse.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/Pulse.cs
@@ -13,6 +13,8 @@ public class Pulse : MonoBehaviour
 
     [Header("Options")]
     public bool autoCaptureBaseScaleInEditor = true; // recalcule la base si tu modifies la scale à la main
+    [Tooltip("Force l'utilisation du temps non-scalé même en dehors de l'UI.")]
+    [SerializeField] private bool forceUnscaledTime = false;
 
     private Vector3 baseScale;
 
@@ -24,6 +26,12 @@ public class Pulse : MonoBehaviour
     private Color baseColor = Color.white;
     private bool hasColorProperty = false;
     private static readonly int ColorID = Shader.PropertyToID("_Color");
+    /// <summary>
+    /// Indique si le script doit se baser sur Time.unscaledTime. Cette valeur est
+    /// forcée à true pour les éléments d'UI afin qu'ils continuent d'animer même
+    /// lorsque Time.timeScale tombe à 0 (cas de l'écran de victoire par exemple).
+    /// </summary>
+    private bool useUnscaledTime = false;
 
     void Awake()
     {
@@ -47,6 +55,11 @@ public class Pulse : MonoBehaviour
         canvasGroup = GetComponent<CanvasGroup>();
         genericRenderer = GetComponent<Renderer>();
 
+        // Le choix du temps utilisé est initialisé à partir du paramètre exposé
+        // dans l'inspecteur. Cela permet de forcer un comportement spécifique
+        // pour des effets hors UI si nécessaire.
+        useUnscaledTime = forceUnscaledTime;
+
         if (genericRenderer != null)
         {
             // Prépare MPB et détecte la propriété _Color sans toucher au matériau partagé
@@ -67,10 +80,9 @@ public class Pulse : MonoBehaviour
         }
         else if (canvasGroup != null)
         {
-        // Les CanvasGroup doivent pulser mme lorsque Time.timeScale est nul :
-        // on bascule donc automatiquement sur Time.unscaledTime lorsqu'un lment UI est dtect.
-        float timeSource = canvasGroup != null ? Time.unscaledTime : Time.time;
-        float t = (Mathf.Sin(timeSource * pulseSpeed) + 1f) * 0.5f;
+            // Les CanvasGroup appartiennent à l'UI : on bascule automatiquement sur
+            // Time.unscaledTime pour que l'animation reste active même durant une pause.
+            useUnscaledTime = true;
             hasColorProperty = true;
         }
     }
@@ -92,8 +104,10 @@ public class Pulse : MonoBehaviour
         if (baseScale == Vector3.zero)
             baseScale = transform.localScale;
 
+        // Sélection du temps de référence : non-scalé pour l'UI/pause, sinon temps classique.
+        float timeSource = useUnscaledTime ? Time.unscaledTime : Time.time;
         // t va de 0 (min) à 1 (max)
-        float t = (Mathf.Sin(Time.time * pulseSpeed) + 1f) * 0.5f;
+        float t = (Mathf.Sin(timeSource * pulseSpeed) + 1f) * 0.5f;
         float scaleFactor = Mathf.Lerp(1f - pulseAmount, 1f + pulseAmount, t);
         transform.localScale = baseScale * scaleFactor;
 


### PR DESCRIPTION
## Résumé
- sécurise la recherche du bouton « Continuer » afin de ne plus interrompre l'affichage de l'écran de victoire et de permettre à Confirm de quitter correctement le combat
- alimente l'effet Pulse via le temps non-scalé pour les éléments d'UI (avec option de forcer ce mode) afin que l'animation reste active pendant les pauses

## Tests
- Aucun test automatisé disponible dans l'environnement


------
https://chatgpt.com/codex/tasks/task_e_690c5af42f20832598d5e9751d84bf20