### PR TITLE
Supprimer l'ancien champ power des MusicalMoves

### DIFF
--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_Etreinte du Linceul.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 10
   effectType: 0
   effectValue: 10
   buffStat: 0

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_PluieDuRequiem.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 25000
   buffStat: 0

--- a/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
+++ b/Assets/Characters/Boss/CryingAngel/MusicalMove_CryingAngel_SanglotEcorchant.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 18000
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
+++ b/Assets/MusicalMoves/MusicalMove_AccordBienveillant/MusicalMove_AccordBienveillant.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 1
   effectValue: 10000
   buffStat: 2

--- a/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
+++ b/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 1
   effectValue: 20
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_AttaqueBasique/MusicalMove_AttaqueBasique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AttaqueBasique/MusicalMove_AttaqueBasique.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 100
   passiveEffectPrefab: {fileID: 0}

--- a/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrepointChaotique/MusicalMove_ContrepointChaotique.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 50
   effectType: 0
   effectValue: 13000
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
+++ b/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 30
   effectType: 0
   effectValue: 30
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
+++ b/Assets/MusicalMoves/MusicalMove_Eclair/MusicalMove_Eclair.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 10
   effectType: 0
   effectValue: 11000
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
+++ b/Assets/MusicalMoves/MusicalMove_Empty/MusicalMove_Empty.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
+++ b/Assets/MusicalMoves/MusicalMove_FausseNote/MusicalMove_FausseNote.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 5
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
+++ b/Assets/MusicalMoves/MusicalMove_Hate/MusicalMove_Hate.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 0
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
+++ b/Assets/MusicalMoves/MusicalMove_HyoiGattai/HyoiGattai.asset
@@ -19,7 +19,6 @@ MonoBehaviour:
   description: "Fusionne l'\xE2me du lanceur avec celui de son ange gardien."
   stayFaceToTarget: 1
   notes: []
-  power: 0
   fatigueCost: 1
   harmonicCost: 1
   harmonicGeneration: 0

--- a/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
+++ b/Assets/MusicalMoves/MusicalMove_Marque/MusicalMove_Marque.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 7
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PontHarmonique/MusicalMove_PontHarmonique.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 8
   effectValue: 2
   passiveEffectPrefab: {fileID: 100000, guid: a9e8b7c3f95d4f278b1a412be0c8e3a1, type: 3}

--- a/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
+++ b/Assets/MusicalMoves/MusicalMove_PourQuiSonneLeGlas/MusicalMove_PourQuiSonneLeGlas.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 6
   effectValue: 0
   passiveEffectPrefab: {fileID: 1003778626229348816, guid: 5c35b8dd08a5cc642984344a67322c33, type: 3}

--- a/Assets/MusicalMoves/MusicalMove_Presto/MusicalMove_Presto.asset
+++ b/Assets/MusicalMoves/MusicalMove_Presto/MusicalMove_Presto.asset
@@ -30,7 +30,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 10
   effectValue: 0
   passiveEffectPrefab: {fileID: 1144090914521784546, guid: f066fb66a808fc448b02dcc7477eeeb5, type: 3}

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 10
   effectType: 0
   effectValue: 1000
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
+++ b/Assets/MusicalMoves/MusicalMove_RuptureHarmonieuse/MusicalMove_RuptureHarmonieuse.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 10
   effectType: 0
   effectValue: 9500
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 10
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 10
   effectType: 0
   effectValue: 2000
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -28,7 +28,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 4
   effectValue: 0
   buffStat: 0

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  power: 0
   effectType: 4
   effectValue: 0
   buffStat: 0

--- a/Assets/Scripts/Classes/MusicalMoveSO.cs
+++ b/Assets/Scripts/Classes/MusicalMoveSO.cs
@@ -62,12 +62,12 @@ public class MusicalMoveSO : ScriptableObject
     [Tooltip("Type d'harmonique ajouté à la réserve lorsqu'un gain est généré. Même si le gain est nul, cette information aide la lecture stratégique.")]
     public HarmonicType generatedHarmonicType = HarmonicType.Lumiere;
 
-    [Header("Puissance et Effet")]
-    [Tooltip("Puissance de base de l'action, utilisée dans les calculs de dégâts ou de soin.")]
-    public float power = 0;
-    [Tooltip("Effet principal appliqué à la cible lors de l'utilisation du move.")]
+    [Header("Effet principal")]
+    [Tooltip(
+        "Effet appliqué à la cible lors de l'utilisation du move."
+        + " Toute la résolution numérique part désormais de effectValue pour assurer une logique unique.")]
     public MusicalEffectType effectType = MusicalEffectType.Damage;
-    [Tooltip("Valeur numérique associée à l'effet principal.")]
+    [Tooltip("Valeur numérique associée à l'effet principal (dégâts, soins, etc.).")]
     public int effectValue = 10;
 
     [Header("Effets spécifiques")]

--- a/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AnimationEventsManager.cs
@@ -33,11 +33,11 @@ public class AnimationEventsManager : MonoBehaviour
         else
         {
             CharacterUnit caster = transform.GetComponentInParent<CharacterUnit>();
-            float damage = move.power;
-            if (caster != null)
-                damage *= caster.GetAttackMultiplier();
-            // On transmet la position de l'attaquant pour déterminer la bonne animation
-            target.TakeDamage(damage, caster != null ? caster.transform : null);
+            // En supprimant le champ "power", toutes les animations se fient désormais
+            // à la résolution centralisée de MusicalMoveSO.ApplyEffect pour appliquer
+            // les dégâts, soins ou effets spéciaux. Cela garantit que l'on profite
+            // d'EffectValue, des multiplicateurs et des éventuels statuts associés.
+            move.ApplyEffect(caster, target);
         }
     }
 


### PR DESCRIPTION
## Résumé
- retirer le champ `power` des ScriptableObjects de MusicalMove et documenter l'usage exclusif de `effectValue`
- faire appel à la résolution standard d'un move dans `AnimationEventsManager` afin d'appliquer les effets au lieu d'un calcul dédié
- nettoyer tous les assets de MusicalMove pour qu'ils ne sérialisent plus la propriété `power`

## Tests
- non exécutés (non applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e33513948325963824e1678698a0)