### PR TITLE
Aligner Pont Harmonique sur le système de statuts d'altitude

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -29,8 +29,8 @@ MonoBehaviour:
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   power: 0
-  effectType: 0
-  effectValue: 0
+  effectType: 8
+  effectValue: 2
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -378,6 +378,10 @@ public class MusicalMoveSO : ScriptableObject
         }
         else if (typeToUse == MusicalEffectType.AnchorGround)
         {
+            // Comme pour Presto ou Pour qui sonne le glas, on s'appuie sur un
+            // composant persistant afin de conserver l'état entre les tours :
+            // ici on force explicitement l'ennemi à rester collé au sol pour
+            // la durée définie par le ScriptableObject.
             int turns = Mathf.Max(1, Mathf.RoundToInt(baseValue));
             target.EnsureAltitudeOverrideStatus().AnchorToGround(turns);
         }


### PR DESCRIPTION
## Résumé
- configure Pont Harmonique pour utiliser l'effet AnchorGround pendant deux tours
- documente dans le code que l'effet exploite désormais le même statut persistant que Presto et Pour qui sonne le glas

## Tests
- aucun test automatisé

------
https://chatgpt.com/codex/tasks/task_e_690c8de017388325b4ae3664e2e46218