### PR TITLE
Fixer le slot d'attaque basique du SkillsMenu

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/InputsManager.cs
@@ -564,37 +564,14 @@ public class InputsManager : MonoBehaviour
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            // On calcule explicitement la taille d'une page en excluant le slot réservé
-            // au move spécial. Sans cette correction, les compétences affichées sur les
-            // pages suivantes devenaient inaccessibles (ex : « Pour qui sonne le glas »),
-            // car l'indice de base sautait une compétence entière.
-            int pageSize = Mathf.Max(1, bm.currentSkillsMenuSlots.Count - 1);
-            int baseIndex = bm.currentSkillPageIndex * pageSize;
-            if (bm.skillChoices.Count > baseIndex)
+            // Le premier slot du SkillsMenu correspond désormais à l'attaque basique fixe.
+            // On délègue toute la validation à la logique dédiée pour conserver les mêmes contrôles
+            // (coûts, cooldown, limites d'utilisation...) que pour l'input direct d'attaque basique.
+            if (bm.TryStartBaseAttackSelection())
             {
-                bm.currentMove = bm.skillChoices[baseIndex];
-                HarmonicType requiredType = bm.currentMove.consumedHarmonicType;
-                if (bm.currentCharacterUnit.GetHarmonicCount(requiredType) < bm.currentMove.harmonicCost)
-                {
-                    ActionUIDisplayManager.Instance.DisplayInstruction_NotEnoughHarmonics();
-                    return;
-                }
-                if (bm.currentCharacterUnit.IsMoveOnCooldown(bm.currentMove))
-                {
-                    ActionUIDisplayManager.Instance.DisplayInstruction_MoveOnCooldown();
-                    bm.ShowMainMenu();
-                    return;
-                }
-                bm.ToggleMenuContainers(false, false, false);
-                // On contrôle ici si la même touche sert à confirmer : seule cette situation impose
-                // de différer la validation pour éviter un lancement immédiat.
+                // Même protection que pour les autres sélections : si la touche chevauche "Confirm",
+                // on bloque la validation sur la prochaine frame afin d'éviter un déclenchement instantané.
                 MettreAJourIgnorerValidationApresSelection(ctx);
-                bm.HandleTargetSelection(bm.currentMove);
-                // Les animations de visée sont désormais intégrées dans la Timeline de préparation
-            }
-            else
-            {
-                Debug.LogWarning("[InputsManager] OnSelect1 ignoré : pas de skill disponible !");
             }
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_ItemsMenu)
@@ -631,13 +608,19 @@ public class InputsManager : MonoBehaviour
         }
         else if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            // Même logique que pour la première compétence : on retire le slot spécial
-            // du calcul afin que l'indice colle à l'affichage réel de la page courante.
-            int pageSize = Mathf.Max(1, bm.currentSkillsMenuSlots.Count - 1);
-            int baseIndex = bm.currentSkillPageIndex * pageSize;
-            if (bm.skillChoices.Count > baseIndex + 1)
+            // Les slots paginés démarrent à l'indice 1 (0 = attaque basique fixe).
+            int paginatedSlots = bm.currentSkillsMenuSlots.Count - 2;
+            if (paginatedSlots <= 0)
             {
-                bm.currentMove = bm.skillChoices[baseIndex + 1];
+                Debug.LogWarning("[InputsManager] OnSelect2 ignoré : aucun slot paginé disponible !");
+                return;
+            }
+
+            int pageSize = paginatedSlots;
+            int baseIndex = bm.currentSkillPageIndex * pageSize;
+            if (bm.skillChoices.Count > baseIndex)
+            {
+                bm.currentMove = bm.skillChoices[baseIndex];
                 HarmonicType requiredType = bm.currentMove.consumedHarmonicType;
                 if (bm.currentCharacterUnit.GetHarmonicCount(requiredType) < bm.currentMove.harmonicCost)
                 {
@@ -688,13 +671,19 @@ public class InputsManager : MonoBehaviour
 
         if (bm.currentBattleState == BattleState.SquadUnit_SkillsMenu)
         {
-            // Idem pour le troisième slot standard : on s'aligne sur la pagination
-            // effective afin que chaque case affichée dans le menu soit sélectionnable.
-            int pageSize = Mathf.Max(1, bm.currentSkillsMenuSlots.Count - 1);
-            int baseIndex = bm.currentSkillPageIndex * pageSize;
-            if (bm.skillChoices.Count > baseIndex + 2)
+            // Ce troisième bouton cible le deuxième slot paginé (indice 2 au total).
+            int paginatedSlots = bm.currentSkillsMenuSlots.Count - 2;
+            if (paginatedSlots <= 1)
             {
-                bm.currentMove = bm.skillChoices[baseIndex + 2];
+                Debug.LogWarning("[InputsManager] OnSelect3 ignoré : moins de deux slots paginés disponibles !");
+                return;
+            }
+
+            int pageSize = paginatedSlots;
+            int baseIndex = bm.currentSkillPageIndex * pageSize;
+            if (bm.skillChoices.Count > baseIndex + 1)
+            {
+                bm.currentMove = bm.skillChoices[baseIndex + 1];
                 HarmonicType requiredType = bm.currentMove.consumedHarmonicType;
                 if (bm.currentCharacterUnit.GetHarmonicCount(requiredType) < bm.currentMove.harmonicCost)
                 {
@@ -800,8 +789,12 @@ public class InputsManager : MonoBehaviour
             return;
 
         // Calcule le nombre de cases disponibles pour les attaques musicales classiques
-        // (le dernier slot du menu étant réservé au mouvement spécial).
-        int pageSize = bm.currentSkillsMenuSlots.Count - 1;
+        // (le premier slot étant l'attaque basique fixe et le dernier le move spécial).
+        int pageSize = bm.currentSkillsMenuSlots.Count - 2;
+
+        // Sans slot paginé, aucune page supplémentaire ne peut être affichée.
+        if (pageSize <= 0)
+            return;
 
         // Si le total des attaques disponibles tient sur une seule page, inutile de tenter
         // une navigation : on quitte simplement la méthode.
@@ -826,8 +819,12 @@ public class InputsManager : MonoBehaviour
         if (bm.currentBattleState != BattleState.SquadUnit_SkillsMenu)
             return;
 
-        // Détermination du nombre d'attaques affichables par page (hors move spécial).
-        int pageSize = bm.currentSkillsMenuSlots.Count - 1;
+        // Détermination du nombre d'attaques affichables par page (hors attaque basique et move spécial).
+        int pageSize = bm.currentSkillsMenuSlots.Count - 2;
+
+        // Sans slot paginé, il est impossible de reculer.
+        if (pageSize <= 0)
+            return;
 
         // Si une seule page suffit à afficher toutes les compétences, il n'y a rien
         // à afficher de plus et l'on quitte la méthode.

--- a/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/NewBattleManager.cs
@@ -369,6 +369,12 @@ public class NewBattleManager : MonoBehaviour
     [HideInInspector] public List<MusicalMoveSO> skillChoices = new List<MusicalMoveSO>();
     // Mouvement spécial actuel (affiché dans le 4e slot du SkillsMenu)
     [HideInInspector] public MusicalMoveSO specialMoveChoice;
+    /// <summary>
+    ///     Mouvement d'attaque basique affiché dans le premier slot du SkillsMenu.
+    ///     Ce champ reste public (en hide) pour simplifier la consultation dans l'inspecteur
+    ///     tout en garantissant un point d'accès unique pour l'UI et les inputs.
+    /// </summary>
+    [HideInInspector] public MusicalMoveSO basicAttackMoveChoice;
     [HideInInspector] public List<ItemData> itemChoices = new List<ItemData>();
     [HideInInspector] public MusicalMoveSO currentMove;
     [HideInInspector] public ItemData currentItem;
@@ -2779,6 +2785,17 @@ public class NewBattleManager : MonoBehaviour
         // Réordonne les attaques selon le set sélectionné afin de mettre en avant les favoris.
         skillChoices = currentCharacterUnit.OrderMovesForCurrentSet(skillChoices);
 
+        // Identifie l'attaque basique dédiée au premier slot du SkillsMenu.
+        // Même si cette attaque n'apparaît pas dans la liste (fallback global, limites d'utilisation...),
+        // on force son affichage fixe pour respecter les attentes des joueurs.
+        basicAttackMoveChoice = ResolveBasicAttackMove(currentCharacterUnit);
+        if (basicAttackMoveChoice != null)
+        {
+            // On retire l'attaque basique de la liste paginée afin qu'elle ne se décale jamais
+            // lorsqu'on feuillette les autres compétences musicales.
+            skillChoices.RemoveAll(move => move == basicAttackMoveChoice);
+        }
+
         // Détermine le mouvement spécial autorisé, qui sera affiché dans le 4e slot
         specialMoveChoice = (currentCharacterUnit.Data.specialMusicalMove != null &&
             currentCharacterUnit.CanUseMove(currentCharacterUnit.Data.specialMusicalMove))
@@ -2809,32 +2826,73 @@ public class NewBattleManager : MonoBehaviour
             return;
         }
 
-        int pageSize = specialSlotIndex; // Slots disponibles pour les attaques musicales classiques
-        int startIndex = currentSkillPageIndex * pageSize;
+        // 0) Assure l'affichage fixe de l'attaque basique dans le tout premier slot
+        if (currentSkillsMenuSlots.Count > 0)
+        {
+            Transform basicSlot = currentSkillsMenuSlots[0];
+            if (basicAttackMoveChoice != null && currentCharacterUnit != null && currentCharacterUnit.Data != null)
+            {
+                UpdateButton(basicSlot, basicAttackMoveChoice.moveName, basicAttackMoveChoice.moveIcon);
 
-        // 1) Affiche les attaques musicales standard dans les premiers slots
+                bool enoughHarmonic = currentCharacterUnit.GetHarmonicCount(basicAttackMoveChoice.consumedHarmonicType) >= basicAttackMoveChoice.harmonicCost;
+                bool resonanceOk = !basicAttackMoveChoice.enterAwake || currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.awakeHarmonicThreshold;
+                bool usageOk = currentCharacterUnit.CanUseMove(basicAttackMoveChoice);
+                bool cooldownOk = !currentCharacterUnit.IsMoveOnCooldown(basicAttackMoveChoice);
+                bool available = enoughHarmonic && resonanceOk && usageOk && cooldownOk;
+                SetButtonAvailability(basicSlot, available, false);
+            }
+            else
+            {
+                // Fallback visuel en cas d'absence d'attaque basique (situation exceptionnelle)
+                if (emptyMove != null)
+                    UpdateButton(basicSlot, emptyMove.moveName, emptyMove.moveIcon);
+                else
+                    UpdateButton(basicSlot, "Indisponible", null);
+                SetButtonAvailability(basicSlot, false, false);
+            }
+        }
+
+        const int baseAttackSlotIndex = 0;
+        int paginatedSlotOffset = baseAttackSlotIndex + 1;
+        int pageSize = Mathf.Max(0, specialSlotIndex - paginatedSlotOffset);
+
+        if (pageSize > 0)
+        {
+            int maxPage = Mathf.Max(0, (skillChoices.Count - 1) / pageSize);
+            currentSkillPageIndex = Mathf.Clamp(currentSkillPageIndex, 0, maxPage);
+        }
+        else
+        {
+            currentSkillPageIndex = 0;
+        }
+
+        int startIndex = pageSize > 0 ? currentSkillPageIndex * pageSize : 0;
+
+        // 1) Affiche les attaques musicales paginées (hors attaque basique et move spécial)
         for (int i = 0; i < pageSize; i++)
         {
+            int slotIndex = paginatedSlotOffset + i;
+            Transform slot = currentSkillsMenuSlots[slotIndex];
             int globalIndex = startIndex + i;
             if (globalIndex < skillChoices.Count)
             {
                 var move = skillChoices[globalIndex];
-                UpdateButton(currentSkillsMenuSlots[i], move.moveName, move.moveIcon);
+                UpdateButton(slot, move.moveName, move.moveIcon);
 
                 bool enoughHarmonic = currentCharacterUnit.GetHarmonicCount(move.consumedHarmonicType) >= move.harmonicCost;
                 bool resonanceOk = !move.enterAwake || currentCharacterUnit.GetHarmonicCount(currentCharacterUnit.Data.harmonicType) >= currentCharacterUnit.Data.awakeHarmonicThreshold;
                 bool usageOk = currentCharacterUnit.CanUseMove(move);
                 bool available = enoughHarmonic && resonanceOk && usageOk;
-                SetButtonAvailability(currentSkillsMenuSlots[i], available, false);
+                SetButtonAvailability(slot, available, false);
             }
             else
             {
                 // Slot vide ou hors de portée
                 if (emptyMove != null)
-                    UpdateButton(currentSkillsMenuSlots[i], emptyMove.moveName, emptyMove.moveIcon);
+                    UpdateButton(slot, emptyMove.moveName, emptyMove.moveIcon);
                 else
-                    UpdateButton(currentSkillsMenuSlots[i], "Indisponible", null);
-                SetButtonAvailability(currentSkillsMenuSlots[i], false, false);
+                    UpdateButton(slot, "Indisponible", null);
+                SetButtonAvailability(slot, false, false);
             }
         }
 
@@ -2864,12 +2922,12 @@ public class NewBattleManager : MonoBehaviour
     /// </summary>
     public void NextSkillPage()
     {
-        // Calcule le nombre de pages possibles (hors slot spécial)
-        int pageSize = currentSkillsMenuSlots.Count - 1;
+        // Calcule le nombre de slots paginés (hors attaque basique et move spécial)
+        int pageSize = currentSkillsMenuSlots.Count - 2;
         if (pageSize <= 0)
         {
-            // Évite une division par zéro si aucun slot n'est disponible
-            Debug.LogWarning("[NextSkillPage] Impossible de changer de page : nombre de slots insuffisant.");
+            // Évite une division par zéro si aucun slot paginé n'est disponible
+            Debug.LogWarning("[NextSkillPage] Impossible de changer de page : aucun slot paginé.");
             return;
         }
 


### PR DESCRIPTION
## Résumé
- isole l'attaque basique pour la placer dans un slot fixe du SkillsMenu
- adapte l'affichage des compétences pour gérer le slot d'attaque et la pagination restante
- met à jour la navigation des entrées afin de cibler correctement le slot fixe et les slots paginés

## Tests
- non exécutés (environnement Unity hors ligne)


------
https://chatgpt.com/codex/tasks/task_e_690cd22d09c08325898d3852ad4b15e3