### PR TITLE
Externalisation de la gestion des effets d'état

### DIFF
--- a/Assets/Scripts/Classes/ItemData.cs
+++ b/Assets/Scripts/Classes/ItemData.cs
@@ -251,13 +251,13 @@ public class ItemData : ScriptableObject
 
     private void ApplyBuff(CharacterUnit target)
     {
-        InventoryManager.Instance?.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
+        CharacterStatusEffectController.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
     }
 
     private void ApplyDebuff(CharacterUnit target)
     {
         // Utilise les champs dédiés aux débuffs pour éviter toute confusion
-        InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
+        CharacterStatusEffectController.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
     }
 
     private void ApplyDamage(CharacterUnit caster, CharacterUnit target, float value)
@@ -280,22 +280,22 @@ public class ItemData : ScriptableObject
 
     private void ApplyInterceptionImmunity(CharacterUnit target)
     {
-        InventoryManager.Instance?.ApplyInterceptionImmunity(target, Mathf.RoundToInt(buffDuration));
+        CharacterStatusEffectController.ApplyInterceptionImmunity(target, Mathf.RoundToInt(buffDuration));
     }
 
     private void ApplyExtendEffects(CharacterUnit target)
     {
-        InventoryManager.Instance?.ExtendEffectDurations(target, Mathf.RoundToInt(buffDuration));
+        CharacterStatusEffectController.ExtendEffectDurations(target, buffDuration);
     }
 
     private void ApplySleep(CharacterUnit target)
     {
-        InventoryManager.Instance?.ApplySleep(target);
+        CharacterStatusEffectController.ApplySleep(target);
     }
 
     private void ApplyWakeUp(CharacterUnit target)
     {
-        InventoryManager.Instance?.RemoveSleep(target);
+        CharacterStatusEffectController.RemoveSleep(target);
     }
 }
 

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -339,21 +339,21 @@ public class MusicalMoveSO : ScriptableObject
         {
             // Les buffs intrinsèques sont gérés via l'InventoryManager pour
             // conserver une logique unique entre les Items et les MusicalMoves.
-            InventoryManager.Instance?.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
+            CharacterStatusEffectController.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
         }
         else if (typeToUse == MusicalEffectType.Debuff)
         {
-            InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
+            CharacterStatusEffectController.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
         }
         else if (typeToUse == MusicalEffectType.Sleep)
         {
-            InventoryManager.Instance?.ApplySleep(target);
+            CharacterStatusEffectController.ApplySleep(target);
         }
         else if (typeToUse == MusicalEffectType.WakeUpAll)
         {
             foreach (var unit in NewBattleManager.Instance.activeCharacterUnits)
             {
-                InventoryManager.Instance?.RemoveSleep(unit);
+                CharacterStatusEffectController.RemoveSleep(unit);
             }
         }
         else if (typeToUse == MusicalEffectType.LoyaltyMark)
@@ -389,12 +389,12 @@ public class MusicalMoveSO : ScriptableObject
         // Applique ensuite les éventuels effets secondaires définis plus haut.
         if (buffStat != BuffStatType.None && typeToUse != MusicalEffectType.Buff)
         {
-            InventoryManager.Instance?.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
+            CharacterStatusEffectController.ApplyBuff(target, buffStat, buffAmount, buffDuration, buffIsPercentage);
         }
 
         if (debuffStat != DebuffStatType.None && typeToUse != MusicalEffectType.Debuff)
         {
-            InventoryManager.Instance?.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
+            CharacterStatusEffectController.ApplyDebuff(target, debuffStat, debuffAmount, debuffDuration, debuffIsPercentage);
         }
     }
 }

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterStatusEffectController.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterStatusEffectController.cs
@@ -1,0 +1,285 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Centralise la gestion des effets temporaires appliqués à une <see cref="CharacterUnit"/>.
+/// L'objectif est de sortir cette responsabilité de l'InventoryManager afin de rendre
+/// le code plus modulaire : tout système (Items, MusicalMoves, scripts narratifs...)
+/// peut désormais appliquer un buff ou un débuff sans connaître la structure interne
+/// de l'inventaire. Le composant se charge également de remettre l'unité dans son état
+/// initial lorsque l'effet arrive à expiration ou que l'objet est désactivé.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(CharacterUnit))]
+public class CharacterStatusEffectController : MonoBehaviour
+{
+    /// <summary>
+    /// Représente un modificateur actif (buff ou débuff).
+    /// Chaque entrée conserve la valeur appliquée ainsi que la durée restante.
+    /// Lorsque le compteur arrive à zéro, la valeur est automatiquement retirée
+    /// et l'entrée supprimée.
+    /// </summary>
+    private sealed class ActiveModifier
+    {
+        public BuffStatType stat;
+        public float value;
+        public float remainingDuration;
+        public bool isInfinite;
+        public Coroutine routine;
+    }
+
+    private CharacterUnit owner;
+
+    /// <summary>
+    /// Liste des modificateurs actuellement appliqués à l'unité.
+    /// L'utilisation d'une liste (plutôt qu'un simple dictionnaire par statistique)
+    /// permet de conserver plusieurs buffs cumulés avec des durées différentes.
+    /// </summary>
+    private readonly List<ActiveModifier> activeModifiers = new();
+
+    /// <summary>
+    /// Fournit un accès paresseux au composant, en créant automatiquement
+    /// une instance lorsque l'unité ciblée n'en possède pas encore.
+    /// </summary>
+    public static CharacterStatusEffectController GetOrCreate(CharacterUnit unit)
+    {
+        if (unit == null)
+            return null;
+
+        if (!unit.TryGetComponent(out CharacterStatusEffectController controller))
+            controller = unit.gameObject.AddComponent<CharacterStatusEffectController>();
+
+        return controller;
+    }
+
+    #region Cycle de vie
+
+    private void Awake()
+    {
+        owner = GetComponent<CharacterUnit>();
+    }
+
+    private void OnDisable()
+    {
+        // Lorsqu'une unité sort de la scène, on réinitialise proprement les effets.
+        ResetAllModifiers();
+    }
+
+    private void OnDestroy()
+    {
+        ResetAllModifiers();
+    }
+
+    #endregion
+
+    #region API statique conviviale
+
+    public static void ApplyBuff(CharacterUnit target, BuffStatType stat, int amount, float duration, bool isPercentage)
+    {
+        GetOrCreate(target)?.ApplyBuffInternal(stat, amount, duration, isPercentage);
+    }
+
+    public static void ApplyDebuff(CharacterUnit target, DebuffStatType stat, int amount, float duration, bool isPercentage)
+    {
+        GetOrCreate(target)?.ApplyDebuffInternal(stat, amount, duration, isPercentage);
+    }
+
+    public static void ApplyInterceptionImmunity(CharacterUnit target, int turns)
+    {
+        GetOrCreate(target)?.ApplyInterceptionImmunityInternal(turns);
+    }
+
+    public static void ExtendEffectDurations(CharacterUnit target, float additionalDuration)
+    {
+        GetOrCreate(target)?.ExtendEffectDurationsInternal(additionalDuration);
+    }
+
+    public static void ApplySleep(CharacterUnit target)
+    {
+        GetOrCreate(target)?.ApplySleepInternal();
+    }
+
+    public static void RemoveSleep(CharacterUnit target)
+    {
+        GetOrCreate(target)?.RemoveSleepInternal();
+    }
+
+    #endregion
+
+    #region Méthodes d'instance
+
+    private void ApplyBuffInternal(BuffStatType stat, int amount, float duration, bool isPercentage)
+    {
+        if (owner == null || stat == BuffStatType.None || amount == 0)
+            return;
+
+        float baseValue = GetBaseStat(stat);
+        float delta = isPercentage ? baseValue * amount / 100f : amount;
+        ApplyModifier(stat, delta, duration);
+    }
+
+    private void ApplyDebuffInternal(DebuffStatType stat, int amount, float duration, bool isPercentage)
+    {
+        if (owner == null || stat == DebuffStatType.None || amount == 0)
+            return;
+
+        float baseValue = GetBaseStat((BuffStatType)stat);
+        float delta = isPercentage ? baseValue * amount / 100f : amount;
+        // Un débuff est simplement un buff négatif : on applique la valeur inverse.
+        ApplyModifier((BuffStatType)stat, -delta, duration);
+    }
+
+    private void ApplyInterceptionImmunityInternal(int turns)
+    {
+        if (owner == null || turns <= 0)
+            return;
+
+        owner.isInterceptionImmune = true;
+        owner.interceptionImmunityTurns = Mathf.Max(owner.interceptionImmunityTurns, turns);
+    }
+
+    /// <summary>
+    /// Prolonge la durée de tous les effets temporaires appliqués à l'unité.
+    /// Le paramètre est volontairement en <see cref="float"/> afin de gérer
+    /// aussi bien les durées exprimées en secondes que celles assimilées à un
+    /// nombre de tours. Les effets infinis restent inchangés.
+    /// </summary>
+    private void ExtendEffectDurationsInternal(float additionalDuration)
+    {
+        if (additionalDuration <= 0f)
+            return;
+
+        foreach (var modifier in activeModifiers)
+        {
+            if (!modifier.isInfinite)
+                modifier.remainingDuration += additionalDuration;
+        }
+
+        if (owner != null && owner.interceptionImmunityTurns > 0)
+            owner.interceptionImmunityTurns += Mathf.RoundToInt(additionalDuration);
+    }
+
+    private void ApplySleepInternal()
+    {
+        if (owner == null)
+            return;
+
+        var sleep = owner.GetComponent<SleepStatus>();
+        if (sleep == null)
+            sleep = owner.gameObject.AddComponent<SleepStatus>();
+        sleep.Sleep();
+    }
+
+    private void RemoveSleepInternal()
+    {
+        if (owner == null)
+            return;
+
+        var sleep = owner.GetComponent<SleepStatus>();
+        if (sleep != null)
+            sleep.WakeUp();
+    }
+
+    #endregion
+
+    #region Gestion interne des modificateurs
+
+    /// <summary>
+    /// Ajoute un modificateur et applique immédiatement sa valeur. Le retrait
+    /// est assuré soit par la coroutine dédiée, soit par <see cref="ResetAllModifiers"/>.
+    /// </summary>
+    private void ApplyModifier(BuffStatType stat, float value, float duration)
+    {
+        if (Mathf.Approximately(value, 0f))
+            return;
+
+        var modifier = new ActiveModifier
+        {
+            stat = stat,
+            value = value,
+            remainingDuration = Mathf.Max(0f, duration),
+            isInfinite = duration <= 0f
+        };
+
+        activeModifiers.Add(modifier);
+        ModifyStat(stat, value);
+
+        if (!modifier.isInfinite)
+            modifier.routine = StartCoroutine(ModifierLifetime(modifier));
+    }
+
+    private IEnumerator ModifierLifetime(ActiveModifier modifier)
+    {
+        while (modifier.remainingDuration > 0f)
+        {
+            yield return null;
+            modifier.remainingDuration -= Time.deltaTime;
+        }
+
+        FinalizeModifier(modifier);
+    }
+
+    private void FinalizeModifier(ActiveModifier modifier)
+    {
+        ModifyStat(modifier.stat, -modifier.value);
+        if (modifier.routine != null)
+        {
+            StopCoroutine(modifier.routine);
+            modifier.routine = null;
+        }
+
+        activeModifiers.Remove(modifier);
+    }
+
+    private void ResetAllModifiers()
+    {
+        for (int i = activeModifiers.Count - 1; i >= 0; i--)
+        {
+            var modifier = activeModifiers[i];
+            if (modifier.routine != null)
+            {
+                StopCoroutine(modifier.routine);
+                modifier.routine = null;
+            }
+
+            ModifyStat(modifier.stat, -modifier.value);
+            activeModifiers.RemoveAt(i);
+        }
+    }
+
+    private void ModifyStat(BuffStatType stat, float delta)
+    {
+        if (owner == null)
+            return;
+
+        switch (stat)
+        {
+            case BuffStatType.Strength:
+                owner.currentStrength += delta;
+                break;
+            case BuffStatType.Defense:
+                owner.currentDefense += delta;
+                break;
+            case BuffStatType.Initiative:
+                owner.currentInitiative += delta;
+                break;
+        }
+    }
+
+    private float GetBaseStat(BuffStatType stat)
+    {
+        if (owner == null || owner.Data == null)
+            return 0f;
+
+        return stat switch
+        {
+            BuffStatType.Strength => owner.Data.baseStrength,
+            BuffStatType.Defense => owner.Data.baseDefense,
+            BuffStatType.Initiative => owner.Data.baseInitiative,
+            _ => 0f,
+        };
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterStatusEffectController.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterStatusEffectController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7078b287ac24756ae6c907e095bab01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InventoryManager.cs
@@ -51,6 +51,12 @@ public class InventoryManager : MonoBehaviour
     /// </summary>
     public IReadOnlyList<InventoryItemStack> ItemStacks => itemStacks;
 
+    /// <remarks>
+    /// La gestion des buffs, débuffs et autres états temporaires a été extraite dans
+    /// <see cref="CharacterStatusEffectController"/> afin de clarifier les responsabilités.
+    /// Conserver cette classe centrée sur l'inventaire améliore la maintenabilité globale.
+    /// </remarks>
+
     /// <summary>
     /// Coroutine en cours responsable du fondu d'alpha du CanvasGroup.
     /// On la conserve pour éviter d'empiler plusieurs transitions concurrentes.
@@ -157,20 +163,6 @@ public class InventoryManager : MonoBehaviour
     private InputAction inventorySelectSubPanelLeftAction;
     private InputAction inventorySelectSubPanelRightAction;
     private InputAction inventoryNavigateAction;
-
-    // --- Suivi des effets temporaires appliqués aux personnages ---
-    // Pour chaque personnage, on garde la liste des modificateurs actifs afin
-    // de pouvoir prolonger leur durée si nécessaire.
-    private class ActiveStatModifier
-    {
-        public BuffStatType stat;    // Statistique affectée
-        public float value;          // Valeur actuellement appliquée
-        public float remaining;      // Temps restant avant la fin de l'effet
-        public Coroutine routine;    // Coroutine responsable de la durée
-    }
-
-    // Dictionnaire principal : clé = unité concernée, valeur = liste de ses modificateurs
-    private readonly Dictionary<CharacterUnit, List<ActiveStatModifier>> activeModifiers = new();
 
     private void Awake()
     {
@@ -339,149 +331,6 @@ public class InventoryManager : MonoBehaviour
         item.ApplyEffect(null, target, false);
     }
 
-    public void ApplyBuff(CharacterUnit target, BuffStatType stat, int amount, float duration, bool isPercentage)
-    {
-        if (target == null || stat == BuffStatType.None || amount == 0)
-            return;
-
-        float baseValue = GetBaseStat(target, stat);
-        float value = isPercentage ? baseValue * amount / 100f : amount;
-        ApplyStatModifier(target, stat, value, duration);
-    }
-
-    public void ApplyDebuff(CharacterUnit target, DebuffStatType stat, int amount, float duration, bool isPercentage)
-    {
-        if (target == null || stat == DebuffStatType.None || amount == 0)
-            return;
-
-        float baseValue = GetBaseStat(target, (BuffStatType)stat);
-        float value = isPercentage ? baseValue * amount / 100f : amount;
-        ApplyStatModifier(target, (BuffStatType)stat, -value, duration);
-    }
-
-    /// <summary>
-    /// Applique ou prolonge un modificateur de statistique.
-    /// </summary>
-    private void ApplyStatModifier(CharacterUnit target, BuffStatType stat, float value, float duration)
-    {
-        if (!activeModifiers.TryGetValue(target, out var list))
-        {
-            list = new List<ActiveStatModifier>();
-            activeModifiers[target] = list;
-        }
-
-        var modifier = list.Find(m => m.stat == stat);
-        if (modifier != null)
-        {
-            // Si un modificateur existe déjà, on cumule la valeur et on prolonge sa durée
-            ModifyStat(target, stat, value);
-            modifier.value += value;
-            modifier.remaining += duration;
-        }
-        else
-        {
-            modifier = new ActiveStatModifier
-            {
-                stat = stat,
-                value = value,
-                remaining = duration
-            };
-            ModifyStat(target, stat, value);
-            modifier.routine = StartCoroutine(StatModifierRoutine(target, modifier));
-            list.Add(modifier);
-        }
-    }
-
-    /// <summary>
-    /// Coroutine gérant la durée d'un modificateur.
-    /// </summary>
-    private IEnumerator StatModifierRoutine(CharacterUnit target, ActiveStatModifier modifier)
-    {
-        while (modifier.remaining > 0f)
-        {
-            yield return null;
-            modifier.remaining -= Time.deltaTime;
-        }
-        ModifyStat(target, modifier.stat, -modifier.value);
-        activeModifiers[target].Remove(modifier);
-    }
-
-    private void ModifyStat(CharacterUnit target, BuffStatType stat, float delta)
-    {
-        switch (stat)
-        {
-            case BuffStatType.Strength:
-                target.currentStrength += delta;
-                break;
-            case BuffStatType.Defense:
-                target.currentDefense += delta;
-                break;
-            case BuffStatType.Initiative:
-                target.currentInitiative += delta;
-                break;
-        }
-    }
-
-    private float GetBaseStat(CharacterUnit target, BuffStatType stat)
-    {
-        return stat switch
-        {
-            BuffStatType.Strength => target.Data.baseStrength,
-            BuffStatType.Defense => target.Data.baseDefense,
-            BuffStatType.Initiative => target.Data.baseInitiative,
-            _ => 0f,
-        };
-    }
-
-    public void ApplyInterceptionImmunity(CharacterUnit target, int turns)
-    {
-        if (target == null)
-            return;
-        target.isInterceptionImmune = true;
-        target.interceptionImmunityTurns = Mathf.Max(target.interceptionImmunityTurns, turns);
-    }
-
-    /// <summary>
-    /// Prolonge la durée de tous les effets temporaires actuellement actifs sur la cible.
-    /// </summary>
-    public void ExtendEffectDurations(CharacterUnit target, int additionalTurns)
-    {
-        if (target == null || additionalTurns <= 0)
-            return;
-
-        // Prolonge l'immunité à l'interception si présente
-        if (target.interceptionImmunityTurns > 0)
-            target.interceptionImmunityTurns += additionalTurns;
-
-        // Prolonge également tous les buffs/debuffs suivis pour cette unité
-        if (activeModifiers.TryGetValue(target, out var list))
-        {
-            foreach (var modifier in list)
-            {
-                modifier.remaining += additionalTurns;
-            }
-        }
-    }
-
-    public void ApplySleep(CharacterUnit target)
-    {
-        if (target == null)
-            return;
-        var sleep = target.GetComponent<SleepStatus>();
-        if (sleep == null)
-            sleep = target.gameObject.AddComponent<SleepStatus>();
-        sleep.Sleep();
-    }
-
-    public void RemoveSleep(CharacterUnit target)
-    {
-        if (target == null)
-            return;
-        var sleep = target.GetComponent<SleepStatus>();
-        if (sleep != null)
-            sleep.WakeUp();
-    }
-
     // ------------------------------------------------------------------
     // Gestion des limitations d'utilisation des items
     // ------------------------------------------------------------------
@@ -512,11 +361,11 @@ public class InventoryManager : MonoBehaviour
         if (!consumed && item.consumeOnUse)
             return;
 
-            if (item.consumeOnUse && stack.quantity <= 0)
-            {
-                itemStacks.Remove(stack);
-                stackLookup.Remove(item);
-            }
+        if (item.consumeOnUse && stack.quantity <= 0)
+        {
+            itemStacks.Remove(stack);
+            stackLookup.Remove(item);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Résumé
- introduit `CharacterStatusEffectController` pour centraliser les buffs, débuffs et états spéciaux des unités
- débranche l'`InventoryManager` de la logique d'effets et met à jour Items et MusicalMoves vers la nouvelle API

## Tests
- Aucun test automatisé exécuté (projet Unity)


------
https://chatgpt.com/codex/tasks/task_e_690c77a69e74832581ce71f67155306c