### PR TITLE
Généralise le prefab des effets passifs des MusicalMoves

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -32,8 +32,8 @@ MonoBehaviour:
   power: 0
   effectType: 6
   effectValue: 0
-  loyaltyMarkPrefab: {fileID: 5087381848559928121, guid: 4ef3f6c7c5cc40a0bece206e5af9f25b, type: 3}
-  loyaltyMarkVerticalOffset: 0.6
+  passiveEffectPrefab: {fileID: 5087381848559928121, guid: 4ef3f6c7c5cc40a0bece206e5af9f25b, type: 3}
+  passiveEffectVerticalOffset: 0.6
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -71,10 +71,10 @@ public class MusicalMoveSO : ScriptableObject
     public int effectValue = 10;
 
     [Header("Effets spécifiques")]
-    [Tooltip("Prefab instancié au-dessus de la cible lorsqu'une LoyaltyMark est appliquée.")]
-    public GameObject loyaltyMarkPrefab;
-    [Tooltip("Décalage vertical supplémentaire pour positionner le prefab de LoyaltyMark.")]
-    public float loyaltyMarkVerticalOffset = 0.5f;
+    [Tooltip("Prefab générique instancié pour représenter un effet passif appliqué à la cible (marque de loyauté, lien, etc.).")]
+    public GameObject passiveEffectPrefab;
+    [Tooltip("Décalage vertical supplémentaire pour positionner le prefab passif sans chevaucher la cible.")]
+    public float passiveEffectVerticalOffset = 0.5f;
 
     // ------------------------------------------------------------------
     // Buffs et débuffs supplémentaires
@@ -367,7 +367,9 @@ public class MusicalMoveSO : ScriptableObject
             var mark = target.GetComponent<LoyaltyMark>();
             if (mark == null)
                 mark = target.gameObject.AddComponent<LoyaltyMark>();
-            mark.SetProtector(caster, loyaltyMarkPrefab, loyaltyMarkVerticalOffset);
+            // Utilise le prefab générique défini sur le move afin d'autoriser la réutilisation
+            // de ce champ pour d'autres effets passifs sans renommer le code côté gameplay.
+            mark.SetProtector(caster, passiveEffectPrefab, passiveEffectVerticalOffset);
         }
         else if (typeToUse == MusicalEffectType.LinkMark)
         {


### PR DESCRIPTION
## Summary
- renomme le champ de prefab passif dans MusicalMoveSO pour qu'il soit utilisable par tous les effets
- met à jour le move "Pour qui sonne le glas" pour référencer le nouveau champ générique

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c86cb68f08325b71149eec20e0de4