### PR TITLE
Sécuriser la récupération de la BattleCamera pour AddHarmonicPopup

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/AddHarmonicPopup.cs
@@ -42,7 +42,22 @@ public class AddHarmonicPopup : MonoBehaviour
 
         textMesh.text = "+" + amount.ToString();
 
-        battleCamera = GameObject.FindGameObjectWithTag("BattleCamera").GetComponent<Camera>();
+        // Dans certaines scènes de tests simplifiées, la BattleCamera n'est pas instanciée :
+        // on sécurise donc sa récupération pour éviter une NullReference qui crasherait le popup.
+        GameObject battleCameraGO = GameObject.FindGameObjectWithTag("BattleCamera");
+        if (battleCameraGO == null)
+        {
+            Debug.LogWarning("[AddHarmonicPopup] Aucune BattleCamera trouvée : initialisation du popup annulée pour cette scène simplifiée.");
+            return;
+        }
+
+        // La caméra est indispensable pour convertir la position monde en position écran du popup.
+        battleCamera = battleCameraGO.GetComponent<Camera>();
+        if (battleCamera == null)
+        {
+            Debug.LogWarning("[AddHarmonicPopup] Le GameObject BattleCamera n'a pas de composant Camera : initialisation du popup annulée.");
+            return;
+        }
 
         canvasGroup = GetComponent<CanvasGroup>();
         if (canvasGroup == null)


### PR DESCRIPTION
## Summary
- sécuriser la recherche de la BattleCamera avant de récupérer son composant Camera dans AddHarmonicPopup
- interrompre l'initialisation du popup en consignant un avertissement lorsque la BattleCamera est absente ou incomplète

## Testing
- not run (non applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691394677e088325a1767702235ff8f1)