### PR TITLE
Ajoute l'effet Presto avec attaques automatiques

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_Presto/MusicalMove_Presto.asset
+++ b/Assets/MusicalMoves/MusicalMove_Presto/MusicalMove_Presto.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
   moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Fait vibrer le sol sous la cible et l'endort jusqu'\xE0 ce qu'elle\n   
-    subisse des d\xE9g\xE2ts."
+  description: "Marque la cible d'un glyphe de tempo qui l'oblige \xE0 lancer une attaque\n
+    basique apr\xE8s chaque tour jusqu'au prochain tour du lanceur."
   inventoryCategory: MusicalMove
-  inventorySummary: "Endort un ennemi isol\xE9."
+  inventorySummary: "Force la cible \xE0 r\xE9pliquer automatiquement jusqu'au prochain tour du lanceur."
   consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 0
@@ -30,8 +30,10 @@ MonoBehaviour:
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   power: 0
-  effectType: 4
+  effectType: 10
   effectValue: 0
+  passiveEffectPrefab: {fileID: 2788147605682259812, guid: bfbd1b12b5fc6c248862eacd73f041b3, type: 3}
+  passiveEffectVerticalOffset: 0.9
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -386,6 +386,11 @@ public class MusicalMoveSO : ScriptableObject
             int turns = Mathf.Max(1, Mathf.RoundToInt(baseValue));
             target.EnsureAltitudeOverrideStatus().SuspendInAir(turns);
         }
+        else if (typeToUse == MusicalEffectType.PrestoForcedAttack)
+        {
+            // Crée un statut dédié qui instancie le prefab et gère les attaques automatiques.
+            PrestoForcedAttackSystem.ApplyStatus(target, caster, passiveEffectPrefab, passiveEffectVerticalOffset);
+        }
         // Les effets visuels comme la création ou la suppression de sol sont
         // désormais entièrement gérés par la timeline, aucune instanciation
         // de prefab n'est nécessaire ici.
@@ -420,7 +425,7 @@ public enum MoveType
     Alteration  // Modifie le terrain ou l'état d'une cible sans être purement offensif ou défensif.
 }
 
-public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark, AnchorGround, SuspendAir }
+public enum MusicalEffectType { Damage, Heal, Buff, Debuff, Sleep, WakeUpAll, LoyaltyMark, LinkMark, AnchorGround, SuspendAir, PrestoForcedAttack }
 
 public enum RelativePosition { Front, Back, Left, Right , NC}
 

--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -1738,6 +1738,52 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         return availableAttacks[index];
     }
 
+    /// <summary>
+    ///     Renvoie l'attaque basique utilisée pour les effets automatiques (comme Presto).
+    ///     On privilégie une attaque offensive accessible dans l'état courant.
+    /// </summary>
+    public MusicalMoveSO GetBasicAttack()
+    {
+        if (Data == null || Data.musicalAttacks == null || Data.musicalAttacks.Length == 0)
+            return null;
+
+        foreach (var move in Data.musicalAttacks)
+        {
+            if (move == null)
+                continue;
+
+            bool canUse = (!move.onlyAwake || IsAwake)
+                          && (!move.enterAwake || !IsAwake)
+                          && (!move.enterAwake || GetHarmonicCount(Data.harmonicType) >= Data.awakeHarmonicThreshold)
+                          && GetHarmonicCount(move.consumedHarmonicType) >= move.harmonicCost
+                          && !IsMoveOnCooldown(move);
+
+            if (!canUse)
+                continue;
+
+            if (move.moveType == MoveType.Attack && move.effectType == MusicalEffectType.Damage)
+                return move; // Premier candidat offensif trouvé : suffisant pour une attaque basique.
+        }
+
+        // Aucun move purement offensif : on tente malgré tout de retourner le premier move accessible (ex : support forcé).
+        foreach (var move in Data.musicalAttacks)
+        {
+            if (move == null)
+                continue;
+
+            bool canUse = (!move.onlyAwake || IsAwake)
+                          && (!move.enterAwake || !IsAwake)
+                          && (!move.enterAwake || GetHarmonicCount(Data.harmonicType) >= Data.awakeHarmonicThreshold)
+                          && GetHarmonicCount(move.consumedHarmonicType) >= move.harmonicCost
+                          && !IsMoveOnCooldown(move);
+
+            if (canUse)
+                return move;
+        }
+
+        return null;
+    }
+
     public CharacterUnit SelectTargetFromSquad()
     {
         var squad = NewBattleManager.Instance.activeCharacterUnits

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -1740,6 +1740,8 @@ public class NewBattleManager : MonoBehaviour
         // Réinitialise la timeline visuelle (ordre + surbrillance)
         BattleTimelineUIManager.Instance?.Refresh(null);
         isTurnResolving = false;
+        // Déclenche les attaques automatiques liées à Presto avant l'évaluation de fin de combat.
+        PrestoForcedAttackSystem.HandleTurnEnded(endingUnit);
         HandleEndOfBattle();
 
         // Cache la jauge si elle existe pour éviter les références invalides.
@@ -3920,6 +3922,9 @@ public class NewBattleManager : MonoBehaviour
             return; // Aucun changement : on évite les répétitions sonores inutiles.
 
         currentCharacterUnit = newCurrentCharacterUnit;
+
+        // Informe immédiatement le statut Presto pour savoir si le lanceur vient de rejouer.
+        PrestoForcedAttackSystem.HandleActiveUnitChanged(currentCharacterUnit);
 
         if (currentCharacterUnit == null)
             return; // Parfois utilisé lors des resets de combat : aucune unité active.

--- a/Assets/Scripts/MonoBehavioursUsed/PrestoForcedAttackStatus.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/PrestoForcedAttackStatus.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+///     Applique l'enchantement propre au MusicalMove « Presto ».
+///     Tant que l'effet est actif, la cible effectue automatiquement
+///     une attaque basique après le tour de chaque unité en combat.
+///     L'effet prend fin dès que le lanceur rejoue.
+/// </summary>
+[DisallowMultipleComponent]
+[RequireComponent(typeof(CharacterUnit))]
+public class PrestoForcedAttackStatus : MonoBehaviour
+{
+    /// <summary>Référence directe vers l'unité affectée pour éviter les <c>GetComponent</c> répétés.</summary>
+    private CharacterUnit owner;
+
+    /// <summary>Unité ayant lancé Presto. Permet de savoir quand mettre fin à l'effet.</summary>
+    private CharacterUnit caster;
+
+    /// <summary>Instance du prefab visuel instancié sur la cible pour matérialiser l'effet.</summary>
+    private GameObject visualInstance;
+
+    /// <summary>Prefab actuellement utilisé pour l'effet visuel (sert à détecter les changements de configuration).</summary>
+    private GameObject currentPrefab;
+
+    /// <summary>Décalage vertical appliqué au visuel afin qu'il flotte au-dessus du personnage.</summary>
+    private float verticalOffset = 0.5f;
+
+    /// <summary>
+    /// Compteur du nombre de fois où le début du tour du lanceur a été observé
+    /// depuis l'application de l'effet. Dès qu'on atteint la valeur 2
+    /// (tour initial + tour suivant), on désactive le statut.
+    /// </summary>
+    private int casterTurnObservations = 0;
+
+    /// <summary>État interne indiquant si l'instance est toujours valide.</summary>
+    private bool isActive = false;
+
+    private void Awake()
+    {
+        owner = GetComponent<CharacterUnit>();
+    }
+
+    private void LateUpdate()
+    {
+        // Maintient le visuel à la bonne hauteur même si la taille du personnage varie (animation, échelle dynamique...).
+        UpdateVisualTransform();
+    }
+
+    /// <summary>
+    /// Prépare le statut : enregistre le lanceur, instancie le visuel et reset le suivi de tour.
+    /// </summary>
+    /// <param name="source">Personnage ayant lancé Presto.</param>
+    /// <param name="effectPrefab">Prefab visuel configuré sur le move.</param>
+    /// <param name="additionalOffset">Décalage vertical supplémentaire défini sur le move.</param>
+    public void Configure(CharacterUnit source, GameObject effectPrefab, float additionalOffset)
+    {
+        caster = source;
+        verticalOffset = Mathf.Max(0f, additionalOffset);
+        casterTurnObservations = 1; // On a déjà observé le tour en cours lors du lancement de Presto.
+        isActive = true;
+
+        EnsureVisual(effectPrefab);
+
+        // Enregistre le statut auprès du gestionnaire global pour recevoir les événements de tour.
+        PrestoForcedAttackSystem.Register(this);
+    }
+
+    /// <summary>
+    /// Notifié par le gestionnaire lorsque n'importe quelle unité termine son tour.
+    /// </summary>
+    public void HandleTurnEnded(CharacterUnit endedUnit)
+    {
+        if (!isActive)
+            return;
+
+        if (owner == null || owner.currentHP <= 0)
+        {
+            // La cible n'est plus en état d'agir : on nettoie immédiatement le statut.
+            Cleanup();
+            return;
+        }
+
+        if (caster != null && caster.currentHP <= 0)
+        {
+            // Si le lanceur tombe au combat, l'effet se dissipe naturellement.
+            Cleanup();
+            return;
+        }
+
+        if (endedUnit == null)
+            return;
+
+        // Recherche l'attaque basique utilisable par la cible.
+        MusicalMoveSO basicAttack = owner.GetBasicAttack();
+        if (basicAttack == null)
+            return; // Cible incapable d'attaquer : on laisse l'effet actif au cas où un set serait rétabli plus tard.
+
+        // Recherche d'une victime valable dans le camp opposé.
+        CharacterUnit forcedTarget = ResolveForcedAttackTarget();
+        if (forcedTarget == null)
+            return; // Aucun adversaire valide (ex : tous K.O.).
+
+        if (NewBattleManager.Instance != null)
+            NewBattleManager.Instance.OrientUnitTowardTarget(owner, forcedTarget);
+
+        // Exécute immédiatement l'effet du move sans passer par un QTE.
+        basicAttack.ApplyEffect(owner, forcedTarget, false);
+    }
+
+    /// <summary>
+    /// Notifié quand l'unité active change. Utilisé pour détecter le prochain tour du lanceur.
+    /// </summary>
+    public void HandleActiveUnitChanged(CharacterUnit newUnit)
+    {
+        if (!isActive || caster == null)
+            return;
+
+        if (newUnit != caster)
+            return;
+
+        casterTurnObservations++;
+        if (casterTurnObservations >= 2)
+            Cleanup();
+    }
+
+    /// <summary>
+    /// Détermine une cible adverse à frapper automatiquement.
+    /// </summary>
+    private CharacterUnit ResolveForcedAttackTarget()
+    {
+        if (NewBattleManager.Instance == null || owner == null || owner.Data == null)
+            return null;
+
+        bool ownerIsPlayer = owner.Data.isPlayerControlled;
+        List<CharacterUnit> candidates = NewBattleManager.Instance.activeCharacterUnits
+            .Where(u => u != null && u != owner && u.Data != null && u.Data.isPlayerControlled != ownerIsPlayer && u.currentHP > 0)
+            .ToList();
+
+        if (candidates.Count == 0)
+            return null;
+
+        // Sélection aléatoire pour éviter toute répétitivité et encourager des situations variées.
+        int index = Random.Range(0, candidates.Count);
+        return candidates[index];
+    }
+
+    /// <summary>
+    /// Instancie ou met à jour le visuel associé au statut.
+    /// </summary>
+    private void EnsureVisual(GameObject prefab)
+    {
+        if (prefab == null)
+        {
+            RemoveVisual();
+            currentPrefab = null;
+            return;
+        }
+
+        if (visualInstance != null && currentPrefab != prefab)
+            RemoveVisual();
+
+        if (visualInstance == null)
+        {
+            visualInstance = Instantiate(prefab, transform);
+            visualInstance.name = $"{prefab.name}_Presto";
+        }
+
+        currentPrefab = prefab;
+        UpdateVisualTransform();
+    }
+
+    /// <summary>
+    /// Positionne le visuel juste au-dessus de l'unité pour rester lisible en toutes circonstances.
+    /// </summary>
+    private void UpdateVisualTransform()
+    {
+        if (visualInstance == null || owner == null)
+            return;
+
+        Bounds bounds = owner.GetVisualBounds();
+        float topY = bounds.center.y + bounds.extents.y;
+        Transform visualTransform = visualInstance.transform;
+        visualTransform.position = new Vector3(owner.transform.position.x, topY + verticalOffset, owner.transform.position.z);
+        visualTransform.rotation = Quaternion.identity;
+    }
+
+    /// <summary>
+    /// Supprime l'effet et détruit le visuel associé.
+    /// </summary>
+    private void Cleanup()
+    {
+        if (!isActive)
+            return;
+
+        isActive = false;
+        PrestoForcedAttackSystem.Unregister(this);
+        RemoveVisual();
+        Destroy(this);
+    }
+    private void RemoveVisual()
+    {
+        if (visualInstance == null)
+            return;
+
+        Destroy(visualInstance);
+        visualInstance = null;
+    }
+
+    private void OnDestroy()
+    {
+        // Garantit la suppression dans les cas où Cleanup n'aurait pas été appelé explicitement (par exemple destruction de l'unité).
+        PrestoForcedAttackSystem.Unregister(this);
+        RemoveVisual();
+        isActive = false;
+    }
+}
+
+/// <summary>
+/// Gestionnaire statique chargé de relayer les événements de combat aux statuts Presto actifs.
+/// Sépare la logique de stockage de la logique d'effet afin de limiter les dépendances croisées.
+/// </summary>
+public static class PrestoForcedAttackSystem
+{
+    /// <summary>Liste des statuts actifs. Le HashSet évite les doublons et accélère les recherches.</summary>
+    private static readonly HashSet<PrestoForcedAttackStatus> ActiveStatuses = new();
+
+    /// <summary>Ajoute un statut à la collection suivie.</summary>
+    public static void Register(PrestoForcedAttackStatus status)
+    {
+        if (status == null)
+            return;
+
+        ActiveStatuses.Add(status);
+    }
+
+    /// <summary>Retire un statut de la collection (appelé automatiquement lors de la fin d'effet).</summary>
+    public static void Unregister(PrestoForcedAttackStatus status)
+    {
+        if (status == null)
+            return;
+
+        ActiveStatuses.Remove(status);
+    }
+
+    /// <summary>
+    /// Applique (ou réapplique) l'effet Presto sur une cible donnée.
+    /// </summary>
+    public static void ApplyStatus(CharacterUnit target, CharacterUnit caster, GameObject effectPrefab, float verticalOffset)
+    {
+        // Sans lanceur la durée ne peut pas être évaluée correctement : on ignore l'application.
+        if (target == null || caster == null)
+            return;
+
+        var status = target.GetComponent<PrestoForcedAttackStatus>();
+        if (status == null)
+            status = target.gameObject.AddComponent<PrestoForcedAttackStatus>();
+
+        status.Configure(caster, effectPrefab, verticalOffset);
+    }
+
+    /// <summary>
+    /// Doit être appelé lorsque n'importe quelle unité termine son tour afin de déclencher les attaques automatiques.
+    /// </summary>
+    public static void HandleTurnEnded(CharacterUnit endedUnit)
+    {
+        if (ActiveStatuses.Count == 0)
+            return;
+
+        foreach (var status in ActiveStatuses.ToArray())
+            status?.HandleTurnEnded(endedUnit);
+    }
+
+    /// <summary>
+    /// Doit être appelé à chaque changement d'unité active pour détecter le retour du lanceur.
+    /// </summary>
+    public static void HandleActiveUnitChanged(CharacterUnit newUnit)
+    {
+        if (ActiveStatuses.Count == 0)
+            return;
+
+        foreach (var status in ActiveStatuses.ToArray())
+            status?.HandleActiveUnitChanged(newUnit);
+    }
+}

--- a/Assets/Scripts/MonoBehavioursUsed/PrestoForcedAttackStatus.cs.meta
+++ b/Assets/Scripts/MonoBehavioursUsed/PrestoForcedAttackStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d2ed6bb6d7b4e9e84fb86b1a66fbf20
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/RepertoireMusicalEtItems.md
+++ b/Docs/RepertoireMusicalEtItems.md
@@ -13,7 +13,7 @@
 | **Rhapsodie** | Attaque | 0 / 0 | ~7 500 dégâts + puissance actuelle du lanceur. | Idéal pour les débutants : aucune ressource, permet d'accumuler des fragments avant de déclencher un combo majeur. |
 | **Éclair** | Attaque | 1 / 1 | ~11 000 dégâts instantanés. | À lier avec la *Clé du Courage* ou des runes de puissance pour éliminer les menaces rapides. |
 | **Contrepoint Chaotique** | Attaque de zone | 1 / 3 | ~13 000 dégâts à chaque ennemi. | Prépare des balayages massifs avant un *Crescendo Fulgurant* pour achever les survivants. |
-| **Tunnel** | Contrôle | 1 / 1 | Endort un ennemi jusqu’à la prochaine blessure. | Combinez avec *Pont Harmonique* pour fixer une cible aérienne puis la neutraliser durablement. |
+| **Tunnel** | Contrôle | 1 / 1 | Appose le glyphe Presto : la cible déclenche une attaque basique après chaque tour jusqu’au retour du lanceur. | Parfait pour accélérer un allié clef ou forcer un ennemi contrôlé à se retourner contre ses pairs avant la prochaine salve du lanceur. |
 | **Fausse Note** | Altération | 1 / 1 | Réveille toutes les unités alliées. | Annule les effets soporifiques des Entités du Rêve ou de l’*Endormissement*. |
 | **Accord Bienveillant** | Soutien | 1 / 1 | Soigne ~10 000 PV et +400 Défense (2 tours). | Ancre parfaite pour les runes défensives lorsque les assauts de l’Ange Pleureur se déchaînent. |
 | **Rupture Harmonieuse** | Affaiblissement | 1 / 2 | ~9 500 dégâts et -400 Défense sur l’ennemi (2 tours). | Lancez-la avant *Crescendo Fulgurant* ou *Sforzando* pour maximiser les dégâts critiques. |


### PR DESCRIPTION
## Résumé
- créer un statut Presto dédié qui instancie le prefab d'effet et force la cible à attaquer après chaque tour
- étendre MusicalMoveSO et le gestionnaire de combat pour relayer les tours au statut et gérer la nouvelle variante d'effet
- mettre à jour l'asset et la documentation de Tunnel/Presto avec le nouveau glyph visuel et sa description

## Tests
- non exécutés (non disponibles dans l'environnement)

------
https://chatgpt.com/codex/tasks/task_e_690c88d334608325b0ca0f78d38a1a0c