### PR TITLE
Ajout des Sceaux et harmonisation des MusicalMoves

### DIFF
--- a/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
+++ b/Assets/MusicalMoves/MusicalMove_AbimeHarmonique/MusicalMove_AbimeHarmonique.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
   moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Fait dispara\xEEtre le sol sous la cible."
+  description: "Force la cible à flotter pendant deux tours, exposant ses défenses au jeu aérien."
   inventoryCategory: MusicalMove
-  inventorySummary: 
-  consumeOnUse: 1
+  inventorySummary: "Suspend un ennemi (2 tours)."
+  consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []
@@ -28,8 +28,8 @@ MonoBehaviour:
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  effectType: 0
-  effectValue: 0
+  effectType: 9
+  effectValue: 2
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
+++ b/Assets/MusicalMoves/MusicalMove_ArpegeRegenerant/MusicalMove_ArpegeRegenerant.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
   moveType: 2
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Soigne tous les alli\xE9s d'une petite quantit\xE9."
+  description: "Diffuse un arpège soignant environ 20 000 PV à toute l'équipe."
   inventoryCategory: MusicalMove
-  inventorySummary: 
-  consumeOnUse: 1
+  inventorySummary: "Soin de groupe ~20 000 PV."
+  consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
@@ -29,7 +29,7 @@ MonoBehaviour:
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   effectType: 1
-  effectValue: 20
+  effectValue: 20000
   buffStat: 0
   buffAmount: 0
   buffDuration: 0

--- a/Assets/MusicalMoves/MusicalMove_AubeDuMetal.meta
+++ b/Assets/MusicalMoves/MusicalMove_AubeDuMetal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3a78928209b4cb69c7b5bab4e9406aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset
+++ b/Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_AubeDuMetal
+  m_EditorClassIdentifier:
+  moveName: Aube du Métal
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Assène ~9 000 dégâts et confère +10 % de puissance physique pendant deux tours au lanceur."
+  inventoryCategory: MusicalMove
+  inventorySummary: "9 000 dégâts +10 % puissance (2 tours)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 0
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 9000
+  buffStat: 1
+  buffAmount: 10
+  buffDuration: 2
+  buffIsPercentage: 1
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0787920ebc8c439daae667f5f3b773cf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BattementDouverture.meta
+++ b/Assets/MusicalMoves/MusicalMove_BattementDouverture.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ca4d543c8654bf094b69e846c755cb2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset
+++ b/Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_BattementDouverture
+  m_EditorClassIdentifier:
+  moveName: Battement d’Ouverture
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Accorde +200 Initiative et allège d’un point la Fatigue de l’allié ciblé pour ouvrir le tour suivant."
+  inventoryCategory: MusicalMove
+  inventorySummary: "+200 Initiative et allègement de Fatigue (1 tour)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 0
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 3
+  buffAmount: 200
+  buffDuration: 1
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7ded82071314cb0983731d3fbb5e558
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BeatSouterrain.meta
+++ b/Assets/MusicalMoves/MusicalMove_BeatSouterrain.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b4eea15bebf44bd95f9144cc0f6e491
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset
+++ b/Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_BeatSouterrain
+  m_EditorClassIdentifier:
+  moveName: Beat Souterrain
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Onde percussive infligeant ~11 000 dégâts aux ennemis souterrains (7 000 sinon) et drainant 1 Harmonie."
+  inventoryCategory: MusicalMove
+  inventorySummary: "AOE 11 000 dégâts (7 000 si non souterrain)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 11000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 2
+  defaultTargetType: 2
+  targetTypes: 02000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce619d6bffe54b80b90db8d4de657451
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BoucleDeVeille.meta
+++ b/Assets/MusicalMoves/MusicalMove_BoucleDeVeille.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43509e4067ad4d15b635883cedc6d689
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset
+++ b/Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_BoucleDeVeille
+  m_EditorClassIdentifier:
+  moveName: Boucle de Veille
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Tisse un voile absorbant 8 000 dégâts et annule la prochaine altération négative reçue."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Bouclier 8 000 + dissipation suivante."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 0
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 2
+  buffAmount: 0
+  buffDuration: 1
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 690d41f5c60d498eb7573c884527e373
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur.meta
+++ b/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70840835a6f14ca398f89080f4a6eab0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset
+++ b/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_CadenceDuTraqueur
+  m_EditorClassIdentifier:
+  moveName: Cadence du Traqueur
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Frappe à 14 000 dégâts convertissant un buff positif de la cible en Fragment Obscur exploitable par l’équipe."
+  inventoryCategory: MusicalMove
+  inventorySummary: "14 000 dégâts + vol d’un buff en Fragment."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 2
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 14000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d3d6b1488094d679b597c6c112c0a3e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CadreDeSilence.meta
+++ b/Assets/MusicalMoves/MusicalMove_CadreDeSilence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6090ef1440d4432fa65649ffb1e586a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset
+++ b/Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_CadreDeSilence
+  m_EditorClassIdentifier:
+  moveName: Cadre de Silence
+  moveType: 4
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Interrompt la prochaine incantation ennemie et réduit son Initiative de 200 pour préparer les contre-attaques."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Interrompt et -200 Initiative (1 tour)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 3
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 3
+  debuffAmount: 200
+  debuffDuration: 1
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c59e00f669ed4674bf04ce7266e99b40
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs.meta
+++ b/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 75b18f4ea38448d4bd4eab6b6157c5e5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset
+++ b/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_CantateDesProfondeurs
+  m_EditorClassIdentifier:
+  moveName: Cantate des Profondeurs
+  moveType: 4
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Exploit tactique infligeant ~12 000 dégâts (ou étourdit les cibles immergées) tout en drainant 2 Harmonie."
+  inventoryCategory: MusicalMove
+  inventorySummary: "12 000 dégâts ou étourdit une cible immergée."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 3
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 12000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10abb95f7b0245ffab2fcdc4e5d0dc3d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_ConqueResiliente.meta
+++ b/Assets/MusicalMoves/MusicalMove_ConqueResiliente.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c5ecf98dee43404fae9bd27fa24a1163
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset
+++ b/Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_ConqueResiliente
+  m_EditorClassIdentifier:
+  moveName: Conque Résiliente
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Confère un renvoi de 50 % des dégâts de mêlée subis pendant un tour grâce à la coque vibratoire de Munin."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Renvoi 50 % dégâts de mêlée (1 tour)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 2
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 2
+  buffAmount: 0
+  buffDuration: 1
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8084fd881a041ad8c9e27020309f6aa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge.meta
+++ b/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59345548511542b7a2605fb2f511c521
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset
+++ b/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_ContrechantDuRefuge
+  m_EditorClassIdentifier:
+  moveName: Contrechant du Refuge
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Crée une zone réduisant de 30 % les dégâts subis et infligeant 6 000 dégâts aux ennemis qui y entrent durant deux tours."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Zone -30 % dégâts reçus + 6 000 dégâts à l’entrée."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 3
+  harmonicCost: 4
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 4
+  defaultTargetType: 4
+  targetTypes: 04000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c72eb4c303042c59b9f38381cee5be6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
+++ b/Assets/MusicalMoves/MusicalMove_CrescendoFulgurant/MusicalMove_CrescendoFulgurant.asset
@@ -16,21 +16,20 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Inflige de lourds d\xE9g\xE2ts \xE0 une cible unique apr\xE8s un
-    court d\xE9lai."
+  description: "Déchaîne un final concentré infligeant environ 30 000 dégâts à une cible isolée."
   inventoryCategory: MusicalMove
-  inventorySummary: 
-  consumeOnUse: 1
+  inventorySummary: "Finisher ~30 000 dégâts (coût 2/2)."
+  consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
-  fatigueCost: 0
-  harmonicCost: 0
+  fatigueCost: 2
+  harmonicCost: 2
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   effectType: 0
-  effectValue: 30
+  effectValue: 30000
   buffStat: 0
   buffAmount: 0
   buffDuration: 0
@@ -48,7 +47,7 @@ MonoBehaviour:
   cooldown: 1
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
-  altitudeCondition: 1
+  altitudeCondition: 2
   targetType: 1
   defaultTargetType: 1
   targetTypes: 01000000

--- a/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie.meta
+++ b/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35ccc472a1da4f2790ed2cf7f7847d48
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset
+++ b/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_FinaleDeLaFratrie
+  m_EditorClassIdentifier:
+  moveName: Finale de la Fratrie
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Climax narratif infligeant ~28 000 dégâts à une cible, soigne 10 000 PV aux alliés et laisse +1 Harmonie durable."
+  inventoryCategory: MusicalMove
+  inventorySummary: "28 000 dégâts + 10 000 soins d’équipe et +1 Harmonie."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 4
+  harmonicCost: 5
+  harmonicGeneration: 1
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 28000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d1c3b266c6340c2aaf508064fb45394
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite.meta
+++ b/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d845e40689a42f1a4c9cf44c8973cff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset
+++ b/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_FluxDeLegitimite
+  m_EditorClassIdentifier:
+  moveName: Flux de Légitimité
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Diffuse une onde purificatrice : +2 Harmonie à l’équipe et dissipation des malédictions actives."
+  inventoryCategory: MusicalMove
+  inventorySummary: "+2 Harmonie d’équipe et purifie les malédictions."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 3
+  harmonicCost: 3
+  harmonicGeneration: 2
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 4
+  defaultTargetType: 4
+  targetTypes: 04000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 497ef656e13f4c39a5adcb5c9c544358
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie.meta
+++ b/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a10322dcac4b4a7cbb3a5e2e2c110f07
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset
+++ b/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_FrappeEnPolychronie
+  m_EditorClassIdentifier:
+  moveName: Frappe en Polychronie
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Inflige ~20 000 dégâts et déclenche toutes les Marques présentes sur la cible pour 40 000 dégâts supplémentaires chacune."
+  inventoryCategory: MusicalMove
+  inventorySummary: "20 000 dégâts + explosion des Marques."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 3
+  harmonicCost: 4
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 20000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d311eae2a31f4b50b3db75d5b1d34150
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_GlissandoApaisant.meta
+++ b/Assets/MusicalMoves/MusicalMove_GlissandoApaisant.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d163dad4536145618aaa1ef75f27677a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset
+++ b/Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_GlissandoApaisant
+  m_EditorClassIdentifier:
+  moveName: Glissando Apaisant
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Rend ~12 000 PV et dissipe la Peur en rappelant les harmonies lumineuses décrites dans HistoireSymphonie."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Soin 12 000 + retire la Peur."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 0
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 1
+  effectValue: 12000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7688069f85844b03afde7358497828eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_LameDeLune.meta
+++ b/Assets/MusicalMoves/MusicalMove_LameDeLune.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e8a7338344140edb30673bb06a087d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset
+++ b/Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_LameDeLune
+  m_EditorClassIdentifier:
+  moveName: Lame de Lune
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Frappe téléportée infligeant ~16 000 dégâts et applique une Saignée astrale de 4 000 dégâts par tour (2 tours)."
+  inventoryCategory: MusicalMove
+  inventorySummary: "16 000 dégâts + saignée astrale."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 2
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 16000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f578df09bec4f95b6f2859f9a7f0179
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_OscillationEmpathique.meta
+++ b/Assets/MusicalMoves/MusicalMove_OscillationEmpathique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad8d6601574943b981c834a3263e01c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset
+++ b/Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_OscillationEmpathique
+  m_EditorClassIdentifier:
+  moveName: Oscillation Empathique
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Copie le principal buff d’un allié sur Lucian pendant deux tours, parfait pour doubler Accord Bienveillant."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Copie le buff majeur d’un allié sur Lucian."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80fbe24ed95f448d935675c0244fad5f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PasDeBrume.meta
+++ b/Assets/MusicalMoves/MusicalMove_PasDeBrume.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 639220d5ca9a4a038ae0e0953d708734
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset
+++ b/Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_PasDeBrume
+  m_EditorClassIdentifier:
+  moveName: Pas de Brume
+  moveType: 4
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Téléporte l’allié ciblé sur la case adjacente libre la plus proche pour clarifier les trajectoires."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Téléporte un allié adjacent."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 0
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d42deee9aec4208b3e71fd9e2165c3f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale.meta
+++ b/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 141aab83109c4ab5a9f293b55656fc2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset
+++ b/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_PolyrythmieFractale
+  m_EditorClassIdentifier:
+  moveName: Polyrythmie Fractale
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Frappe toutes les cibles pour ~18 000 dégâts +2 000 par effet sonore actif, idéal après Vibration de la Source."
+  inventoryCategory: MusicalMove
+  inventorySummary: "AOE 18 000 dégâts (+2 000 par écho)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 3
+  harmonicCost: 4
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 18000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 2
+  defaultTargetType: 2
+  targetTypes: 02000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5730aa3c74324b59ae6137b4c633d186
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PulseInitiatique.meta
+++ b/Assets/MusicalMoves/MusicalMove_PulseInitiatique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1341d56473443a494b7a5a15e6de530
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset
+++ b/Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_PulseInitiatique
+  m_EditorClassIdentifier:
+  moveName: Pulse Initiatique
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Pulse défensif qui rend 600 PV au lanceur et lui confère une charge de Tempo protectrice (max 2)."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Auto-soin 600 PV + 1 charge de Tempo."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 0
+  harmonicCost: 0
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 1
+  effectValue: 600
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 0
+  defaultTargetType: 0
+  targetTypes: 00000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6beb899df834f51b8ecc725c958975d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_RappelDesFragments.meta
+++ b/Assets/MusicalMoves/MusicalMove_RappelDesFragments.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0acb27933214a73846da4f3d3f7b7a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset
+++ b/Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_RappelDesFragments
+  m_EditorClassIdentifier:
+  moveName: Rappel des Fragments
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Consomme les Fragments de mélodie du lanceur pour rendre 4 000 PV et +1 Harmonie par Fragment accumulé."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Convertit les Fragments en soin + Harmonie."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 2
+  harmonicGeneration: 1
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 1
+  effectValue: 4000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 0
+  defaultTargetType: 0
+  targetTypes: 00000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1d5d3fa7fc5448e8dee6c85de4d135f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin.meta
+++ b/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaadacb5154b427eb1e507f57a1ee919
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset
+++ b/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_RepliqueDeMunin
+  m_EditorClassIdentifier:
+  moveName: Réplique de Munin
+  moveType: 2
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Stocke la prochaine action d’un allié et la rejoue automatiquement au tour suivant sans coût supplémentaire."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Enregistre l’action d’un allié pour le tour suivant."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 2
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 2
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 3
+  defaultTargetType: 3
+  targetTypes: 03000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5484cf63c83e443dba1230d85af0c199
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
+++ b/Assets/MusicalMoves/MusicalMove_Rhapsodie/MusicalMove_Rhapsodie.asset
@@ -16,10 +16,9 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Encha\xEEne un motif classique infligeant environ 7\u202F500 points
-    de d\xE9g\xE2ts\n    avant application des multiplicateurs de runes."
+  description: "Enchaîne un motif classique infligeant environ 7 500 points de dégâts avant d'ajouter la puissance actuelle du lanceur."
   inventoryCategory: MusicalMove
-  inventorySummary: "Attaque simple ~7\u202F500 d\xE9g\xE2ts."
+  inventorySummary: "Attaque ~7 500 dégâts + puissance du lanceur."
   consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 1
@@ -30,7 +29,7 @@ MonoBehaviour:
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   effectType: 0
-  effectValue: 1000
+  effectValue: 7500
   buffStat: 0
   buffAmount: 0
   buffDuration: 0
@@ -48,7 +47,7 @@ MonoBehaviour:
   cooldown: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
-  altitudeCondition: 0
+  altitudeCondition: 2
   targetType: 1
   defaultTargetType: 1
   targetTypes: 01000000

--- a/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche.meta
+++ b/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1303187580b04643ae66e93020437f1d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset
+++ b/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_RumeurDeLaBranche
+  m_EditorClassIdentifier:
+  moveName: Rumeur de la Branche
+  moveType: 4
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Révèle les faiblesses d’un ennemi, offrant +15 % de chances de critique à l’équipe pendant un tour."
+  inventoryCategory: MusicalMove
+  inventorySummary: "Révèle et +15 % critiques d’équipe (1 tour)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 1
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 3
+  effectValue: 0
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 0
+  requiresMovement: 0
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 0}
+  tpVfx_End: {fileID: 0}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78aaae75b3474affb44bc1dda235930a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique.meta
+++ b/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d61926aee8a44be80785ad4b3cf7755
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset
+++ b/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_SerpenteauMelodique
+  m_EditorClassIdentifier:
+  moveName: Serpenteau Mélodique
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Inflige environ 6 000 dégâts et appose un Fragment de mélodie cumulable jusqu’à trois charges."
+  inventoryCategory: MusicalMove
+  inventorySummary: "6 000 dégâts et génère un Fragment."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 1
+  harmonicCost: 0
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 6000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b17825ad13b741fc88819d6733cb064a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
+++ b/Assets/MusicalMoves/MusicalMove_Sforzando/MusicalMove_Sforzando.asset
@@ -16,21 +16,20 @@ MonoBehaviour:
   moveType: 1
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Charge fulgurante qui t\xE9l\xE9porte Lucian devant sa cible avant
-    de lib\xE9rer une onde de choc sonore."
+  description: "Bond téléporté infligeant environ 20 000 dégâts et générant +1 Harmonie."
   inventoryCategory: MusicalMove
-  inventorySummary: 
-  consumeOnUse: 1
+  inventorySummary: "20 000 dégâts, téléporte et rend +1 Harmonie."
+  consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
   harmonicCost: 1
-  harmonicGeneration: 10
+  harmonicGeneration: 1
   consumedHarmonicType: 0
   generatedHarmonicType: 0
   effectType: 0
-  effectValue: 2000
+  effectValue: 20000
   buffStat: 0
   buffAmount: 0
   buffDuration: 0
@@ -48,11 +47,11 @@ MonoBehaviour:
   cooldown: 0
   maxUsesPerTurn: 0
   maxUsesPerBattle: 0
-  altitudeCondition: 0
+  altitudeCondition: 2
   targetType: 1
   defaultTargetType: 1
   targetTypes: 01000000
-  travelTime: 0.1
+  travelTime: 0
   legacyMoveSpeed: 500
   legacyMoveSpeedConverted: 1
   castDistance: 2

--- a/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
+++ b/Assets/MusicalMoves/MusicalMove_StaccatoEtourdissant/MusicalMove_StaccatoEtourdissant.asset
@@ -16,10 +16,10 @@ MonoBehaviour:
   moveType: 3
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: Endort un ennemi pendant un tour.
+  description: "Endort une cible pendant un tour, idéal pour verrouiller un boss avant une offensive."
   inventoryCategory: MusicalMove
-  inventorySummary: 
-  consumeOnUse: 1
+  inventorySummary: "Sommeil ciblé (1 tour)."
+  consumeOnUse: 0
   recommendedMusicalMoves: []
   stayFaceToTarget: 0
   notes: []

--- a/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel.meta
+++ b/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07bdfb2564664b4db91b26cd7cb35ac1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset
+++ b/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_SyncopeDAzazel
+  m_EditorClassIdentifier:
+  moveName: Syncope d’Azazel
+  moveType: 3
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Inflige ~13 000 dégâts, réduit la Défense de 300 et bloque la régénération en générant une dissonance maléfique."
+  inventoryCategory: MusicalMove
+  inventorySummary: "13 000 dégâts et -300 Défense (2 tours)."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 2
+  harmonicCost: 3
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 13000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 2
+  debuffAmount: 300
+  debuffDuration: 2
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 1
+  defaultTargetType: 1
+  targetTypes: 01000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 013d521151694a8b9eeb795466190ddd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
+++ b/Assets/MusicalMoves/MusicalMove_Tunnel/MusicalMove_Tunnel.asset
@@ -13,23 +13,24 @@ MonoBehaviour:
   m_Name: MusicalMove_Tunnel
   m_EditorClassIdentifier: 
   moveName: Tunnel
-  moveType: 3
+  moveType: 4
   onlyAwake: 0
   moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
-  description: "Fait vibrer le sol sous la cible et l'endort jusqu'\xE0 ce qu'elle\n   
-    subisse des d\xE9g\xE2ts."
+  description: "Appose le glyphe Presto : la cible lance une attaque basique après chaque tour jusqu'au retour du lanceur."
   inventoryCategory: MusicalMove
-  inventorySummary: "Endort un ennemi isol\xE9."
+  inventorySummary: "Glyphe Presto : attaques automatiques forcées."
   consumeOnUse: 0
   recommendedMusicalMoves: []
-  stayFaceToTarget: 0
+  stayFaceToTarget: 1
   notes: []
   fatigueCost: 1
   harmonicCost: 1
   harmonicGeneration: 0
   consumedHarmonicType: 0
   generatedHarmonicType: 0
-  effectType: 4
+  effectType: 10
+  passiveEffectPrefab: {fileID: 1144090914521784546, guid: f066fb66a808fc448b02dcc7477eeeb5, type: 3}
+  passiveEffectVerticalOffset: 0
   effectValue: 0
   buffStat: 0
   buffAmount: 0

--- a/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource.meta
+++ b/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a81c691612c947eb9b1016f3b7cf31cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset
+++ b/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8caee409dd862bf429bf43fff5538c9f, type: 3}
+  m_Name: MusicalMove_VibrationDeLaSource
+  m_EditorClassIdentifier:
+  moveName: Vibration de la Source
+  moveType: 1
+  onlyAwake: 0
+  moveIcon: {fileID: 21300000, guid: ce91bdc56c840414db431f433e0d249a, type: 3}
+  description: "Inflige ~15 000 dégâts et applique Résonance (+5 % dégâts harmoniques cumulables) à chaque ennemi frappé."
+  inventoryCategory: MusicalMove
+  inventorySummary: "AOE 15 000 dégâts + Résonance."
+  consumeOnUse: 0
+  recommendedMusicalMoves: []
+  stayFaceToTarget: 1
+  notes: []
+  fatigueCost: 3
+  harmonicCost: 3
+  harmonicGeneration: 0
+  consumedHarmonicType: 0
+  generatedHarmonicType: 0
+  effectType: 0
+  effectValue: 15000
+  buffStat: 0
+  buffAmount: 0
+  buffDuration: 0
+  buffIsPercentage: 0
+  debuffStat: 0
+  debuffAmount: 0
+  debuffDuration: 0
+  debuffIsPercentage: 0
+  useCriticalVariant: 0
+  criticalEffectType: 0
+  criticalEffectValue: 20
+  criticalFatigueCost: 1
+  criticalHarmonicCost: 1
+  criticalHarmonicGeneration: 0
+  cooldown: 0
+  maxUsesPerTurn: 0
+  maxUsesPerBattle: 0
+  altitudeCondition: 2
+  targetType: 2
+  defaultTargetType: 2
+  targetTypes: 02000000
+  travelTime: 0
+  legacyMoveSpeed: 0
+  legacyMoveSpeedConverted: 1
+  castDistance: 1.5
+  requiresMovement: 1
+  teleportDelay: 0.2
+  stayInPlace: 0
+  interceptable: 1
+  relativePosition: 0
+  tpVfx_Start: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpVfx_End: {fileID: 6184656141151889893, guid: fd3bb88cc4cdc8948a3f71e9353dfec9, type: 3}
+  tpSFx_Start: {fileID: 0}
+  tpSFx_End: {fileID: 0}
+  warningClip: {fileID: 0}
+  startDelay: 0
+  enterAwake: 0
+  preparingAnimation: {fileID: 0}
+  preparingTimeline: {fileID: 0}
+  performingTimeline: {fileID: 0}
+  retreatTimeline: {fileID: 0}
+  preparingCameraRole: 5
+  preparingToPerformingCameraDelay: 0
+  performingCameraRole: 2
+  retreatCameraRole: 3

--- a/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset.meta
+++ b/Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e288b05a08df48ff904bc3b4766cdfbc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux.meta
+++ b/Assets/Sceaux.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b81c35d07cf347bc97745b06207a357f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi.meta
+++ b/Assets/Sceaux/Defi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54ff808cdf0e44d19ae094c813b555c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset
+++ b/Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_HarmonieFrele
+  m_EditorClassIdentifier:
+  sealName: Sceau d’Harmonie Frêle
+  archetype: 1
+  intensity: 1
+  icon: {fileID: 0}
+  effectSummary: -30 % PV max pour tous les alliés mais +50 % régénération d’Harmonie.
+  usageTips: Favorise les compositions centrées sur les combos incessants décrits dans HistoireSymphonie.
+  scoreModifierPercent: 15
+  loreNote: Les virtuoses l’utilisent pour courir après la perfection au détriment de leur survie.

--- a/Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset.meta
+++ b/Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a35477b7ea1c4030b5acf8d30018d8d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi/Sceau_LameDechainee.asset
+++ b/Assets/Sceaux/Defi/Sceau_LameDechainee.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_LameDechainee
+  m_EditorClassIdentifier:
+  sealName: Sceau de Lame Déchaînée
+  archetype: 1
+  intensity: 1
+  icon: {fileID: 0}
+  effectSummary: +25 % dégâts subis par le porteur et +20 % dégâts infligés.
+  usageTips: Transforme le porteur en glass-cannon pour les combats éclairs maîtrisés.
+  scoreModifierPercent: 10
+  loreNote: Symbole des duels rapides relatés lors de la révolte contre Azazel.

--- a/Assets/Sceaux/Defi/Sceau_LameDechainee.asset.meta
+++ b/Assets/Sceaux/Defi/Sceau_LameDechainee.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1501643868db48c39e962ccd6095826d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi/Sceau_MesureInflexible.asset
+++ b/Assets/Sceaux/Defi/Sceau_MesureInflexible.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_MesureInflexible
+  m_EditorClassIdentifier:
+  sealName: Sceau de la Mesure Inflexible
+  archetype: 1
+  intensity: 1
+  icon: {fileID: 0}
+  effectSummary: Les cooldowns ne peuvent plus être réduits mais chaque coup critique génère +1 Harmonie.
+  usageTips: Encourage la précision rythmique et le placement de critiques successifs.
+  scoreModifierPercent: 10
+  loreNote: Né pendant l’ultime affrontement contre la Convocation pour sanctifier la rigueur.

--- a/Assets/Sceaux/Defi/Sceau_MesureInflexible.asset.meta
+++ b/Assets/Sceaux/Defi/Sceau_MesureInflexible.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46539339f7c14f9ebd894a4b123e0cef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset
+++ b/Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_SilenceAbsolu
+  m_EditorClassIdentifier:
+  sealName: Sceau de Silence Absolu
+  archetype: 1
+  intensity: 1
+  icon: {fileID: 0}
+  effectSummary: Désactive les soins externes reçus mais +40 % dégâts sur les MusicalMoves offensifs.
+  usageTips: À réserver aux runs où l’équipe élimine les ennemis avant toute riposte.
+  scoreModifierPercent: 12
+  loreNote: Gravé lors du serment de Lucian pour combattre sans filet face aux hérauts d’Azazel.

--- a/Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset.meta
+++ b/Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 067ebf8960704e74be64532a5fe8ebcb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset
+++ b/Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_VirtuositeSoliste
+  m_EditorClassIdentifier:
+  sealName: Sceau de Virtuosité Soliste
+  archetype: 1
+  intensity: 1
+  icon: {fileID: 0}
+  effectSummary: Le porteur ne reçoit plus de buffs alliés mais gagne +35 % Initiative et +15 % critique.
+  usageTips: Test ultime pour piloter un héros isolé dans les duels prolongés contre les menaces majeures.
+  scoreModifierPercent: 15
+  loreNote: Inspiré par les solos de Kael lors des concerts d’adieu de la Fratrie.

--- a/Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset.meta
+++ b/Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ac489994f484a9781aafedf1e35939c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques.meta
+++ b/Assets/Sceaux/Specifiques.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdb58a2c9e484837b4a2fe2fa99f9046
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset
+++ b/Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_GraviteMesuree
+  m_EditorClassIdentifier:
+  sealName: Sceau de Gravité Mesurée
+  archetype: 2
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Réduit de 60 % les effets de poussée/traction subis et -25 % dégâts de chute.
+  usageTips: Essentiel dans les arènes instables où les Séraphins manipulent la gravité.
+  scoreModifierPercent: -10
+  loreNote: Les maîtres de la pesanteur du Sanctuaire l’utilisent lors des ascensions décrites dans la chronique.

--- a/Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset.meta
+++ b/Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78ada3fea1184ed49ee85f8b194b500c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset
+++ b/Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_HarpeSolaire
+  m_EditorClassIdentifier:
+  sealName: Sceau de la Harpe Solaire
+  archetype: 2
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +20 % dégâts contre les créatures du Néant et lumière persistante annulant la Peur.
+  usageTips: À équiper lors des expéditions dans les couloirs obscurs de la Convocation montante.
+  scoreModifierPercent: -15
+  loreNote: Réunit les rayons de l’aube que Munin convoqua pour repousser les ombres de la Convocation.

--- a/Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset.meta
+++ b/Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a2632ccbb7740dba9b2216d4306c564
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset
+++ b/Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_MurmureProtecteur
+  m_EditorClassIdentifier:
+  sealName: Sceau de Murmure Protecteur
+  archetype: 2
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +20 % PV max et +15 % résistances harmoniques.
+  usageTips: Idéal contre les prédateurs empathiques ou les gardiens drainants qui pressent l’équipe.
+  scoreModifierPercent: -10
+  loreNote: Les veilleurs des Murmures l’emportent lors des vigies nocturnes relatées dans HistoireSymphonie.

--- a/Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset.meta
+++ b/Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11d955a06c5e461cb4968ee05b3a3e42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset
+++ b/Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_ResonanceApaisee
+  m_EditorClassIdentifier:
+  sealName: Sceau de Résonance Apaisée
+  archetype: 2
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Réduit de 50 % les dégâts de Résonance et Dissonance.
+  usageTips: Neutralise les débordements harmoniques des chorales séraphiques ou des avatars d’Azazel.
+  scoreModifierPercent: -10
+  loreNote: Bercé par les chants apaisants de Luna pour calmer les tempêtes du Néant.

--- a/Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset.meta
+++ b/Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea68c5d2e9cb48f99ccf4e615d7d6d8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset
+++ b/Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_VigilanceNocturne
+  m_EditorClassIdentifier:
+  sealName: Sceau de Vigilance Nocturne
+  archetype: 2
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +25 % résistance aux altérations mentales et vision des entités furtives pendant 2 tours.
+  usageTips: Indispensable dans les zones saturées d’illusions ou face aux assassins oniriques.
+  scoreModifierPercent: -10
+  loreNote: Veille constante des sentinelles du Rêve décrite dans les chapitres nocturnes d’HistoireSymphonie.

--- a/Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset.meta
+++ b/Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6e1c6df35fc4cfb8f95c32c2371ef0d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels.meta
+++ b/Assets/Sceaux/Universels.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22fd2ebed82f4634842df0f955fd5e79
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_AvantScene.asset
+++ b/Assets/Sceaux/Universels/Sceau_AvantScene.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_AvantScene
+  m_EditorClassIdentifier:
+  sealName: Sceau de l’Avant-Scène
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +150 Initiative et posture de garde automatique au premier tour.
+  usageTips: Assure la priorité au meneur pour déclencher Pour qui sonne le glas avant toute riposte.
+  scoreModifierPercent: -10
+  loreNote: Gravé pour les entrées théâtrales de Lucian afin de respecter la dramaturgie de Symphonie.

--- a/Assets/Sceaux/Universels/Sceau_AvantScene.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_AvantScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 677450a8ac6646349e35e586a0629984
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_CadenceStable.asset
+++ b/Assets/Sceaux/Universels/Sceau_CadenceStable.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_CadenceStable
+  m_EditorClassIdentifier:
+  sealName: Sceau de Cadence Stable
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Réduit tous les cooldowns de 1 tour (minimum 1).
+  usageTips: Maintient un tempo régulier pour enchaîner Tunnel, Staccato Étourdissant et les ultimes offensifs.
+  scoreModifierPercent: -10
+  loreNote: Munin a gravé ce sceau pour stabiliser le rythme des novices lors des duels décrits dans HistoireSymphonie.

--- a/Assets/Sceaux/Universels/Sceau_CadenceStable.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_CadenceStable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1f41a29e9764b439cf4c910f44ec197
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset
+++ b/Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_CercleHarmonise
+  m_EditorClassIdentifier:
+  sealName: Sceau du Cercle Harmonisé
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Crée au tour 1 une zone réduisant de 15 % les dégâts reçus par les alliés adjacents (2 tours).
+  usageTips: Idéal pour fortifier le noyau de soutien autour d’Arpège Régénérant.
+  scoreModifierPercent: -10
+  loreNote: Issu des rites de rassemblement de la Fratrie lorsque Munin dirige la scène.

--- a/Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8099a85ab89b421991938753c4bf09ec
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset
+++ b/Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_CoeurAccorde
+  m_EditorClassIdentifier:
+  sealName: Sceau du Cœur Accordé
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +30 % soins reçus et +10 % régénération d’Harmonie pendant 3 tours.
+  usageTips: Amplifie Arpège Régénérant et soutient les duos mélodiques détaillés dans HistoireSymphonie.
+  scoreModifierPercent: -10
+  loreNote: Scellé lors de la veillée des Fragments Calmes pour préserver l’écho des anciens compagnons.

--- a/Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 103a37061c864f46b7cdb86f8a6d3412
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_CordesStoiques.asset
+++ b/Assets/Sceaux/Universels/Sceau_CordesStoiques.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_CordesStoiques
+  m_EditorClassIdentifier:
+  sealName: Sceau des Cordes Stoïques
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +40 % durée des buffs défensifs du porteur et +10 % résistances globales.
+  usageTips: Prolonge Accord Bienveillant et les runes protectrices évoquées dans HistoireSymphonie.
+  scoreModifierPercent: -10
+  loreNote: Tressé à partir des cordes de la harpe de Munin pour les défenseurs de la Fratrie.

--- a/Assets/Sceaux/Universels/Sceau_CordesStoiques.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_CordesStoiques.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ccad5b47e2a44d6b02a936259430a33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset
+++ b/Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_EchoSuspendu
+  m_EditorClassIdentifier:
+  sealName: Sceau de l’Écho Suspendu
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: La première attaque de zone ennemie inflige -40 % dégâts et ne peut pas repousser.
+  usageTips: Protège les lignes pendant la préparation d’un Crescendo Fulgurant ou d’un Contrechant du Refuge.
+  scoreModifierPercent: -10
+  loreNote: Inspiré par les chants suspendus de Luna pour immobiliser les vagues séraphiques.

--- a/Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fa04d4f5d7b4dd08eaf609f1b92caa3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset
+++ b/Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_FatigueAllegee
+  m_EditorClassIdentifier:
+  sealName: Sceau de Fatigue Allégée
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Réduit de 1 le coût en Fatigue des MusicalMoves du premier tour (minimum 0).
+  usageTips: Accélère la mise en place de plusieurs buffs immédiats sans pénaliser la suite du combat.
+  scoreModifierPercent: -10
+  loreNote: Munin l’offre aux chefs d’orchestre hésitants avant les assauts initiaux des Séraphins.

--- a/Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f63863353dd14797bd2de69e885d61a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset
+++ b/Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_FragmentsCalmes
+  m_EditorClassIdentifier:
+  sealName: Sceau des Fragments Calmes
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Convertit jusqu’à 2 fragments de mélodie en un voile de 4 000 PV chacun au début du combat.
+  usageTips: Protège les plans centrés sur Rappel des Fragments avant un basculement offensif.
+  scoreModifierPercent: -10
+  loreNote: Résonne avec les souvenirs des compagnons tombés évoqués dans la chronique HistoireSymphonie.

--- a/Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77c46dcf503642feb0c32e73688d41fc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset
+++ b/Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_ImpulsionFranche
+  m_EditorClassIdentifier:
+  sealName: Sceau de l’Impulsion Franche
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Les trois premiers MusicalMoves lancés coûtent -1 Harmonie (minimum 0).
+  usageTips: Accélère les ouvertures agressives basées sur Sforzando et Crescendo Fulgurant.
+  scoreModifierPercent: -15
+  loreNote: Né des récits de Kael pour surprendre les Séraphins lors des assauts éclairs.

--- a/Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a315da5f1b88442f9945c0f8b0c98f9c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_MainGuidee.asset
+++ b/Assets/Sceaux/Universels/Sceau_MainGuidee.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_MainGuidee
+  m_EditorClassIdentifier:
+  sealName: Sceau de Main Guidée
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +25 % dégâts sur les attaques basiques uniquement.
+  usageTips: Parfait pour des ouvertures autour de Rhapsodie ou Serpenteau Mélodique avant de lancer les combos lourds.
+  scoreModifierPercent: -10
+  loreNote: Les Fratries en apprentissage l’utilisent pour ressentir la pulsation héroïque avant les concerts martiaux.

--- a/Assets/Sceaux/Universels/Sceau_MainGuidee.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_MainGuidee.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1148a80728a42e9845b4be4c3f91a1c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_OndePerseverante.asset
+++ b/Assets/Sceaux/Universels/Sceau_OndePerseverante.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_OndePerseverante
+  m_EditorClassIdentifier:
+  sealName: Sceau de l’Onde Persévérante
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: À 50 % PV, déclenche une vague de soin de 12 000 PV (1 fois par combat).
+  usageTips: Idéal pour soutenir les tanks lors des duels prolongés contre Azazel.
+  scoreModifierPercent: -10
+  loreNote: Les érudits du Refuge l’activent lors des longues veillées pour raviver la flamme de la Fratrie.

--- a/Assets/Sceaux/Universels/Sceau_OndePerseverante.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_OndePerseverante.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30d5abd1d4194243a57cd83a3e10798f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_PulsationConstante.asset
+++ b/Assets/Sceaux/Universels/Sceau_PulsationConstante.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_PulsationConstante
+  m_EditorClassIdentifier:
+  sealName: Sceau de Pulsation Constante
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: +1 charge de Tempo et +300 Initiative au groupe au tour 1.
+  usageTips: Synchronise immédiatement l’équipe pour lancer un assaut coordonné dès l’ouverture.
+  scoreModifierPercent: -10
+  loreNote: Forgé dans les ateliers de Munin pour apprivoiser les battements décrits dans le prologue de Symphonie.

--- a/Assets/Sceaux/Universels/Sceau_PulsationConstante.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_PulsationConstante.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6be141b8482a498b85353b1d32b49261
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_RempartArcanique.asset
+++ b/Assets/Sceaux/Universels/Sceau_RempartArcanique.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_RempartArcanique
+  m_EditorClassIdentifier:
+  sealName: Sceau du Rempart Arcanique
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Octroie un bouclier de 6 000 PV et dissipe 1 altération au début du combat.
+  usageTips: Sécurise l’entrée en scène face aux Séraphins saturés de malédictions.
+  scoreModifierPercent: -10
+  loreNote: Tiré des archives de la Convocation, il protège les héros lors des premières confrontations d’Azazel.

--- a/Assets/Sceaux/Universels/Sceau_RempartArcanique.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_RempartArcanique.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a34f9eb018e84e608f04877a3dd8b1b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_RumeurLucide.asset
+++ b/Assets/Sceaux/Universels/Sceau_RumeurLucide.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_RumeurLucide
+  m_EditorClassIdentifier:
+  sealName: Sceau de la Rumeur Lucide
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: Révèle l’intention de la cible principale pendant 2 tours et +15 % chances de critique contre elle.
+  usageTips: Optimise les fenêtres d’exécution pour Rupture Harmonieuse et Frappe en Polychronie.
+  scoreModifierPercent: -10
+  loreNote: Les archivistes l’emploient pour anticiper les motifs secrets des Séraphins dissidents.

--- a/Assets/Sceaux/Universels/Sceau_RumeurLucide.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_RumeurLucide.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f37e871f040247faa9646790da8efed7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Sceaux/Universels/Sceau_SilenceStratege.asset
+++ b/Assets/Sceaux/Universels/Sceau_SilenceStratege.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0de7f5c6b44044e28d89d7c6c8dbc456, type: 3}
+  m_Name: Sceau_SilenceStratege
+  m_EditorClassIdentifier:
+  sealName: Sceau du Silence Stratège
+  archetype: 0
+  intensity: 0
+  icon: {fileID: 0}
+  effectSummary: La première incantation ennemie est retardée d’un tour et inflige -20 % dégâts.
+  usageTips: Ouvre une fenêtre pour interrompre les chorales séraphiques via Cadre de Silence.
+  scoreModifierPercent: -10
+  loreNote: Utilisé par les sentinelles nocturnes pour contrecarrer les prières forcées du Néant.

--- a/Assets/Sceaux/Universels/Sceau_SilenceStratege.asset.meta
+++ b/Assets/Sceaux/Universels/Sceau_SilenceStratege.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec47eb535f6246cdb39f2a654945dcb3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Classes/SceauSO.cs
+++ b/Assets/Scripts/Classes/SceauSO.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+/// <summary>
+///     ScriptableObject décrivant un Sceau modulant la difficulté selon la documentation « Répertoire des MusicalMoves ».
+///     Chaque instance encode les ajustements de score, les effets de gameplay et les conseils narratifs afin que
+///     l'éditeur Unity affiche des données homogènes pour les game designers.
+/// </summary>
+[CreateAssetMenu(fileName = "NewSceau", menuName = "Symphonie/Sceau")]
+public class SceauSO : ScriptableObject
+{
+    [Header("Identité et catégorisation"), Tooltip("Nom affiché dans l'inventaire et les interfaces.")]
+    public string sealName = "Nouveau Sceau";
+
+    [Tooltip("Regroupe le Sceau selon la famille décrite dans la documentation (universel, défi, spécifique).")]
+    public SceauArchetype archetype = SceauArchetype.Universel;
+
+    [Tooltip("Indique si le Sceau facilite (valeurs négatives) ou augmente la difficulté (valeurs positives).")]
+    public SceauIntensity intensity = SceauIntensity.Facilitation;
+
+    [Tooltip("Icône optionnelle pour illustrer le Sceau dans les menus.")]
+    public Sprite icon;
+
+    [Header("Effets de gameplay"), Tooltip("Résumé concis de l'effet principal pour les designers.")]
+    [TextArea]
+    public string effectSummary;
+
+    [Tooltip("Conseils sur les meilleures situations d'utilisation afin de guider les nouveaux joueurs.")]
+    [TextArea]
+    public string usageTips;
+
+    [Tooltip("Modification du score final en pourcentage. Utiliser des valeurs négatives pour les Sceaux de facilitation.")]
+    public float scoreModifierPercent;
+
+    [Header("Contexte narratif"), Tooltip("Note facultative pour relier le Sceau à l'histoire de Symphonie.")]
+    [TextArea]
+    public string loreNote;
+}
+
+/// <summary>
+/// Catégories décrivant le périmètre d'utilisation du Sceau.
+/// </summary>
+public enum SceauArchetype
+{
+    Universel,
+    UniverselDefi,
+    Specifique
+}
+
+/// <summary>
+/// Renseigne si le Sceau rend la partie plus accessible ou propose un défi supplémentaire.
+/// </summary>
+public enum SceauIntensity
+{
+    Facilitation,
+    Defi
+}

--- a/Assets/Scripts/Classes/SceauSO.cs.meta
+++ b/Assets/Scripts/Classes/SceauSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0de7f5c6b44044e28d89d7c6c8dbc456
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/RepertoireActionsMusicales.md
+++ b/Docs/RepertoireActionsMusicales.md
@@ -104,3 +104,65 @@ rencontres et les variantes spécifiques optimisées pour des situations récurr
 | **Finale de la Fratrie** | Ultime | 4 / 5 | 28 000 dégâts à une cible et 10 000 soins aux alliés, puis +1 Harmonie durable. | Climax narratif : à employer lorsque Munin soutient Lucian contre Azazel, offrant une conclusion émotive et stratégique. |
 
 En maîtrisant cette liste, chaque chef d’orchestre dispose d'un guide clair tandis que les virtuoses peuvent planifier des suites d'accords fidèles à la légende de Symphonie.
+
+
+### Implémentation Unity des nouvelles actions
+
+| Nom | Asset Unity | Fatigue / Harmonie | Effet principal | Notes d'utilisation |
+|-----|-------------|--------------------|-----------------|---------------------|
+| Battement d’Ouverture | `Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset` | 0 / 1 | Buff Initiative +200, réduction de Fatigue (1 tour) | Prépare les ouvertures de Kael ou Luna avant un tour explosif. |
+| Serpenteau Mélodique | `Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset` | 1 / 0 | ~6 000 dégâts + applique un Fragment de mélodie | Accumule les Fragments pour Rappel des Fragments ou Frappe en Polychronie. |
+| Cantate des Profondeurs | `Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset` | 2 / 3 | ~12 000 dégâts (étourdit les cibles immergées) | Synergie directe avec Abîme Harmonique pour verrouiller une cible. |
+| Polyrythmie Fractale | `Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset` | 3 / 4 | AOE ~18 000 dégâts +2 000 par effet sonore | Clôture les combos après Vibration de la Source. |
+| Pulse Initiatique | `Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset` | 0 / 0 | Auto-soin 600 PV + charge de Tempo | Sécurise le lanceur avant une séquence à risque. |
+| Boucle de Veille | `Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset` | 0 / 1 | Voile absorbant 8 000 dégâts + annule la prochaine altération | Protège un allié clé avant l’arrivée des malédictions séraphiques. |
+| Glissando Apaisant | `Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset` | 1 / 0 | ~12 000 soins + dissipe la Peur | Incontournable face aux assauts émotionnels de l’Ange Pleureur. |
+| Aube du Métal | `Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset` | 1 / 0 | ~9 000 dégâts +10 % puissance physique (2 tours) | Lance les combos physiques décrits dans HistoireSymphonie. |
+| Pas de Brume | `Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset` | 1 / 0 | Téléporte l’allié ciblé sur une case adjacente | Repositionne Munin sans déclencher d’interception. |
+| Oscillation Empathique | `Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset` | 1 / 1 | Copie le buff majeur d’un allié sur Lucian (2 tours) | Double Accord Bienveillant avant un pic de dégâts. |
+| Cadre de Silence | `Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset` | 1 / 1 | Interruption + -200 Initiative (1 tour) | À déclencher lorsque les Séraphins préparent une bénédiction. |
+| Rumeur de la Branche | `Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset` | 1 / 1 | Dévoile la cible et +15 % critique d’équipe | Optimise Frappe en Polychronie contre les lieutenants du Rêve. |
+| Lame de Lune | `Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset` | 1 / 2 | ~16 000 dégâts + Saignée astrale | Synergie avec Hate pour rester au contact en mêlée. |
+| Beat Souterrain | `Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset` | 2 / 1 | AOE ~11 000 dégâts (7 000 si non souterrain) | Couvre les anomalies de terrain détaillées dans Docs/ConditionsAltitude.md. |
+| Cadence du Traqueur | `Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset` | 2 / 2 | ~14 000 dégâts + convertit un buff en Fragment Obscur | Prépare les explosions de Crescendo Fulgurant. |
+| Réplique de Munin | `Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset` | 2 / 2 | Stocke l’action d’un allié pour le tour suivant | Duplique un soin critique ou un Sforzando surprise. |
+| Syncope d’Azazel | `Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset` | 2 / 3 | ~13 000 dégâts et -300 Défense (2 tours) | Neutralise les clones d’Azazel en empêchant la régénération. |
+| Conque Résiliente | `Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset` | 2 / 2 | Renvoi 50 % dégâts mêlée (1 tour) | Combinez avec Pour qui sonne le glas pour tenir la ligne. |
+| Rappel des Fragments | `Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset` | 2 / 2 | Convertit les Fragments en 4 000 PV +1 Harmonie chacun | Point de bascule entre early et mid-game. |
+| Vibration de la Source | `Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset` | 3 / 3 | AOE ~15 000 dégâts + Résonance cumulable | Prépare Polyrythmie Fractale pour saturer les défenses. |
+| Flux de Légitimité | `Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset` | 3 / 3 | +2 Harmonie d’équipe et purification | À garder pour les phases critiques de la Convocation. |
+| Contrechant du Refuge | `Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset` | 3 / 4 | Zone -30 % dégâts subis + 6 000 dégâts à l’entrée | Verrouille un sanctuaire comme décrit dans HistoireSymphonie. |
+| Frappe en Polychronie | `Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset` | 3 / 4 | ~20 000 dégâts + déclenche les Marques | Finisher idéal après les combos de Kael. |
+| Finale de la Fratrie | `Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset` | 4 / 5 | ~28 000 dégâts, soigne 10 000 PV aux alliés, +1 Harmonie | Climax narratif lors des duels contre Azazel. |
+
+### ScriptableObjects Sceaux
+
+Les Sceaux décrits en début de document sont désormais disponibles sous `Assets/Sceaux` et utilisent le script `Assets/Scripts/Classes/SceauSO.cs`. Le tableau ci-dessous récapitule les instances fournies :
+
+| Nom | Asset Unity | Famille | Modificateur de score |
+|-----|-------------|---------|-----------------------|
+| Sceau de Cadence Stable | `Assets/Sceaux/Universels/Sceau_CadenceStable.asset` | Universel | -10 % |
+| Sceau de Main Guidée | `Assets/Sceaux/Universels/Sceau_MainGuidee.asset` | Universel | -10 % |
+| Sceau de Fatigue Allégée | `Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset` | Universel | -10 % |
+| Sceau du Rempart Arcanique | `Assets/Sceaux/Universels/Sceau_RempartArcanique.asset` | Universel | -10 % |
+| Sceau de l’Avant-Scène | `Assets/Sceaux/Universels/Sceau_AvantScene.asset` | Universel | -10 % |
+| Sceau du Cœur Accordé | `Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset` | Universel | -10 % |
+| Sceau de l’Écho Suspendu | `Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset` | Universel | -10 % |
+| Sceau de Pulsation Constante | `Assets/Sceaux/Universels/Sceau_PulsationConstante.asset` | Universel | -10 % |
+| Sceau de l’Onde Persévérante | `Assets/Sceaux/Universels/Sceau_OndePerseverante.asset` | Universel | -10 % |
+| Sceau de l’Impulsion Franche | `Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset` | Universel | -15 % |
+| Sceau des Cordes Stoïques | `Assets/Sceaux/Universels/Sceau_CordesStoiques.asset` | Universel | -10 % |
+| Sceau de la Rumeur Lucide | `Assets/Sceaux/Universels/Sceau_RumeurLucide.asset` | Universel | -10 % |
+| Sceau des Fragments Calmes | `Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset` | Universel | -10 % |
+| Sceau du Cercle Harmonisé | `Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset` | Universel | -10 % |
+| Sceau du Silence Stratège | `Assets/Sceaux/Universels/Sceau_SilenceStratege.asset` | Universel | -10 % |
+| Sceau de Lame Déchaînée | `Assets/Sceaux/Defi/Sceau_LameDechainee.asset` | Défi | +10 % |
+| Sceau de Silence Absolu | `Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset` | Défi | +12 % |
+| Sceau d’Harmonie Frêle | `Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset` | Défi | +15 % |
+| Sceau de la Mesure Inflexible | `Assets/Sceaux/Defi/Sceau_MesureInflexible.asset` | Défi | +10 % |
+| Sceau de Virtuosité Soliste | `Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset` | Défi | +15 % |
+| Sceau de Murmure Protecteur | `Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset` | Spécifique | -10 % |
+| Sceau de Résonance Apaisée | `Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset` | Spécifique | -10 % |
+| Sceau de Vigilance Nocturne | `Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset` | Spécifique | -10 % |
+| Sceau de la Harpe Solaire | `Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset` | Spécifique | -15 % |
+| Sceau de Gravité Mesurée | `Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset` | Spécifique | -10 % |


### PR DESCRIPTION
## Résumé
- ajout d’un ScriptableObject `SceauSO` pour centraliser les paramètres de difficulté et création des 25 Sceaux décrits dans la documentation
- création des 24 MusicalMoves manquants avec leurs coûts, effets et résumés narratifs, ainsi que mise à jour des moves existants pour refléter la fiche de design
- extension de `Docs/RepertoireActionsMusicales.md` afin de référencer les nouveaux assets Unity et leurs usages

## Tests
- non exécutés (données Unity uniquement)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139aad65cc8325b95db647043585a7)