### PR TITLE
Ajouter le visuel et l'audio pour la marque de loyauté

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -32,6 +32,8 @@ MonoBehaviour:
   power: 0
   effectType: 6
   effectValue: 0
+  loyaltyMarkPrefab: {fileID: 5087381848559928121, guid: 4ef3f6c7c5cc40a0bece206e5af9f25b, type: 3}
+  loyaltyMarkVerticalOffset: 0.6
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/Prefabs/LoyaltyMark.prefab
+++ b/Assets/Prefabs/LoyaltyMark.prefab
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5087381848559928121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1962749814377063527}
+  - component: {fileID: 296447642024378930}
+  m_Layer: 0
+  m_Name: LoyaltyMark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1962749814377063527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5087381848559928121}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &296447642024378930
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5087381848559928121}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 550
+  m_Sprite: {fileID: 21300000, guid: 9e98874fe30530a4eb450b2197212327, type: 3}
+  m_Color: {r: 0.9764706, g: 0.8862745, b: 0.29411766, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/LoyaltyMark.prefab.meta
+++ b/Assets/Prefabs/LoyaltyMark.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4ef3f6c7c5cc40a0bece206e5af9f25b
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -70,6 +70,12 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Valeur numérique associée à l'effet principal.")]
     public int effectValue = 10;
 
+    [Header("Effets spécifiques")]
+    [Tooltip("Prefab instancié au-dessus de la cible lorsqu'une LoyaltyMark est appliquée.")]
+    public GameObject loyaltyMarkPrefab;
+    [Tooltip("Décalage vertical supplémentaire pour positionner le prefab de LoyaltyMark.")]
+    public float loyaltyMarkVerticalOffset = 0.5f;
+
     // ------------------------------------------------------------------
     // Buffs et débuffs supplémentaires
     // ------------------------------------------------------------------
@@ -361,7 +367,7 @@ public class MusicalMoveSO : ScriptableObject
             var mark = target.GetComponent<LoyaltyMark>();
             if (mark == null)
                 mark = target.gameObject.AddComponent<LoyaltyMark>();
-            mark.SetProtector(caster);
+            mark.SetProtector(caster, loyaltyMarkPrefab, loyaltyMarkVerticalOffset);
         }
         else if (typeToUse == MusicalEffectType.LinkMark)
         {

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -1245,7 +1245,13 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         {
             var mark = GetComponent<LoyaltyMark>();
             if (mark != null && mark.RedirectDamage(amount))
+            {
+                // Lorsque la redirection fonctionne, la cible ne subit aucun dégât.
+                // On en profite pour jouer le remerciement adéquat si le lanceur
+                // est un allié et qu'un clip a été configuré.
+                TryPlayLoyaltyMarkAllyClip(mark);
                 return;
+            }
         }
 
         currentHP = Mathf.Max(currentHP - amount, 0);
@@ -1314,6 +1320,32 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         // Affiche un message de parade via l'UI
         ActionUIDisplayManager.Instance?.DisplayParry(Data.characterName);
+    }
+
+    /// <summary>
+    ///     Déclenche le clip vocal prévu lorsque la marque de loyauté protège
+    ///     un allié. Aucune lecture n'est effectuée si le protecteur est ennemi
+    ///     ou si aucun son n'a été configuré dans les données de personnage.
+    /// </summary>
+    /// <param name="mark">Marque de loyauté actuellement active sur cette unité.</param>
+    private void TryPlayLoyaltyMarkAllyClip(LoyaltyMark mark)
+    {
+        if (mark == null || Data == null)
+            return;
+
+        CharacterUnit markProtector = mark.protector;
+        if (markProtector == null || markProtector.Data == null)
+            return;
+
+        // On vérifie que la victime et le protecteur appartiennent bien à la même équipe.
+        if (markProtector.Data.characterType != Data.characterType)
+            return;
+
+        AudioClipSO clip = Data.loyaltyMarkTargetAlly;
+        if (clip == null)
+            return;
+
+        AudioManager.Instance?.PlayVoice(clip);
     }
 
     /// <summary>

--- a/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/LoyaltyMark.cs
@@ -1,14 +1,80 @@
 using UnityEngine;
 
+/// <summary>
+///     Composant attaché à une unité marquée par « Pour qui sonne le glas ».
+///     Il relie la victime à son protecteur et gère à la fois la redirection
+///     des dégâts et l'affichage visuel de la marque.
+/// </summary>
 public class LoyaltyMark : MonoBehaviour
 {
+    /// <summary>Référence de l'unité qui encaisse les dégâts à la place de la cible.</summary>
     public CharacterUnit protector;
 
-    public void SetProtector(CharacterUnit unit)
+    // Décalage vertical appliqué au visuel pour flotter légèrement au-dessus
+    // de la tête de l'unité. Valeur ajustable à l'initialisation.
+    private float visualOffset = DefaultVisualOffset;
+
+    // Mise en cache de l'unité porteuse : on évite ainsi des GetComponent
+    // répétés lors des recalculs de position.
+    private CharacterUnit owner;
+
+    // Instance runtime du prefab de marque, instanciée lors de l'application
+    // de l'effet. Elle est détruite automatiquement quand le composant est retiré.
+    private GameObject visualInstance;
+
+    // Référence du prefab actuellement utilisé, utile pour savoir si l'on doit
+    // ré-instancier un nouveau visuel (par exemple si le designer change le FX).
+    private GameObject currentPrefab;
+
+    // Échelle initiale du prefab pour respecter le calibrage artistique lors des repositionnements.
+    private Vector3 initialVisualScale = Vector3.one;
+
+    // Valeur de repli utilisée quand aucun volume visuel n'est disponible.
+    private const float DefaultHeightFallback = 1.5f;
+
+    // Décalage par défaut utilisé si le move n'en fournit pas un explicitement.
+    private const float DefaultVisualOffset = 0.5f;
+
+    private void Awake()
     {
-        protector = unit;
+        // Mise en cache de l'unité porteuse pour accélérer tous les calculs ultérieurs.
+        owner = GetComponent<CharacterUnit>();
     }
 
+    private void LateUpdate()
+    {
+        // Maintient le visuel aligné au sommet du personnage si la taille change
+        // (animations, variations d'échelle temporaires, etc.).
+        UpdateVisualTransform();
+    }
+
+    /// <summary>
+    ///     Enregistre le protecteur et prépare éventuellement le visuel associé.
+    /// </summary>
+    /// <param name="unit">Unité qui prendra les dégâts à la place de la cible.</param>
+    /// <param name="markPrefab">Prefab instancié au-dessus de la victime.</param>
+    /// <param name="verticalOffset">Décalage supplémentaire appliqué au visuel.</param>
+    public void SetProtector(CharacterUnit unit, GameObject markPrefab = null, float verticalOffset = DefaultVisualOffset)
+    {
+        protector = unit;
+        visualOffset = Mathf.Max(0f, verticalOffset);
+
+        if (markPrefab == null)
+        {
+            // Aucun prefab fourni : on supprime l'éventuel visuel existant pour éviter
+            // de laisser une icône obsolète au-dessus de la cible.
+            RemoveVisual();
+            return;
+        }
+
+        EnsureVisual(markPrefab);
+    }
+
+    /// <summary>
+    ///     Redirige les dégâts vers le protecteur si les conditions sont réunies.
+    /// </summary>
+    /// <param name="amount">Montant de dégâts initialement destiné à la victime.</param>
+    /// <returns>Vrai si la redirection a bien été effectuée.</returns>
     public bool RedirectDamage(float amount)
     {
         // Aucun protecteur valide ou protecteur déjà hors combat : on ne redirige pas
@@ -19,5 +85,70 @@ public class LoyaltyMark : MonoBehaviour
         // la redirection pour éviter une récursion infinie.
         protector.TakeDamage(amount * 0.5f, transform, false);
         return true;
+    }
+
+    private void EnsureVisual(GameObject markPrefab)
+    {
+        // Si le prefab a changé, on supprime la version précédente avant d'en instancier une nouvelle.
+        if (visualInstance != null && currentPrefab != markPrefab)
+        {
+            RemoveVisual();
+        }
+
+        if (visualInstance == null)
+        {
+            // Instancie le prefab comme enfant de l'unité afin qu'il suive automatiquement ses déplacements.
+            visualInstance = Instantiate(markPrefab, transform);
+            visualInstance.name = $"{markPrefab.name}_Runtime";
+            currentPrefab = markPrefab;
+            initialVisualScale = visualInstance.transform.localScale;
+        }
+
+        UpdateVisualTransform();
+    }
+
+    private void UpdateVisualTransform()
+    {
+        if (visualInstance == null)
+            return;
+
+        // Calcule la position idéale en se basant sur les bounds visuels de l'unité.
+        Vector3 anchorPosition = ComputeAnchorPosition();
+        Transform visualTransform = visualInstance.transform;
+
+        visualTransform.position = anchorPosition;
+        visualTransform.rotation = Quaternion.identity; // On garde le visuel orienté de façon neutre.
+        visualTransform.localScale = initialVisualScale; // Préserve l'échelle configurée sur le prefab.
+    }
+
+    private Vector3 ComputeAnchorPosition()
+    {
+        // Si l'unité possède un volume visuel fiable, on place la marque juste au-dessus de son sommet.
+        if (owner != null)
+        {
+            Bounds bounds = owner.GetVisualBounds();
+            float topY = bounds.center.y + bounds.extents.y;
+            return new Vector3(transform.position.x, topY + visualOffset, transform.position.z);
+        }
+
+        // Fallback : on part de la position de base de l'unité.
+        return transform.position + Vector3.up * (DefaultHeightFallback + visualOffset);
+    }
+
+    private void RemoveVisual()
+    {
+        if (visualInstance == null)
+            return;
+
+        Destroy(visualInstance);
+        visualInstance = null;
+        currentPrefab = null;
+        initialVisualScale = Vector3.one;
+    }
+
+    private void OnDestroy()
+    {
+        // Nettoie l'éventuel visuel généré dynamiquement pour éviter les GameObjects orphelins.
+        RemoveVisual();
     }
 }

--- a/Docs/RepertoireMusicalEtItems.md
+++ b/Docs/RepertoireMusicalEtItems.md
@@ -17,7 +17,7 @@
 | **Fausse Note** | Altération | 1 / 1 | Réveille toutes les unités alliées. | Annule les effets soporifiques des Entités du Rêve ou de l’*Endormissement*. |
 | **Accord Bienveillant** | Soutien | 1 / 1 | Soigne ~10 000 PV et +400 Défense (2 tours). | Ancre parfaite pour les runes défensives lorsque les assauts de l’Ange Pleureur se déchaînent. |
 | **Rupture Harmonieuse** | Affaiblissement | 1 / 2 | ~9 500 dégâts et -400 Défense sur l’ennemi (2 tours). | Lancez-la avant *Crescendo Fulgurant* ou *Sforzando* pour maximiser les dégâts critiques. |
-| **Pour qui sonne le glas** | Protection | 1 / 1 | Applique une marque de loyauté reliant l’allié au lanceur. | Encourage les interceptions héroïques de Lucian pour protéger Thalia et Kael. |
+| **Pour qui sonne le glas** | Protection | 1 / 1 | Appose une marque de loyauté : la cible alliée ignore les dégâts subis tandis que le lanceur encaisse la moitié à sa place. | Déclenche un remerciement vocal du protégé ; combinez-la avec les postures défensives de Lucian pour temporiser les assauts majeurs. |
 | **Marque** | Tactique | 1 / 1 | Appose une marque de lien sur l’ennemi. | Sert de point d’ancrage pour les combos de Kael ou les runes d’exécution. |
 | **Hate** | Placement | 1 / 0 | Lucian se place devant la cible pour absorber les attaques. | À utiliser juste avant *Sforzando* pour rester au contact de l’adversaire. |
 | **Pont Harmonique** | Altération | 1 / 1 | Ramène une cible volante au sol pour 2 tours. | Indispensable contre les entités en suspension avant d’enchaîner les attaques terrestres. |


### PR DESCRIPTION
## Summary
- instancier un prefab LoyaltyMark lorsque « Pour qui sonne le glas » est lancé et documenter le nouvel effet
- améliorer la redirection de dégâts pour jouer la réplique alliée adéquate
- ajouter le prefab LoyaltyMark et ses paramètres dédiés dans le projet

## Testing
- non exécuté (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_690c7c97290c832585af38006021d990