### PR TITLE
Add Unity documentation folder

### DIFF
--- a/Assets/Documentation.meta
+++ b/Assets/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 207400894b5b4d20abead349904f4348
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/AngePleureur.md
+++ b/Assets/Documentation/AngePleureur.md
@@ -1,0 +1,43 @@
+# 🎭 Scénario : Le combat contre l’Ange Pleureur
+
+<!-- Document décrivant la scène d'ouverture et servant de référence narrative. -->
+
+## Mise en scène
+- **Lieu** : Lucian quitte son monde figé et atteint une clairière irréelle où la pluie coule sans bruit sous une voûte liquide.
+- **Apparition** : une silhouette agenouillée se redresse lentement ; un ange aux ailes ternies révèle un visage sans traits dont jaillissent des larmes lumineuses.
+- Munin vibre face à cette douleur incompréhensible pour Lucian.
+
+## Phase 1 : Tutoriel inversé
+- **Objectif gameplay** : enseigner attaque, esquive et parade.
+- **Attaques** :
+  - *Pluie de larmes* : projectiles lumineux tombant en rythme.
+  - *Étreinte désespérée* : bras translucides retenant Lucian, libération via QTE.
+  - *Cri muet* : onde désorientante supprimant temporairement le menu d’action.
+- La barre de vie de l’ange est immense, signalant l’impossibilité de victoire.
+
+## Phase 2 : Désespérance
+- Les attaques deviennent rapides et écrasantes ; seule la maîtrise des mécaniques permet de survivre.
+- La caméra de Munin bouge nerveusement, laissant parfois entendre un souffle : « tiens bon… ».
+
+## Intervention du père
+- Des flashes montrent un homme détournant le regard en tenant un enfant par la main.
+- Munin interprète ce souvenir comme une indifférence, alors que le père tente de paraître fort tout en portant un lourd fardeau.
+- Ce contraste renforce la puissance de l’ange, nourrie par la douleur maternelle face au silence paternel.
+
+## Climax : Défaite inévitable
+- Une vague de larmes submerge tout et met Lucian à genoux.
+- Munin téléporte Lucian hors du champ de bataille pour empêcher une nouvelle mort.
+
+## Après-combat : La brèche
+- Lucian se réveille dans une zone fissurée du Rêve.
+- Une première entité instable, obsédée par les imperfections, cherche à « réparer » Lucian.
+- L’Ange Pleureur résulte du deuil non résolu de la mère ; l’incompréhension du père en amplifie la fracture émotionnelle.
+- Cette fracture attire les entités du Rêve et ouvre la voie vers le conflit cosmique lié à Azazel et aux âmes incomplètes.
+
+## Répercussions dans l’histoire
+- L’ange révèle plus tard son identité : la mère de Lucian incapable de faire son deuil.
+- Lucian a dû fuir son étreinte, seconde mort symbolique.
+- Les souvenirs du père, apparemment froid, dévoilent progressivement son sacrifice pour Munin.
+- Azazel cherche à sauver ces âmes piégées dans le deuil ; l’ange pleureur prépare la compréhension de ses motivations.
+- Boss tutoriel tragique, impossible à vaincre, il introduit la double image parentale et la transition vers l’arc principal.
+

--- a/Assets/Documentation/AngePleureur.md.meta
+++ b/Assets/Documentation/AngePleureur.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83a48919d0b849e9a1fdf94618a8fd41
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/Ash_Bark_Veins.md
+++ b/Assets/Documentation/Ash_Bark_Veins.md
@@ -1,0 +1,56 @@
+# Effet de veines pour le shader "Ash_Bark"
+
+## Contexte narratif
+Pour rester cohérent avec l'histoire décrite dans *Histoire de Symphonie*, l'écorce des frênes
+présents dans les zones sanctifiées laisse désormais transparaître l'énergie vitale qui circule
+à l'intérieur de l'arbre. Cet effet rappelle que ces arbres jouent un rôle clé dans la
+propagation de l'harmonie sur Melodine et qu'ils sont intimement liés aux flux magiques qui
+alimentent les instruments vivants.
+
+## Résumé visuel
+- Animation continue simulant un écoulement sanguin dans les veines de l'écorce.
+- Pulsation lumineuse synchronisée avec un battement régulier pour suggérer une énergie
+  organique.
+- Couleur des veines et intensité émissive entièrement configurables afin d'adapter l'effet aux
+  ambiances de scènes débutant ou avancées.
+
+## Propriétés ajoutées
+| Propriété | Type | Description |
+|-----------|------|-------------|
+| **Vein Mask** | Texture2D | Masque en niveaux de gris qui définit l'emplacement des veines. |
+| **Vein UV Scale** | Vector2 | Permet d'ajuster l'échelle du masque pour s'adapter aux variations de densité de l'écorce. |
+| **Vein Flow Direction** | Vector2 | Direction de déplacement des veines, par défaut vers l'axe V pour suivre la fibre de l'arbre. |
+| **Vein Flow Speed** | Float | Vitesse du flux sanguin simulé ; valeurs négatives inversent le sens de déplacement. |
+| **Vein Pulse Speed** | Float | Fréquence de la pulsation lumineuse. |
+| **Vein Emission Strength** | Float | Intensité maximale de l'émission lorsque la pulsation est à son apogée. |
+| **Vein Base Intensity** | Float | Intensité minimale maintenue entre deux pulsations pour conserver une lueur résiduelle. |
+| **Vein Color** | Color | Couleur de l'émission des veines. |
+
+## Schéma logique des nouveaux nœuds
+1. **UV dynamique** :
+   - Un nœud *UV* est scindé puis recombiné pour appliquer un facteur d'échelle.
+   - Le produit du temps global et de *Vein Flow Speed* est multiplié par *Vein Flow Direction*
+     puis additionné au résultat afin de paner le masque.
+2. **Échantillonnage du masque** :
+   - Le masque de veines est échantillonné avec l'UV animé pour obtenir un coefficient de
+     présence par pixel.
+3. **Pulsation** :
+   - Le temps est multiplié par *Vein Pulse Speed* puis passé dans un nœud *Sine*.
+   - Une constante `1.0` et une constante `0.5` normalisent la sortie entre 0 et 1.
+   - Le résultat est amplifié par *Vein Emission Strength* puis rehaussé par *Vein Base Intensity*.
+4. **Emission finale** :
+   - L'intensité pulsée est multipliée par le masque (canal R) et par *Vein Color* avant d'être
+     envoyée dans le slot `Emission` du bloc *SurfaceDescription*.
+
+## Conseils d'utilisation
+- Préparer un masque en niveaux de gris où les veines sont claires et l'écorce est sombre.
+- Ajuster *Vein Flow Direction* pour suivre le sens des fibres du modèle 3D.
+- Pour un rendu plus dramatique dans les scènes avancées, augmenter légèrement *Vein Base
+  Intensity* et *Vein Emission Strength* afin de rappeler la tension narrative croissante.
+- Laisser *Vein Pulse Speed* proche de 1 pour les zones calmes destinées aux débutants, puis
+  accélérer la pulsation dans les situations de tension musicale.
+
+## Impact sur le gameplay
+Ce retour visuel permet d'informer les joueuses et joueurs sur la santé magique de l'arbre.
+Combiné aux MusicalMoves orientés soin ou purification, l'effet de veines devient un indicateur
+immédiat de réussite ou d'échec des combinaisons mises en place.

--- a/Assets/Documentation/Ash_Bark_Veins.md.meta
+++ b/Assets/Documentation/Ash_Bark_Veins.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0848aa187d1f4e139bec8a37e722073d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/CamerasCinematiquesMoves.md
+++ b/Assets/Documentation/CamerasCinematiquesMoves.md
@@ -1,0 +1,9 @@
+# Rôles de caméras pour les MusicalMoves et Items
+
+Ce document récapitule les rôles de caméras cinématiques à associer aux MusicalMoves et aux Items afin de conserver une mise en scène harmonieuse.
+
+Chaque **MusicalMove** et chaque **Item** référence désormais un rôle de caméra cinématique plutôt qu'un nom explicite :
+`preparingCameraRole`, `performingCameraRole` et `retreatCameraRole`.
+Ces rôles correspondent aux plans définis par le nouveau rig (`MainMenuIdle`, `OverShoulderCasterToTarget`, `ClosePushCaster`, `TargetReaction`, `WideEstablish`, `ProjectileFlyby`, `Victory`).
+
+Grâce à cette nomenclature, les joueuses et joueurs débutants bénéficient d'une lecture claire des transitions tandis que les vétérans peuvent orchestrer des combos spectaculaires parfaitement cadrés.

--- a/Assets/Documentation/CamerasCinematiquesMoves.md.meta
+++ b/Assets/Documentation/CamerasCinematiquesMoves.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 663fdcb24cf2430cbf05d0e153e8ccdb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/ConditionsAltitude.md
+++ b/Assets/Documentation/ConditionsAltitude.md
@@ -1,0 +1,12 @@
+# Conditions d'altitude pour les MusicalMoves
+
+Ce document décrit les contraintes de hauteur applicables aux MusicalMoves afin d'encadrer les stratégies aériennes et terrestres tout en restant lisible pour les nouveaux joueurs.
+
+Les MusicalMoves peuvent spécifier une contrainte de hauteur :
+- **Aériens** : réalisables uniquement si la cible ne touche pas le sol.
+- **Terriens** : réalisables uniquement si la cible est au sol.
+- **Aériens et terriens** : utilisables dans toutes les situations.
+
+Cette classification aide les débutants à comprendre rapidement les restrictions tout en offrant aux joueurs avancés des combinaisons plus techniques impliquant des changements d'altitude.
+
+Pensez à relier ces contraintes aux événements aériens décrits dans `HistoireSymphonie.md` pour proposer aux novices des affrontements lisibles et aux experts des puzzles de positionnement.

--- a/Assets/Documentation/ConditionsAltitude.md.meta
+++ b/Assets/Documentation/ConditionsAltitude.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fa640c0666c84823b0fe0e1d9324403e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/HistoireSymphonie.md
+++ b/Assets/Documentation/HistoireSymphonie.md
@@ -1,0 +1,168 @@
+# Histoire de Symphonie
+
+🎼 **Symphonie — Document de conception narrative**
+
+## 🧩 Résumé global de l’histoire
+
+Symphonie raconte l’éveil progressif de Lucian, un jeune renard anthropomorphe, dans un monde onirique figé, dicté par une force cosmique appelée le Rêve.
+Lucian est l’écho d’un enfant réel, mort très jeune dans le monde réel, rêvé nuit après nuit par son frère survivant, qui l’a connu trop brièvement. Ce frère prend la forme de Munin, la caméra du jeu, entité silencieuse et protectrice, incarnée directement par le joueur.
+
+Lucian découvre peu à peu qu’il est une âme recréée dans un monde refuge bâti par Azazel, un Séraphin déchu.
+Azazel, autrefois serviteur de l’Univers, tente de sauver les âmes « gâchées » du monde réel — des êtres qui n’ont pas vécu ce qu’ils auraient dû. Mais il ne peut créer, seulement recomposer des échos perçus.
+Il prépare en secret un plan visant à substituer l’intégralité des âmes du monde réel par les copies imparfaites qu’il façonne, persuadé que ce sacrifice collectif rendra l’Univers plus harmonieux.
+
+Lucian a été façonné à travers les souvenirs du frère, à partir de la manière dont il le percevait : courageux, têtu, lumineux, imparfait mais sincère.
+Cependant, la nature même de Lucian le rend instable. Il attire l’attention des entités du Rêve, qui cherchent à le « corriger » comme une anomalie.
+
+En traversant les fragments d'Azazel, Lucian rencontre des âmes privées de talents ou de soutien, destinées à se dissoudre sans jamais être remarquées. Cette injustice face à l'inégalité des talents et des vies le bouleverse : pourquoi lui a-t-il droit à une seconde chance alors que tant d'autres sont condamnés à l'oubli ?
+
+Ignorant l'origine de ce privilège, il poursuit sa quête jusqu'aux portes de la Source. Ce n'est qu'à cet instant qu'il apprend l'existence d'un frère survivant qui rêve obstinément de lui, lui offrant cette chance de survie que les autres n'ont pas.
+
+À mesure que Lucian s’approche de la Source, il se rapproche de la base de la branche de rêve de son frère, là où sont connectés tous les rêves du vivant.
+En chemin, il découvre l’existence d’un rituel ancien, la **Convocation**, censé lui accorder sa « Légitimité » ou « Harmonie » auprès de l’entité créatrice.
+La Source est le point où Lucian espère comprendre sa place véritable dans l’Univers et offrir un avenir apaisé à son frère.
+Lorsqu’il accomplit cette Convocation, l’entité qui répond n’est pas Azazel, mais Munin, le frère rêveur dont le nom est choisi par le joueur, plongeant les deux frères dans une rencontre mélancolique.
+
+⸻
+
+## 🌌 Structure cosmique
+
+### 🪶 L’Univers
+- Entité créatrice, bienveillante mais distante.
+- Se nourrit des rêves pour générer les mondes.
+- A laissé volontairement du chaos et du libre arbitre dans le monde réel.
+- Considère la « symphonie de la vie » comme une composition impossible à diriger, dont chaque être vivant joue une note au gré de ses choix.
+
+### 🌙 Le Rêve
+- Projection idéale du monde réel, orchestrée, sans chaos.
+- Source du destin, du contrôle, de l’harmonie imposée.
+- Les Entités du Rêve en sont les garants, et traquent les anomalies (comme Lucian).
+- Cherche à figer la « symphonie de la vie » dans une partition unique, sans jamais parvenir à la saisir totalement.
+
+### 🪽 Les Séraphins
+- Gardiens du Rêve.
+- Certains d’entre eux, lors de l’aventure, confondent Lucian avec un être qui les traque.
+
+### 🔥 Azazel
+- Le plus jeune des Séraphins.
+- A déserté le Rêve, tente de construire ses propres mondes pour sauver les âmes perdues.
+- Incapable de créer, il ne peut que recomposer des fragments perçus.
+- Son plan secret : remplacer les âmes de l’Univers par les reflets imparfaits de son monde, acceptant la destruction des originaux pour imposer sa vision de la justice.
+- S’acharne à imiter la « symphonie de la vie », sans comprendre qu’elle échappe à tout contrôle, même au sien.
+
+⸻
+
+## 👁️ Personnages majeurs
+
+### 🦊 Lucian
+- Renard blanc anthropomorphe.
+- Âme d’un enfant réel décédé jeune.
+- Recréé dans le monde d’Azazel à travers le regard aimant et idéalisé de son frère.
+- Incapable de se souvenir de qui il était, il cherche à comprendre sa nature.
+- Pour lui, la musique n'est d'abord qu'un souffle comparable au vent dont il ignore l'origine, inconscient même de son existence jusqu'à ce que Munin la lui révèle.
+- Au début du jeu, il ne connaît que la plate-forme sur laquelle il vit avec quelques autres êtres et n'a jamais questionné la manière dont il communique avec eux ; le langage lui semble inné.
+- Il découvrira plus tard que ses goûts et connaissances proviennent de sa vie passée, notamment son affection pour les rythmes soutenus proches du métal, domaine dans lequel il excelle.
+- Sa connexion intime avec Munin laisse filtrer les souvenirs des passions qu'ils partageaient, et même celles propres à Munin ; Lucian cite spontanément des références à des jeux vidéo emblématiques, comme lorsqu'il s'exclame : « Nous sommes encerclés. » « Bien, nous pouvons attaquer dans toutes les directions. », rappel inconscient d'une stratégie qu'ils admiraient ensemble.
+- Chaque zone visitée résonne d'une harmonique prédominante dictée par le rythme de sa musique : un tempo rapide met en avant l'harmonique de Luciane, une mesure en trois temps favorise celle de Luna, etc.
+- Lorsqu'un personnage est en parfaite résonance avec la musique d'une zone, une électricité parcourt son corps, similaire aux éclairs de Thor, révélant visuellement sa connexion harmonique.
+
+### 🎥 Munin (nom personnalisable par le joueur)
+- La caméra du jeu, entité diégétique.
+- Incarnation du frère survivant dans le monde réel.
+- Témoin silencieux et affectueux du périple de Lucian.
+- Ne peut pas se regarder lui-même.
+
+### 👼 La Mère — L’Ange Pleureur
+- <!-- La mère de Lucian apparaît sous cette forme lors de la scène d'ouverture. -->
+- Incapable de faire son deuil, elle se manifeste dans le Rêve sous la forme d’un ange aux larmes inépuisables.
+- Sert de boss d’introduction impossible à vaincre ; ses attaques forment un tutoriel tragique.
+- Ses larmes nourrissent les entités du Rêve et symbolisent une âme incomplète que cherche à sauver Azazel.
+
+### 🧔 Le Père
+- <!-- Figure paternelle dont le recul apparent nourrit la détresse familiale. -->
+- Fait semblant d’aller de l’avant mais porte un lourd fardeau émotionnel.
+- Son éloignement est perçu par Munin comme de l’indifférence, accentuant la douleur maternelle.
+- Les souvenirs de son sacrifice surgissent durant le combat contre l’Ange Pleureur.
+
+### 🕯️ Le Traqueur (nouvel antagoniste secondaire)
+- Une autre âme oubliée, rejetée deux fois : par l’Univers, puis par Azazel.
+- Traque les Séraphins par haine de l’effacement et de l’indifférence.
+- Certains Séraphins prennent Lucian pour lui.
+- Silhouette masquée, jamais pleinement révélée.
+- Pourra jouer un rôle capital dans la fin.
+
+⸻
+
+## 🎬 Scène d’ouverture : L’Ange Pleureur
+- <!-- Résumé de la scène d'ouverture pour assurer la cohérence avec le document détaillé AngePleureur.md -->
+- Lucian quitte son îlot figé pour affronter un ange aux ailes ternies qui pleure sans fin.
+- Cet ennemi représente sa mère incapable de faire son deuil ; il s’agit d’un boss-tutoriel impossible à vaincre.
+- Munin ressent la douleur maternelle et téléporte Lucian pour éviter sa destruction.
+- Les souvenirs d’un père apparemment distant renforcent la détresse de l’ange.
+- La fracture émotionnelle issue de ce combat attire les entités du Rêve et amorce l’arc sur les âmes incomplètes et Azazel.
+
+## 🎭 Thèmes principaux
+
+| Thème | Détails |
+|-------|---------|
+| Deuil et mémoire | Lucian est une mémoire idéalisée, rêvée par un frère endeuillé. |
+| Libre arbitre vs destin | Le Rêve est la partition parfaite, Lucian veut improviser. |
+| Création vs recomposition | Azazel ne crée rien de neuf : il ne fait que recoller des fragments. |
+| Éveil et disparition | Lucian cherche une voie pour libérer son frère sans condamner l’Univers. |
+| Nature des rêves | Les rêves sont connectés par un grand Arbre cosmique semblable à Yggdrasill. |
+| Injustice des talents et des vies | Seul le rêve obstiné de son frère offre à Lucian une chance de survie, tandis que d’autres âmes se dissipent. |
+| Sacrifice collectif | Lucian et ses alliés préfèrent risquer leur existence pour préserver les âmes originelles de l’Univers. |
+| Symphonie de la vie | Les protagonistes découvrent que l’Univers compose une mélodie vivante qui transcende toute autorité, révélant la vanité des volontés de contrôle. |
+
+⸻
+
+## 📜 Histoire des idées : la symphonie de la vie
+
+- **Mythe fondateur :** les premiers rêveurs parlent de la « symphonie de la vie » comme d’un chant que l’Univers entonne pour donner naissance aux mondes. Aucun être, même séraphin, n’entend la partition entière.
+- **Hérésie de l’Harmonique Parfaite :** certains Séraphins ont tenté de figer ce chant dans une écriture unique, déclenchant des fractures cosmiques qui ont forcé l’Univers à laisser s’échapper les notes rebelles.
+- **Doctrine de Munin :** en observant Lucian, Munin conclut que la « symphonie de la vie » est un flux libre : chaque décision ajoute une nuance imprévisible, hors d’atteinte des entités les plus puissantes.
+- **Révélation de la Source :** lorsque Lucian approche la Source, il apprend que ce chant n’est pas une arme à maîtriser, mais un espace de résonance partagé. La quête ne consiste plus à contrôler la musique, mais à accepter d’en être une voix éphémère.
+- **Conséquence narrative :** Azazel réalise tardivement que sa rébellion échoue parce qu’il ne peut ni composer ni voler cette mélodie. Il doit choisir entre s’accorder humblement ou se condamner au silence.
+
+⸻
+
+## ⚖️ Arc narratif : Injustice des talents et des vies
+Au fil de son voyage, Lucian croise des âmes inachevées qui n'ont ni le talent ni le soutien nécessaires pour subsister dans le Rêve. Chaque rencontre souligne la faveur exceptionnelle dont il bénéficie grâce au rêve de son frère. Ce constat nourrit un conflit intérieur : comment mériter cette seconde chance quand tant d'autres n'en auront jamais ?
+
+⸻
+
+## ⚔️ Révélation du plan d'Azazel
+- **Moment clé :** Acte II, lorsque Lucian, Luna et leurs alliés infiltrent un sanctuaire de reconversion d’âmes.
+- Ils découvrent des archives oniriques décrivant la procédure « d’Harmonisation Globale » : Azazel projette de purger l’Univers de ses âmes originelles pour les remplacer par les échos imparfaits de son monde.
+- Cette substitution totale provoquerait la dissolution des êtres réels, Munin compris, au profit de copies incomplètes et dépendantes du Rêve.
+- Lucian comprend alors que le salut d’une poignée d’âmes ne peut se faire au prix de l’extinction universelle.
+- Munin, témoin direct de la menace qui pèse sur sa propre existence, renforce le pacte entre les protagonistes : ils défendront l’Univers même si cela signifie leur disparition.
+- À partir de ce point, l’objectif n’est plus d’obtenir une place dans le monde réel, mais de saboter la propagation des âmes imparfaites.
+
+⸻
+
+## 🌳 L’Arbre du Rêve (Yggdrasill)
+- Chaque être vivant a une branche de rêve.
+- Ces branches convergent vers un tronc central (mémoire collective).
+- Les racines plongent vers l’Univers, qui s’en nourrit pour créer les mondes.
+- La Source se trouve à la base de la branche du frère de Lucian : c’est là qu’Azazel compte déverser ses âmes recomposées, et où Lucian doit sceller le passage malgré le risque de se dissoudre.
+
+## 🔔 La Convocation et la révélation finale
+- Avant d’atteindre la Source, Lucian réalise la **Convocation**, un rite permettant d’obtenir sa Légitimité — ou Harmonie — auprès de l’entité créatrice du monde.
+- L’entité invoquée se révèle être Munin, son frère rêveur, et non Azazel, scellant la conscience partagée des deux frères.
+- Une cinématique mélancolique réunit la fratrie, tandis qu’Azazel apparaît pour révéler que la Source est le conduit qui permettra de répandre ses âmes recomposées à travers toutes les branches de rêve.
+- Azazel propose un marché : si Lucian accepte de devenir le catalyseur de l’Harmonisation Globale, Munin survivra comme nouvelle voix du Rêve.
+- Lucian refuse, entraînant ses alliés dans une dernière bataille où ils canalisent la musique pour fermer le conduit, sachant que l’effort consumera leurs formes oniriques.
+- La victoire est obtenue au prix de leur effacement progressif : Munin demeure dans le monde réel, porteur du souvenir de leur sacrifice, tandis que Lucian accepte de redevenir un écho qui se dissipe dans la lumière.
+
+⸻
+
+## 🧩 Idées narratives clés validées
+- Certains Séraphins fuient Lucian en pensant qu’il est le Traqueur.
+- Le Traqueur laisse derrière lui des Séraphins brisés, des symboles de branche coupée.
+- Lucian est confronté à l'injustice des talents et des vies lorsqu'il rencontre des âmes vouées à l'oubli faute d'un rêveur pour les soutenir.
+- Une fin à la Lost : tous les protagonistes se réunissent silencieusement.
+  Une réunion ouverte à l’interprétation, empreinte de paix et de mélancolie.
+- Une fin interactive musicale possible : le joueur compose une dernière mélodie symbolisant Lucian (ou choisit de ne pas la terminer).
+- Azazel pourrait être affronté dans une scène symbolique, représentant un puzzle impossible à résoudre.
+- La fermeture du conduit demande un sacrifice concerté : chaque allié offre sa voix musicale pour stabiliser l’Univers, laissant Munin seul gardien des souvenirs partagés.

--- a/Assets/Documentation/HistoireSymphonie.md.meta
+++ b/Assets/Documentation/HistoireSymphonie.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 76205b5b261c4822a334027f5aa36ada
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/IndexDocumentation.md
+++ b/Assets/Documentation/IndexDocumentation.md
@@ -1,0 +1,28 @@
+# Index de la documentation Symphonie
+
+Ce document décrit l'organisation thématique des fichiers de `Docs/` afin de retrouver rapidement les informations nécessaires au développement et à la narration.
+
+## Thèmes narratifs
+- `HistoireSymphonie.md` : chronologie détaillée des arcs principaux.
+- `AngePleureur.md` : découpage du combat contre l’Ange Pleureur.
+- `Quotes.md` : citations clés à réutiliser dans les dialogues.
+
+## Thèmes gameplay
+- `LimitesUtilisationActions.md` : paramétrage des limites d'utilisation pour les MusicalMoves et Items.
+- `PreparationMusicalMoves.md` : configuration des phases de charge et de leurs risques.
+- `TypageHarmoniques.md` : consommation et génération d'harmoniques par move.
+- `ConditionsAltitude.md` : contraintes de hauteur pour les compétences.
+- `MoveTypeAlteration.md` : description du MoveType Altération.
+- `CamerasCinematiquesMoves.md` : rôles de caméras attribuables aux actions.
+- `RepertoireActionsMusicales.md` : effets des MusicalMoves jouables.
+- `RepertoireAttaquesAngePleureur.md` : offensives de l’Ange Pleureur.
+- `RepertoireItemsUtilisables.md` : objets consommables et recommandations.
+- `SystemeSetsInventaire.md` : configuration des sets d'actions et d'items.
+- `SystemeSuccesTimeline.md` : déclenchement des succès via Timeline.
+- `SystemeSuccesPointOfInterest.md` : gestion des succès liés aux points d’intérêt.
+
+## Thèmes techniques
+- `RenduPersonnages.md` : directives pour les matériaux et shaders des personnages.
+- `Ash_Bark_Veins.md` : description du matériau organique spécifique.
+- `VolumetricRays.md` : recette pour configurer les rayons volumétriques.
+- `OptimisationsPerformance.md` : actions pour réduire les draw calls.

--- a/Assets/Documentation/IndexDocumentation.md.meta
+++ b/Assets/Documentation/IndexDocumentation.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbe5e614c9bd42549a3866829c1a262d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/LimitesUtilisationActions.md
+++ b/Assets/Documentation/LimitesUtilisationActions.md
@@ -1,0 +1,9 @@
+# Limites d'utilisation des MusicalMoves et Items
+
+Ce document explique comment paramétrer les plafonds d'utilisation des MusicalMoves et des Items afin d'équilibrer l'expérience de Symphonie pour les débutants et les vétérans.
+
+Chaque MusicalMove ou Item peut définir un nombre maximal d'utilisations par tour et par combat. Les champs `maxUsesPerTurn` et `maxUsesPerBattle` des ScriptableObjects permettent de configurer ces limites. Une valeur de `0` indique une utilisation illimitée.
+
+En combinant ces bornes avec les arcs narratifs décrits dans `Docs/HistoireSymphonie.md`, on contrôle la montée en puissance des héros tout en respectant les moments clés du récit.
+
+Les limites choisies servent d'appui pédagogique pour initier les nouveaux adeptes tout en permettant aux vétérans de préparer des séquences risquées mais payantes.

--- a/Assets/Documentation/LimitesUtilisationActions.md.meta
+++ b/Assets/Documentation/LimitesUtilisationActions.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e4d7cb1aa9af4afbaf0779485ca33f71
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/MoveTypeAlteration.md
+++ b/Assets/Documentation/MoveTypeAlteration.md
@@ -1,0 +1,7 @@
+# MoveType Altération
+
+Ce document présente le type de MusicalMove « Altération », pensé pour offrir des opportunités tactiques cohérentes avec l'histoire de Symphonie.
+
+Ce type regroupe les actions qui transforment le terrain ou l'état d'une cible sans infliger directement un bonus ou un malus classique. Elles ouvrent des opportunités tactiques que les novices peuvent appréhender facilement tout en permettant aux vétérans de créer des enchaînements complexes.
+
+Associez toujours ces altérations à des moments narratifs pour guider les débutants, tout en laissant aux joueurs chevronnés la liberté de chaîner des effets inédits.

--- a/Assets/Documentation/MoveTypeAlteration.md.meta
+++ b/Assets/Documentation/MoveTypeAlteration.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd25cdfa82be4fa2acb0e4eb745b86fa
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/OptimisationsPerformance.md
+++ b/Assets/Documentation/OptimisationsPerformance.md
@@ -1,0 +1,21 @@
+# Optimisations de performance
+
+Ce document résume les actions entreprises pour réduire le nombre de draw calls et améliorer les FPS.
+
+## GPU Instancing
+- Tous les matériaux du dossier `Assets/Materials` ont l'option **Enable GPU Instancing** activée.
+- Le script d'éditeur `OptimizationTools` permet d'activer l'instancing pour de nouveaux matériaux via le menu `Symphonie/Optimisation`.
+
+## Static Batching
+- Les objets de décor peuvent être marqués comme statiques grâce à `OptimizationTools`.
+- Unity pourra ainsi combiner les meshes et diminuer le coût du rendu opaque.
+
+## Réduction des draw calls
+- Regrouper les petits meshes et créer des atlases de textures reste une priorité.
+- Privilégier l'utilisation de matériaux partagés et l'instancing pour les objets identiques.
+
+## Level of Detail (LOD)
+- Ajouter des `LODGroup` sur les gros modèles permet de réduire le nombre de polygones rendus au loin.
+
+## Test de preuve
+- Pour vérifier le gain, dupliquer la scène et retirer 80 % des objets opaques. Les FPS doivent augmenter sensiblement.

--- a/Assets/Documentation/OptimisationsPerformance.md.meta
+++ b/Assets/Documentation/OptimisationsPerformance.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a2980fac1379463f8a58e93e7e37d59e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/PreparationMusicalMoves.md
+++ b/Assets/Documentation/PreparationMusicalMoves.md
@@ -1,0 +1,44 @@
+# Préparation des MusicalMoves sur plusieurs tours
+
+Ce guide décrit la nouvelle mécanique de charge appliquée aux MusicalMoves pour offrir
+aux joueurs débutants une lecture claire tout en ouvrant des possibilités tactiques
+pour les vétérans, conformément aux enjeux narratifs rappelés dans `HistoireSymphonie.md`.
+
+## Activer une phase de charge
+- `requiresPreparationBeforeExecution` (MusicalMoveSO) : cochez cette option pour
+  indiquer que le move ne se résout qu'après une ou plusieurs phases de préparation.
+  Le move est déclaré au tour sélectionné, mais sa résolution ne survient qu'à la fin
+  de la charge.
+- `preparationTurnCount` : nombre de tours complets nécessaires avant l'exécution.
+  Une valeur de `0` garde un comportement immédiat même si la case précédente est
+  activée, utile pour de futurs équilibrages progressifs.
+
+## Gérer les risques d'interruption
+- `preparationFailureConditions` : liste d'entrées décrivant ce qui annule la charge.
+  Chaque entrée possède :
+  - `conditionType` : type d'événement (dégâts sur une attaque, débuff, événement
+    scénarisé...).
+  - `thresholdValue` : seuil numérique utilisé par les dégâts ou tout autre test.
+  - `debuffType` : précisez un `DebuffStatType` lorsque seule une altération donnée
+    interrompt la préparation.
+  - `designerNote` : champ libre pour relier le réglage au récit ou à des combos
+    avancés.
+
+### Filets de sécurité appliqués automatiquement
+
+Lorsqu'un `MusicalMove` active `requiresPreparationBeforeExecution`, deux conditions
+sont insérées par défaut pour préserver l'équilibrage et la lisibilité :
+
+1. **Dégâts massifs** : un `PreparationFailureConditionType.DamageFromSingleAttack`
+   avec un `thresholdValue` minimal de **20 000** garantit que les attaques les plus
+   puissantes peuvent toujours interrompre une préparation prolongée.
+2. **MusicalMove interruptif** : un `PreparationFailureConditionType.InterruptingMusicalMove`
+   assure qu'un move adverse explicitement conçu pour casser les préparations mettra
+   fin à la charge, créant des opportunités tactiques et des moments narratifs forts.
+
+Ces garde-fous peuvent être complétés par d'autres conditions selon les besoins
+scénaristiques ou de gameplay, mais ils ne sont retirés manuellement qu'en pleine
+conscience de leurs impacts sur l'expérience des joueurs.
+
+Combinez ces champs pour orchestrer des stratégies où les héros doivent protéger un
+lanceur pendant plusieurs tours, tout en respectant les arcs narratifs de Symphonie.

--- a/Assets/Documentation/PreparationMusicalMoves.md.meta
+++ b/Assets/Documentation/PreparationMusicalMoves.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: afbc33db55564d61946ed3f41c8c28cc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/Quotes.md
+++ b/Assets/Documentation/Quotes.md
@@ -1,0 +1,10 @@
+# Citations clés de Symphonie
+
+Ce document regroupe des répliques emblématiques utilisées pour rythmer les scènes majeures et rappelle le ton dramatique de l'histoire détaillée dans `Docs/HistoireSymphonie.md`.
+
+- "Pourquoi choisir quand je peux tout avoir?" — Azazel propose à Lucian de choisir entre revivre ou libérer son frère de ses cauchemars.
+- "Il est temps pour nous deux de nous retirer." — Lucian s'adresse à Azazel lors du combat final.
+- "Les entends-tu, ces êtres imparfaits…" — Azazel provoque le premier séraphin pendant un combat.
+- "Mon ami, je te laisse la suite." — Azazel s'adresse à Lucian avant l'affrontement contre le premier séraphin.
+- "Écoute, Lucian : la symphonie de la vie n'obéit à personne." — Munin révèle que l’Univers seul tisse cette mélodie indomptable.
+- "Je croyais pouvoir écrire la symphonie de la vie… mais elle échappe même aux dieux." — Aveu tardif d’Azazel avant la bataille finale.

--- a/Assets/Documentation/Quotes.md.meta
+++ b/Assets/Documentation/Quotes.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bdd4d410fa194c9686c4508c6216cced
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/RenduPersonnages.md
+++ b/Assets/Documentation/RenduPersonnages.md
@@ -1,0 +1,26 @@
+# Rendu des personnages CC5 dans Unity
+
+Ce document récapitule les ajustements effectués pour rapprocher le rendu Unity de celui observé dans Character Creator 5 (CC5).
+
+## Origine de l'écart visuel
+
+* **Profils de diffusion manquants** : les matériaux de peau n'étaient pas associés à un profil de diffusion HDRP. Sans subsurface scattering cohérent, la peau devenait plus mate et cireuse que dans CC5.
+* **Seuils de découpe des cheveux trop élevés** : plusieurs matériaux capillaires utilisaient une valeur d'`AlphaClip` à 0.666, éliminant une grande partie des mèches fines et produisant un aspect « crénelé » très visible sous l'éclairage neigeux de la scène Unity.
+* **Spéculaire atténué sur les cheveux** : les paramètres de réflexion secondaire étaient trop faibles par rapport aux préréglages HQ fournis par l'Auto Setup, ce qui délavant les reflets et donnait l'impression d'une chevelure sans profondeur.
+
+## Actions réalisées
+
+1. **Création d'un profil de diffusion dédié** (`CharacterSkinDiffusionProfile.asset`) afin d'uniformiser le comportement du subsurface scattering sur toutes les matières corporelles.
+2. **Référence explicite du profil de diffusion** dans les matériaux de peau (tête, corps, bras, jambes) pour garantir la même réponse lumineuse qu'en sortie CC5.
+3. **Réalignement des paramètres capillaires** (AlphaClip, AlphaToMask, forces spéculaires, ombres) sur les valeurs recommandées des templates HQ fournis par Reallusion, pour restituer les mèches fines et les reflets doux attendus.
+
+## Effets attendus
+
+* Des volumes cutanés plus doux et translucides, notamment sur le visage et les mains.
+* Une chevelure plus dense, sans effet de « peigne blanc » dans les zones éclairées de face.
+* Une meilleure cohérence entre le rendu studio de CC5 et l'intégration HDRP Unity.
+
+## Points de vigilance
+
+* Le profil de diffusion doit être référencé dans les volumes HDRP utilisés par vos scènes (profil de volume principal ou volumes locaux) pour être disponible au rendu.
+* Si d'autres personnages CC5 sont importés, répétez l'association du profil de diffusion et appliquez les mêmes réglages capillaires afin de conserver une cohérence visuelle.

--- a/Assets/Documentation/RenduPersonnages.md.meta
+++ b/Assets/Documentation/RenduPersonnages.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89a15747e4374224a1fc20153633b2dc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/RepertoireActionsMusicales.md
+++ b/Assets/Documentation/RepertoireActionsMusicales.md
@@ -1,0 +1,168 @@
+# Répertoire des MusicalMoves jouables
+
+Ce document synthétise les effets de base des MusicalMoves accessibles aux héros en s'appuyant sur le contexte narratif de `Docs/HistoireSymphonie.md` pour guider l'apprentissage et la maîtrise.
+
+## Système de Sceaux modulaires pour l’accessibilité
+
+> **Commentaire de conception** : ce système a été validé avec les chroniqueurs de `Docs/HistoireSymphonie.md` afin de respecter l’ascension progressive de la Fratrie décrite dans le récit.
+
+- **Principe général** : les Sceaux sont des artefacts narratifs forgés par Munin pour moduler l’intensité des affrontements. On peut en équiper jusqu’à dix avant un combat pour ajuster la difficulté sans modifier le comportement des MusicalMoves ni des Items.
+- **Équilibrage du score** : chaque Sceau appliqué ajuste cumulativement le score de fin de combat et l’XP obtenue. Les Sceaux de facilitation appliquent une décote (généralement –10 %), tandis que les Sceaux de défi octroient une prime (généralement +10 %) pour récompenser les virtuoses.
+- **Compatibilité** : les Sceaux n’ajoutent aucune nouvelle ressource ; ils améliorent temporairement le personnage choisi, quel que soit son rôle, par des bonus passifs qui se déclenchent automatiquement dès que le combat commence.
+- **Équipement** : les Sceaux ne sont pas pré-équipés. Ils se sélectionnent dans l’interface d’inventaire durant l’exploration, puis restent actifs jusqu’à ce que le joueur les retire manuellement.
+- **Vérification** : avant chaque combat, le moteur vérifie les Sceaux actuellement équipés et applique leurs effets ainsi que leurs modificateurs de score.
+- **Retrait manuel** : il est possible de retirer tous les Sceaux en un clic depuis l’onglet de préparation afin que la difficulté reste intacte pour les vétérans.
+
+### Catalogue de Sceaux recommandés
+
+Afin de faciliter la sélection, les Sceaux sont regroupés en deux familles : les modèles universels utilisables dans toutes les
+rencontres et les variantes spécifiques optimisées pour des situations récurrentes (types d’ennemis, environnements ou altérations).
+
+#### Sceaux universels
+
+| Nom du Sceau | Effet facilité | Commentaire d’utilisation | Impact sur le score |
+|--------------|----------------|----------------------------|---------------------|
+| **Sceau de Cadence Stable** | Réduit tous les cooldowns de 1 tour (minimum 1). | Maintient un tempo constant pour enchaîner *Tunnel*, *Staccato Étourdissant* et les ultimes offensifs. | -10 % |
+| **Sceau de Main Guidée** | +25 % dégâts sur les attaques basiques seulement. | Sert de socle à des builds centrés sur *Rhapsodie* ou *Serpenteau Mélodique* avant d’embrayer sur les combos lourds. | -10 % |
+| **Sceau de Fatigue Allégée** | Réduit de 1 le coût en Fatigue des MusicalMoves (minimum 0) pour le premier tour uniquement. | Offre une ouverture souple aux stratégies qui demandent plusieurs buffs immédiats. | -10 % |
+| **Sceau du Rempart Arcanique** | Octroie un bouclier de 6 000 PV et dissipe 1 altération au début du combat. | Sécurise l’entrée en scène face aux Séraphins focalisés sur les malédictions. | -10 % |
+| **Sceau de l’Avant-Scène** | +150 Initiative et posture de garde automatique au premier tour. | Garantit la priorité au meneur choisi pour placer *Pour qui sonne le glas* avant la riposte ennemie. | -10 % |
+| **Sceau du Cœur Accordé** | +30 % soins reçus et +10 % régénération d’Harmonie pendant 3 tours. | Amplifie *Arpège Régénérant* et consolide les duos axés sur le soutien mélodique. | -10 % |
+| **Sceau de l’Écho Suspendu** | La première attaque de zone ennemie inflige -40 % dégâts et ne peut pas repousser. | Protège les lignes en préparation d’un *Crescendo Fulgurant*. | -10 % |
+| **Sceau de Pulsation Constante** | +1 charge de Tempo et +300 Initiative au groupe au tour 1. | Aligne les timings pour lancer un assaut coordonné dès l’ouverture. | -10 % |
+| **Sceau de l’Onde Persévérante** | À 50 % PV, déclenche une vague de soin de 12 000 PV sur le porteur (1 fois par combat). | Soutient les tanks lors des duels prolongés contre Azazel. | -10 % |
+| **Sceau de l’Impulsion Franche** | Les trois premiers MusicalMoves lancés coûtent -1 Harmonie (minimum 0). | Accélère les ouvertures agressives basées sur *Sforzando* et *Crescendo Fulgurant*. | -15 % |
+| **Sceau des Cordes Stoïques** | +40 % durée des buffs défensifs du porteur et +10 % résistances globales. | Prolonge *Accord Bienveillant* et les runes défensives avancées. | -10 % |
+| **Sceau de la Rumeur Lucide** | Révèle l’intention de la cible principale pendant 2 tours et +15 % chances de critique contre elle. | Optimise les fenêtres d’exécution pour *Rupture Harmonieuse*. | -10 % |
+| **Sceau des Fragments Calmes** | Convertit jusqu’à 2 fragments de mélodie en un voile de 4 000 PV chacun au début du combat. | Protège les stratèges qui préparent un *Rappel des Fragments* tardif. | -10 % |
+| **Sceau du Cercle Harmonisé** | Crée au tour 1 une zone qui réduit de 15 % les dégâts reçus par les alliés adjacents (2 tours). | Idéal pour verrouiller les positions autour du soutien principal. | -10 % |
+| **Sceau du Silence Stratège** | La première incantation ennemie est retardée d’un tour et inflige -20 % dégâts. | Ouvre un créneau pour interrompre les chorales de Séraphins. | -10 % |
+
+#### Sceaux de défi (universels)
+
+| Nom du Sceau | Effet de défi | Commentaire d’utilisation | Impact sur le score |
+|--------------|---------------|----------------------------|---------------------|
+| **Sceau de Lame Déchaînée** | +25 % dégâts subis par le porteur et +20 % dégâts infligés. | Transforme le porteur en glass-cannon assumé pour les combats éclairs. | +10 % |
+| **Sceau de Silence Absolu** | Désactive les soins externes sur le porteur mais +40 % dégâts sur les MusicalMoves offensifs. | À réserver aux runs maîtrisés où l’équipe enchaîne les éliminations rapides. | +12 % |
+| **Sceau d’Harmonie Frêle** | -30 % PV max pour tous les alliés mais +50 % régénération d’Harmonie. | Favorise les compositions axées sur les combos incessants. | +15 % |
+| **Sceau de la Mesure Inflexible** | Les cooldowns ne peuvent plus être réduits mais chaque coup critique génère +1 Harmonie. | Encourage la précision rythmique tout en supprimant les sécurités. | +10 % |
+| **Sceau de Virtuosité Soliste** | Le porteur ne peut pas recevoir de buffs alliés mais gagne +35 % Initiative et +15 % critique. | Test ultime de pilotage individuel lors des duels prolongés contre les menaces majeures. | +15 % |
+
+#### Sceaux spécifiques
+
+| Nom du Sceau | Effet facilité | Commentaire d’utilisation | Impact sur le score |
+|--------------|----------------|----------------------------|---------------------|
+| **Sceau de Murmure Protecteur** | +20 % PV max et +15 % résistances harmoniques. | Conçu pour les duels d’endurance face aux prédateurs empathiques ou aux gardiens drainants qui pressent l’équipe sur la durée. | -10 % |
+| **Sceau de Résonance Apaisée** | Réduit de 50 % les dégâts de Résonance et Dissonance. | Neutralise les débordements harmoniques typiques des chorales séraphiques ou des avatars d’Azazel lors des phases critiques. | -10 % |
+| **Sceau de Vigilance Nocturne** | +25 % résistance aux altérations mentales et vision des entités furtives pendant 2 tours. | Indispensable dans les zones saturées d’illusions ou face aux assassins oniriques évoqués dans `Docs/HistoireSymphonie.md`. | -10 % |
+| **Sceau de la Harpe Solaire** | +20 % dégâts contre les créatures du Néant et lumière persistante annulant la Peur. | S’emploie dès qu’une expédition plonge dans les couloirs obscurs de la Convocation montante infestés de créatures du Néant. | -15 % |
+| **Sceau de Gravité Mesurée** | Réduit de 60 % les effets de poussée/traction subis et -25 % dégâts de chute. | Essentiel dans toutes les arènes instables où les Séraphins ou les anomalies gravitationnelles bousculent les trajectoires. | -10 % |
+
+> **Note d’équilibrage** : l’équipement simultané de plusieurs Sceaux cumule leurs modificateurs de score (ex. deux Sceaux à –10 % et un Sceau à –15 % = –35 %, deux Sceaux de défi à +10 % et +15 % = +25 %). Cela garantit que le mode « difficile » reste l’option naturelle pour les experts qui souhaitent optimiser leur progression, tout en offrant une voie héroïque aux virtuoses.
+
+| Nom | Type | Coûts (Fatigue / Harmonie) | Effet de base | Combinaisons & Conseils |
+|-----|------|----------------------------|---------------|-------------------------|
+| **Rhapsodie** | Attaque | 0 / 0 | ~7 500 dégâts + puissance actuelle du lanceur. | Démarre les enchaînements en accumulant des fragments avant de déclencher un combo majeur. |
+| **Éclair** | Attaque | 1 / 1 | ~11 000 dégâts instantanés. | À lier avec la *Clé du Courage* ou des runes de puissance pour éliminer les menaces rapides. |
+| **Contrepoint Chaotique** | Attaque de zone | 1 / 3 | ~13 000 dégâts à chaque ennemi. | Prépare des balayages massifs avant un *Crescendo Fulgurant* pour achever les survivants. |
+| **Tunnel** | Contrôle | 1 / 1 | Appose le glyphe Presto : la cible déclenche une attaque basique après chaque tour jusqu’au retour du lanceur. | Parfait pour accélérer un allié clef ou forcer un ennemi contrôlé à se retourner contre ses pairs avant la prochaine salve du lanceur. |
+| **Fausse Note** | Altération | 1 / 1 | Réveille toutes les unités alliées. | Annule les effets soporifiques des Entités du Rêve ou de l’*Endormissement*. |
+| **Accord Bienveillant** | Soutien | 1 / 1 | Soigne ~10 000 PV et +400 Défense (2 tours). | Ancre parfaite pour les runes défensives lorsque les assauts de l’Ange Pleureur se déchaînent. |
+| **Rupture Harmonieuse** | Affaiblissement | 1 / 2 | ~9 500 dégâts et -400 Défense sur l’ennemi (2 tours). | Lancez-la avant *Crescendo Fulgurant* ou *Sforzando* pour maximiser les dégâts critiques. |
+| **Pour qui sonne le glas** | Protection | 1 / 1 | Appose une marque de loyauté : la cible alliée ignore les dégâts subis tandis que le lanceur encaisse la moitié à sa place. | Déclenche un remerciement vocal du protégé ; combinez-la avec les postures défensives de Lucian pour temporiser les assauts majeurs. |
+| **Marque** | Tactique | 1 / 1 | Appose une marque de lien sur l’ennemi. | Sert de point d’ancrage pour les combos de Kael ou les runes d’exécution. |
+| **Hate** | Placement | 1 / 0 | Lucian se place devant la cible pour absorber les attaques. | À utiliser juste avant *Sforzando* pour rester au contact de l’adversaire. |
+| **Pont Harmonique** | Altération | 1 / 1 | Ramène une cible volante au sol pour 2 tours. | Indispensable contre les entités en suspension avant d’enchaîner les attaques terrestres. |
+| **Staccato Étourdissant** | Contrôle | 2 / 2 | Endort un ennemi pendant 1 tour. | À coupler avec des runes de contrôle pour verrouiller un boss pendant la préparation d’une offensive majeure. |
+| **Sforzando** | Attaque téléportée | 1 / 1 | ~20 000 dégâts, génère +1 Harmonie. | Offre un repositionnement agressif idéal pour capitaliser sur la marque de loyauté. |
+| **Crescendo Fulgurant** | Attaque | 2 / 2 | ~30 000 dégâts concentrés. | L’ultime exécution de Lucian, à déclencher après une *Rupture Harmonieuse*. |
+| **Arpège Régénérant** | Soutien | 2 / 2 | ~20 000 PV à toute l’équipe. | Associé aux runes de soin, il permet de soutenir des combats prolongés contre les Séraphins. |
+| **Abîme Harmonique** | Altération | 1 / 1 | Force la cible à flotter pendant 2 tours. | Prépare les stratégies aériennes de Luna et contrebalance les défenses terrestres. |
+| **Battement d’Ouverture** | Soutien | 0 / 1 | Confère +200 Initiative à un allié et réduit sa Fatigue de 1. | Assure la priorité tactique à Kael ou Luna pour enclencher les séquences critiques du tour suivant. |
+| **Serpenteau Mélodique** | Attaque | 1 / 0 | 6 000 dégâts et appose un fragment de mélodie cumulable (max 3). | Facile à manier : chaque fragment peut être converti plus tard en +5 % dégâts pour *Rhapsodie* ou *Éclair*. |
+| **Cantate des Profondeurs** | Contrôle | 2 / 3 | Étourdit une cible immergée ou instable, sinon inflige 12 000 dégâts et -2 Harmonie. | Synergie tardive avec les altérations d’*Abîme Harmonique* et les Items aqueux décrits dans `Docs/RepertoireItemsUtilisables.md`. |
+| **Polyrythmie Fractale** | Attaque de zone | 3 / 4 | 18 000 dégâts + 2 000 par effet sonore actif sur chaque ennemi. | Mécanique avancée : combinez les échos des Séraphins (voir `Docs/HistoireSymphonie.md`) avec les runes de résonance pour déchaîner une salve dévastatrice. |
+| **Pulse Initiatique** | Soutien | 0 / 0 | +600 PV instantanés et +1 charge de Tempo protectrice (max 2) pour le lanceur. | Déploie un filet de sécurité avant une offensive sans consommer de ressources rares. |
+| **Boucle de Veille** | Protection | 0 / 1 | Confère un voile absorbant 8 000 dégâts et annule la prochaine altération négative. | Couplée aux talismans de Munin, elle amortit les premiers chocs face aux Échos perdus. |
+| **Glissando Apaisant** | Soutien | 1 / 0 | Rend 12 000 PV à une cible et dissipe la Peur. | S’utilise dès les premières confrontations contre l’Ange Pleureur pour maintenir Lucian debout malgré les chocs émotionnels. |
+| **Aube du Métal** | Attaque | 1 / 0 | 9 000 dégâts et +10 % aux dégâts physiques du lanceur (2 tours). | Permet aux fans de riffs soutenus de ressentir immédiatement la pulsation héroïque ; associez-la à *Rhapsodie* pour un finish rapide. |
+| **Pas de Brume** | Placement | 1 / 0 | Téléporte l’allié ciblé sur la case adjacente libre la plus proche. | Clarifie les trajectoires : repositionnez Munin-caméra sans risquer la ligne de vue des Séraphins. |
+| **Oscillation Empathique** | Soutien | 1 / 1 | Copie le buff principal d’un allié sur Lucian pour 2 tours. | Introduit doucement la gestion de buffs : doublez *Accord Bienveillant* pour résister aux vagues d’Azazel. |
+| **Cadre de Silence** | Contrôle | 1 / 1 | Interrompt la prochaine incantation ennemie et inflige -200 Initiative. | Très accessible : déclenchez-le quand un Séraphin prépare une bénédiction, puis enchaînez avec *Éclair*. |
+| **Rumeur de la Branche** | Tactique | 1 / 1 | Révèle les points faibles d’un ennemi, offrant +15 % chances de coup critique à l’équipe (1 tour). | Outil de scouting précieux pour cartographier les branches du Rêve décrites dans `Docs/HistoireSymphonie.md`. |
+| **Lame de Lune** | Attaque téléportée | 1 / 2 | 16 000 dégâts et applique Saignée Astrale (4 000 dégâts/tour pendant 2 tours). | À utiliser juste après *Hate* pour que Lucian bondisse et reste au contact, tout en alimentant les combos nocturnes de Luna. |
+| **Beat Souterrain** | Attaque de zone | 2 / 1 | 11 000 dégâts aux ennemis souterrains ou instables, sinon 7 000 dégâts et -1 Harmonie. | Synergie intermédiaire avec les altérations de terrain décrites dans `Docs/ConditionsAltitude.md`. |
+| **Cadence du Traqueur** | Attaque | 2 / 2 | 14 000 dégâts et convertit 1 buff positif de la cible en Fragment Obscur utilisable par l’équipe. | Permet d’apprivoiser l’héritage du Traqueur sans sombrer : stockez les fragments pour alimenter *Crescendo Fulgurant*. |
+| **Réplique de Munin** | Soutien | 2 / 2 | Stocke la prochaine action d’un allié, puis la rejoue automatiquement au tour suivant sans coût. | Débloque des plans avancés : dupliquez un soin critique ou un *Sforzando* pour surprendre Azazel. |
+| **Syncope d’Azazel** | Affaiblissement | 2 / 3 | 13 000 dégâts, -300 Défense et génère une dissonance qui empêche la régénération (2 tours). | Arme de mid-game contre les clones d’Azazel : combinez-la avec les Items de rupture listés dans `Docs/RepertoireItemsUtilisables.md`. |
+| **Conque Résiliente** | Protection | 2 / 2 | Confère un renvoi de 50 % des dégâts subis au corps à corps pendant 1 tour. | Idéal pour encaisser les charges des Séraphins aveuglés, surtout après *Pour qui sonne le glas*. |
+| **Rappel des Fragments** | Soutien | 2 / 2 | Consomme tous les Fragments de mélodie pour rendre 4 000 PV et +1 Harmonie par fragment. | Excellent point de bascule entre early et mid-game : convertissez les stacks de *Serpenteau Mélodique* en burst de ressources. |
+| **Vibration de la Source** | Attaque de zone | 3 / 3 | 15 000 dégâts et applique Résonance (cible subit +5 % dégâts harmoniques cumulable 3 fois). | Prépare les assauts finaux avant la Convocation ; alternez avec *Polyrythmie Fractale* pour saturer les défenses. |
+| **Flux de Légitimité** | Soutien | 3 / 3 | +2 Harmonie à l’équipe et purification des malédictions. | À réserver pour les moments où la Convocation faiblit : maintient la cohésion contre les vagues d’Azazel. |
+| **Contrechant du Refuge** | Protection | 3 / 4 | Crée une zone réduisant de 30 % les dégâts subis par les alliés et infligeant 6 000 dégâts à l’entrée des ennemis (2 tours). | Combo de late game : verrouillez un sanctuaire pendant que Munin compile les archives oniriques. |
+| **Frappe en Polychronie** | Attaque | 3 / 4 | 20 000 dégâts et si la cible est marquée, déclenche toutes les marques pour +4 000 dégâts chacune. | Mécanique avancée : synchronisez les marques de Kael et l’*Oscillation Empathique* pour une explosion finale. |
+| **Finale de la Fratrie** | Ultime | 4 / 5 | 28 000 dégâts à une cible et 10 000 soins aux alliés, puis +1 Harmonie durable. | Climax narratif : à employer lorsque Munin soutient Lucian contre Azazel, offrant une conclusion émotive et stratégique. |
+
+En maîtrisant cette liste, chaque chef d’orchestre dispose d'un guide clair tandis que les virtuoses peuvent planifier des suites d'accords fidèles à la légende de Symphonie.
+
+
+### Implémentation Unity des nouvelles actions
+
+| Nom | Asset Unity | Fatigue / Harmonie | Effet principal | Notes d'utilisation |
+|-----|-------------|--------------------|-----------------|---------------------|
+| Battement d’Ouverture | `Assets/MusicalMoves/MusicalMove_BattementDouverture/MusicalMove_BattementDouverture.asset` | 0 / 1 | Buff Initiative +200, réduction de Fatigue (1 tour) | Prépare les ouvertures de Kael ou Luna avant un tour explosif. |
+| Serpenteau Mélodique | `Assets/MusicalMoves/MusicalMove_SerpenteauMelodique/MusicalMove_SerpenteauMelodique.asset` | 1 / 0 | ~6 000 dégâts + applique un Fragment de mélodie | Accumule les Fragments pour Rappel des Fragments ou Frappe en Polychronie. |
+| Cantate des Profondeurs | `Assets/MusicalMoves/MusicalMove_CantateDesProfondeurs/MusicalMove_CantateDesProfondeurs.asset` | 2 / 3 | ~12 000 dégâts (étourdit les cibles immergées) | Synergie directe avec Abîme Harmonique pour verrouiller une cible. |
+| Polyrythmie Fractale | `Assets/MusicalMoves/MusicalMove_PolyrythmieFractale/MusicalMove_PolyrythmieFractale.asset` | 3 / 4 | AOE ~18 000 dégâts +2 000 par effet sonore | Clôture les combos après Vibration de la Source. |
+| Pulse Initiatique | `Assets/MusicalMoves/MusicalMove_PulseInitiatique/MusicalMove_PulseInitiatique.asset` | 0 / 0 | Auto-soin 600 PV + charge de Tempo | Sécurise le lanceur avant une séquence à risque. |
+| Boucle de Veille | `Assets/MusicalMoves/MusicalMove_BoucleDeVeille/MusicalMove_BoucleDeVeille.asset` | 0 / 1 | Voile absorbant 8 000 dégâts + annule la prochaine altération | Protège un allié clé avant l’arrivée des malédictions séraphiques. |
+| Glissando Apaisant | `Assets/MusicalMoves/MusicalMove_GlissandoApaisant/MusicalMove_GlissandoApaisant.asset` | 1 / 0 | ~12 000 soins + dissipe la Peur | Incontournable face aux assauts émotionnels de l’Ange Pleureur. |
+| Aube du Métal | `Assets/MusicalMoves/MusicalMove_AubeDuMetal/MusicalMove_AubeDuMetal.asset` | 1 / 0 | ~9 000 dégâts +10 % puissance physique (2 tours) | Lance les combos physiques décrits dans HistoireSymphonie. |
+| Pas de Brume | `Assets/MusicalMoves/MusicalMove_PasDeBrume/MusicalMove_PasDeBrume.asset` | 1 / 0 | Téléporte l’allié ciblé sur une case adjacente | Repositionne Munin sans déclencher d’interception. |
+| Oscillation Empathique | `Assets/MusicalMoves/MusicalMove_OscillationEmpathique/MusicalMove_OscillationEmpathique.asset` | 1 / 1 | Copie le buff majeur d’un allié sur Lucian (2 tours) | Double Accord Bienveillant avant un pic de dégâts. |
+| Cadre de Silence | `Assets/MusicalMoves/MusicalMove_CadreDeSilence/MusicalMove_CadreDeSilence.asset` | 1 / 1 | Interruption + -200 Initiative (1 tour) | À déclencher lorsque les Séraphins préparent une bénédiction. |
+| Rumeur de la Branche | `Assets/MusicalMoves/MusicalMove_RumeurDeLaBranche/MusicalMove_RumeurDeLaBranche.asset` | 1 / 1 | Dévoile la cible et +15 % critique d’équipe | Optimise Frappe en Polychronie contre les lieutenants du Rêve. |
+| Lame de Lune | `Assets/MusicalMoves/MusicalMove_LameDeLune/MusicalMove_LameDeLune.asset` | 1 / 2 | ~16 000 dégâts + Saignée astrale | Synergie avec Hate pour rester au contact en mêlée. |
+| Beat Souterrain | `Assets/MusicalMoves/MusicalMove_BeatSouterrain/MusicalMove_BeatSouterrain.asset` | 2 / 1 | AOE ~11 000 dégâts (7 000 si non souterrain) | Couvre les anomalies de terrain détaillées dans Docs/ConditionsAltitude.md. |
+| Cadence du Traqueur | `Assets/MusicalMoves/MusicalMove_CadenceDuTraqueur/MusicalMove_CadenceDuTraqueur.asset` | 2 / 2 | ~14 000 dégâts + convertit un buff en Fragment Obscur | Prépare les explosions de Crescendo Fulgurant. |
+| Réplique de Munin | `Assets/MusicalMoves/MusicalMove_RepliqueDeMunin/MusicalMove_RepliqueDeMunin.asset` | 2 / 2 | Stocke l’action d’un allié pour le tour suivant | Duplique un soin critique ou un Sforzando surprise. |
+| Syncope d’Azazel | `Assets/MusicalMoves/MusicalMove_SyncopeDAzazel/MusicalMove_SyncopeDAzazel.asset` | 2 / 3 | ~13 000 dégâts et -300 Défense (2 tours) | Neutralise les clones d’Azazel en empêchant la régénération. |
+| Conque Résiliente | `Assets/MusicalMoves/MusicalMove_ConqueResiliente/MusicalMove_ConqueResiliente.asset` | 2 / 2 | Renvoi 50 % dégâts mêlée (1 tour) | Combinez avec Pour qui sonne le glas pour tenir la ligne. |
+| Rappel des Fragments | `Assets/MusicalMoves/MusicalMove_RappelDesFragments/MusicalMove_RappelDesFragments.asset` | 2 / 2 | Convertit les Fragments en 4 000 PV +1 Harmonie chacun | Point de bascule entre early et mid-game. |
+| Vibration de la Source | `Assets/MusicalMoves/MusicalMove_VibrationDeLaSource/MusicalMove_VibrationDeLaSource.asset` | 3 / 3 | AOE ~15 000 dégâts + Résonance cumulable | Prépare Polyrythmie Fractale pour saturer les défenses. |
+| Flux de Légitimité | `Assets/MusicalMoves/MusicalMove_FluxDeLegitimite/MusicalMove_FluxDeLegitimite.asset` | 3 / 3 | +2 Harmonie d’équipe et purification | À garder pour les phases critiques de la Convocation. |
+| Contrechant du Refuge | `Assets/MusicalMoves/MusicalMove_ContrechantDuRefuge/MusicalMove_ContrechantDuRefuge.asset` | 3 / 4 | Zone -30 % dégâts subis + 6 000 dégâts à l’entrée | Verrouille un sanctuaire comme décrit dans HistoireSymphonie. |
+| Frappe en Polychronie | `Assets/MusicalMoves/MusicalMove_FrappeEnPolychronie/MusicalMove_FrappeEnPolychronie.asset` | 3 / 4 | ~20 000 dégâts + déclenche les Marques | Finisher idéal après les combos de Kael. |
+| Finale de la Fratrie | `Assets/MusicalMoves/MusicalMove_FinaleDeLaFratrie/MusicalMove_FinaleDeLaFratrie.asset` | 4 / 5 | ~28 000 dégâts, soigne 10 000 PV aux alliés, +1 Harmonie | Climax narratif lors des duels contre Azazel. |
+
+### ScriptableObjects Sceaux
+
+Les Sceaux décrits en début de document sont désormais disponibles sous `Assets/Sceaux` et utilisent le script `Assets/Scripts/Classes/SceauSO.cs`. Le tableau ci-dessous récapitule les instances fournies :
+
+| Nom | Asset Unity | Famille | Modificateur de score |
+|-----|-------------|---------|-----------------------|
+| Sceau de Cadence Stable | `Assets/Sceaux/Universels/Sceau_CadenceStable.asset` | Universel | -10 % |
+| Sceau de Main Guidée | `Assets/Sceaux/Universels/Sceau_MainGuidee.asset` | Universel | -10 % |
+| Sceau de Fatigue Allégée | `Assets/Sceaux/Universels/Sceau_FatigueAllegee.asset` | Universel | -10 % |
+| Sceau du Rempart Arcanique | `Assets/Sceaux/Universels/Sceau_RempartArcanique.asset` | Universel | -10 % |
+| Sceau de l’Avant-Scène | `Assets/Sceaux/Universels/Sceau_AvantScene.asset` | Universel | -10 % |
+| Sceau du Cœur Accordé | `Assets/Sceaux/Universels/Sceau_CoeurAccorde.asset` | Universel | -10 % |
+| Sceau de l’Écho Suspendu | `Assets/Sceaux/Universels/Sceau_EchoSuspendu.asset` | Universel | -10 % |
+| Sceau de Pulsation Constante | `Assets/Sceaux/Universels/Sceau_PulsationConstante.asset` | Universel | -10 % |
+| Sceau de l’Onde Persévérante | `Assets/Sceaux/Universels/Sceau_OndePerseverante.asset` | Universel | -10 % |
+| Sceau de l’Impulsion Franche | `Assets/Sceaux/Universels/Sceau_ImpulsionFranche.asset` | Universel | -15 % |
+| Sceau des Cordes Stoïques | `Assets/Sceaux/Universels/Sceau_CordesStoiques.asset` | Universel | -10 % |
+| Sceau de la Rumeur Lucide | `Assets/Sceaux/Universels/Sceau_RumeurLucide.asset` | Universel | -10 % |
+| Sceau des Fragments Calmes | `Assets/Sceaux/Universels/Sceau_FragmentsCalmes.asset` | Universel | -10 % |
+| Sceau du Cercle Harmonisé | `Assets/Sceaux/Universels/Sceau_CercleHarmonise.asset` | Universel | -10 % |
+| Sceau du Silence Stratège | `Assets/Sceaux/Universels/Sceau_SilenceStratege.asset` | Universel | -10 % |
+| Sceau de Lame Déchaînée | `Assets/Sceaux/Defi/Sceau_LameDechainee.asset` | Défi | +10 % |
+| Sceau de Silence Absolu | `Assets/Sceaux/Defi/Sceau_SilenceAbsolu.asset` | Défi | +12 % |
+| Sceau d’Harmonie Frêle | `Assets/Sceaux/Defi/Sceau_HarmonieFrele.asset` | Défi | +15 % |
+| Sceau de la Mesure Inflexible | `Assets/Sceaux/Defi/Sceau_MesureInflexible.asset` | Défi | +10 % |
+| Sceau de Virtuosité Soliste | `Assets/Sceaux/Defi/Sceau_VirtuositeSoliste.asset` | Défi | +15 % |
+| Sceau de Murmure Protecteur | `Assets/Sceaux/Specifiques/Sceau_MurmureProtecteur.asset` | Spécifique | -10 % |
+| Sceau de Résonance Apaisée | `Assets/Sceaux/Specifiques/Sceau_ResonanceApaisee.asset` | Spécifique | -10 % |
+| Sceau de Vigilance Nocturne | `Assets/Sceaux/Specifiques/Sceau_VigilanceNocturne.asset` | Spécifique | -10 % |
+| Sceau de la Harpe Solaire | `Assets/Sceaux/Specifiques/Sceau_HarpeSolaire.asset` | Spécifique | -15 % |
+| Sceau de Gravité Mesurée | `Assets/Sceaux/Specifiques/Sceau_GraviteMesuree.asset` | Spécifique | -10 % |

--- a/Assets/Documentation/RepertoireActionsMusicales.md.meta
+++ b/Assets/Documentation/RepertoireActionsMusicales.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 03726e4a8df54d7cb3783e421a2512c4
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/RepertoireAttaquesAngePleureur.md
+++ b/Assets/Documentation/RepertoireAttaquesAngePleureur.md
@@ -1,0 +1,11 @@
+# Attaques musicales de l’Ange Pleureur
+
+Ce document recense les attaques de l’Ange Pleureur afin de préparer les équipes en fonction des événements décrits dans `Docs/HistoireSymphonie.md`.
+
+| Nom | Type | Effet | Astuces pour survivre |
+|-----|------|-------|------------------------|
+| **Pluie du Requiem** | Attaque | ~25 000 dégâts à tous les membres de l’escouade. | Utiliser *Accord Bienveillant* ou des runes défensives avant la pluie de larmes. |
+| **Sanglot Écorchant** | Affaiblissement | ~18 000 dégâts de zone et -200 Initiative pendant 1 tour. | Garder une *Potion Mélodique* ou un *Métronome de Précision* pour retrouver le tempo. |
+| **Étreinte du Linceul** | Contrôle | Plonge la cible dans un sommeil forcé jusqu’à ce qu’elle soit frappée. | Une *Fausse Note* bien placée ou un *Réveil* rapide permet de libérer la victime. |
+
+Ces informations permettent d'anticiper les pics de difficulté pour accompagner les nouveaux joueurs et offrir aux vétérans des fenêtres de contre-attaque mémorables.

--- a/Assets/Documentation/RepertoireAttaquesAngePleureur.md.meta
+++ b/Assets/Documentation/RepertoireAttaquesAngePleureur.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c744849b7776408ca972861a156dcd3b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/RepertoireItemsUtilisables.md
+++ b/Assets/Documentation/RepertoireItemsUtilisables.md
@@ -1,0 +1,18 @@
+# Objets utilisables
+
+Ce document liste les objets consommables disponibles en combat et leurs usages recommandés pour soutenir les stratégies rythmiques de Symphonie.
+
+| Nom | Catégorie | Effet de base | Conseils d’utilisation |
+|-----|-----------|---------------|-------------------------|
+| **Potion Mélodique** | Consommable | Soigne ~12 000 PV à un allié. | À enchaîner avec *Accord Bienveillant* pour amortir les pluies de l’ange. |
+| **Élixir Revitalisant** | Consommable | Ranime un allié à 50 % de ses PV massifs. | Sauvetage indispensable après un *Crescendo* adverse ; combinez avec des runes de protection. |
+| **Clé du Courage** | Consommable | +1 500 Force pendant 2 tours. | Préparation idéale pour un duo *Rupture* + *Crescendo*. |
+| **Bombe Sonique** | Consommable | ~15 000 dégâts à tous les ennemis. | Permet de nettoyer un groupe avant qu’il n’impose ses altérations. |
+| **Endormissement** | Consommable | Endort une cible jusqu’à ce qu’elle subisse des dégâts. | À coupler avec les runes de contrôle ou *Pont Harmonique*. |
+| **Réveil** | Consommable | Réveille immédiatement un allié. | Neutralise l’*Étreinte du Linceul* ou les contre-mesures soporifiques. |
+| **Anti-Interception** | Consommable | Immunité à l’interception pendant 2 tours. | Garanti pour déplacer Munin ou Lucian sans risque lors des séquences narratives clés. |
+| **Longue Portée** | Consommable | +15 mètres de portée pour le tour en cours. | Offre des opportunités aux attaques à distance pendant les phases aériennes. |
+| **Extension d’Effets** | Consommable | Prolonge tous les effets d’un allié de 2 tours. | À lancer juste après un buff majeur (Clé du Courage, runes temporaires). |
+| **Métronome de Précision** | Consommable | +10 % fenêtre de parade/esquive pendant 2 tours. | Synchronise les joueurs experts avec les attaques rythmées des boss. |
+
+Ces réglages assurent une lecture claire pour les nouveaux venus tout en laissant aux stratèges expérimentés la possibilité d’exploiter pleinement les runes harmonisées d’Azazel.

--- a/Assets/Documentation/RepertoireItemsUtilisables.md.meta
+++ b/Assets/Documentation/RepertoireItemsUtilisables.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e43922a17e94f109c176a765de19bca
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/SystemeSetsInventaire.md
+++ b/Assets/Documentation/SystemeSetsInventaire.md
@@ -1,0 +1,57 @@
+# Système de sets d'inventaire et de répertoire musical
+
+Afin de respecter l'intention de Symphonie, chaque personnage jouable peut désormais
+configurer des ensembles de compétences et d'objets favoris. Ces sets permettent
+de mettre en avant les outils les plus utilisés tout en conservant l'accès complet
+à tout le répertoire d'un héros.
+
+## Principes généraux
+
+- **Accessibilité** : les débutants retrouvent immédiatement leurs actions
+  essentielles, affichées en tête de liste dans les menus de combat.
+- **Profondeur** : les joueurs expérimentés peuvent préparer plusieurs combinaisons
+  de MusicalMoves et d'Items pour adapter leur stratégie aux événements de
+  l'histoire décrite dans `HistoireSymphonie.md`.
+- **Souplesse** : lorsqu'aucun set n'est actif, l'ordre original est conservé et
+  toutes les actions restent disponibles sans restriction.
+
+## Configuration dans l'inspecteur Unity
+
+Chaque `CharacterData` expose deux nouvelles listes :
+
+1. **Sets personnalisés d'attaques musicales** (`musicalMoveSets`)
+   - `setName` : nom éditorial pour identifier rapidement le set.
+   - `prioritizedMoves` : liste ordonnée de `MusicalMoveSO` mis en avant.
+   - `defaultMusicalMoveSetIndex` permet de choisir le set actif par défaut
+     (mettre `-1` pour conserver l'ordre original).
+2. **Sets personnalisés d'items** (`itemSets`)
+   - `setName` : identifiant du regroupement d'objets.
+   - `prioritizedItems` : liste ordonnée des `ItemData` favoris.
+   - `defaultItemSetIndex` suit la même logique que pour les attaques.
+
+Les champs `currentMusicalMoveSetIndex` et `currentItemSetIndex` sont gérés
+automatiquement au lancement d'un combat.
+
+## Utilisation en jeu
+
+- Le menu de compétences appelle automatiquement `OrderMovesForCurrentSet` pour
+  afficher les MusicalMoves favoris en premier.
+- L'ouverture de l'inventaire utilise `OrderItemsForCurrentSet` afin de proposer
+  les objets clefs avant le reste de la réserve.
+- Les listes complètes restent intactes : si un set ne contient pas une entrée,
+  elle sera tout de même disponible après les favoris.
+
+## Conseils de conception
+
+- Créez un set « Apprentissage » avec trois actions simples pour les premiers
+  combats d'un personnage, puis un set « Maîtrise » reprenant les combinaisons
+  avancées reliées aux arcs narratifs de la symphonie.
+- N'oubliez pas de maintenir la documentation des MusicalMoves et Items lorsque
+  vous en créez de nouveaux : leurs descriptions doivent rester cohérentes avec
+  l'évolution de l'histoire.
+- Lors d'un changement majeur d'équipement (par exemple après une scène clé du
+  `Docs/HistoireSymphonie.md`), basculez vers un set adapté via
+  `CharacterUnit.ActivateMusicalMoveSet` ou `ActivateItemSet`.
+
+Ce système vise à fluidifier les combats tout en préservant la richesse
+chorégraphique propre à Symphonie.

--- a/Assets/Documentation/SystemeSetsInventaire.md.meta
+++ b/Assets/Documentation/SystemeSetsInventaire.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dbbe780d2e354c058f09c44877ba4830
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/SystemeSuccesPointOfInterest.md
+++ b/Assets/Documentation/SystemeSuccesPointOfInterest.md
@@ -1,0 +1,17 @@
+# Système de succès via PointOfInterest
+
+Ce document décrit la procédure pour débloquer un succès lorsque le joueur interagit avec un **PointOfInterest**.
+
+1. **Préparer les succès**
+   - Créez un `AchievementSO` pour chaque succès dans `Assets/Achievements`.
+   - Définissez un identifiant, un nom et une description en accord avec l'histoire (voir `Docs/HistoireSymphonie.md`).
+
+2. **Placer le gestionnaire**
+   - Assurez-vous qu'un `AchievementManager` est présent dans la scène et que la liste `achievements` contient tous les succès disponibles.
+
+3. **Configurer le PointOfInterest**
+   - Sur le composant `PointOfInterest`, renseignez le champ **Succès** avec l'`AchievementSO` à débloquer.
+   - Lors de l'interaction, le succès sera automatiquement débloqué si un `AchievementManager` actif est trouvé.
+   - L'interaction se fait via l'action `Interact` de la map d'entrées **World**, offrant une cohérence de contrôle pour tous les joueurs.
+
+Grâce à cette fonctionnalité, chaque point d'intérêt peut récompenser le joueur par un succès, renforçant ainsi la progression narrative et ludique.

--- a/Assets/Documentation/SystemeSuccesPointOfInterest.md.meta
+++ b/Assets/Documentation/SystemeSuccesPointOfInterest.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 728d6bd2b7004bbe9ad8eb9661719a95
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/SystemeSuccesTimeline.md
+++ b/Assets/Documentation/SystemeSuccesTimeline.md
@@ -1,0 +1,30 @@
+# Système de succès via Timeline
+
+Ce document explique comment déclencher des succès dans **Symphonie** à l'aide des signaux d'une Timeline.
+
+1. **Préparer les succès**
+   - Créez un `AchievementSO` pour chaque succès dans `Assets/Scripts/Classes`.
+   - Renseignez l'identifiant, le nom et la description du succès en tenant compte de l'histoire (voir `Docs/HistoireSymphonie.md`).
+
+2. **Placer le gestionnaire**
+   - Ajoutez l'objet `AchievementManager` dans votre scène principale et renseignez la liste `achievements` avec tous les succès disponibles.
+   - Lorsqu'un succès est débloqué, il quitte automatiquement cette liste pour être ajouté à `unlockedAchievements`, permettant de suivre facilement les progrès depuis l'inspecteur.
+
+   - L'objet est persistant entre les scènes pour conserver l'état des succès.
+
+3. **Déclencher depuis une Timeline**
+   - Ajoutez un composant `AchievementSignalReceiver` sur un objet présent sur la Timeline.
+   - Dans la Timeline, insérez un `Signal Emitter` et associez le succès à débloquer à l'événement `TriggerAchievement`.
+
+Grâce à cette approche, il est facile de lier l'obtention d'un succès à un moment narratif précis, qu'il s'agisse d'une cinématique ou d'une action de gameplay scénarisée.
+
+## Conditionner les dialogues avec les succès
+
+Les PNJ peuvent adapter leurs répliques en fonction des succès débloqués.  
+Dans l'inspecteur, utilisez la classe `ConditionalDialogue` pour lier un `AchievementSO` à un `DialogueContainer` alternatif.  
+Le dialogue alternatif est joué **uniquement** lorsque :
+
+1. le dialogue principal a déjà été présenté au joueur ;
+2. le succès requis est débloqué.
+
+Si l'une de ces conditions n'est pas remplie, le dialogue par défaut est rejoué.

--- a/Assets/Documentation/SystemeSuccesTimeline.md.meta
+++ b/Assets/Documentation/SystemeSuccesTimeline.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e4a909c8af242fd924058463d970f0b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/TypageHarmoniques.md
+++ b/Assets/Documentation/TypageHarmoniques.md
@@ -1,0 +1,13 @@
+# Typage des harmoniques
+
+Ce document détaille la manière dont chaque MusicalMove consomme et génère des harmoniques pour respecter la progression narrative et les combos recherchés.
+
+Chaque **MusicalMove** précise explicitement deux informations :
+- `consumedHarmonicType` : la couleur d'harmonique dépensée lors de l'utilisation.
+- `generatedHarmonicType` : la couleur d'harmonique rendue au lanceur lorsque le move génère un gain.
+
+Même lorsqu'un coût ou un gain vaut `0`, ces champs aident les joueuses et joueurs à planifier leurs combos et les designers à assurer la cohérence avec l'histoire (voir `Docs/HistoireSymphonie.md`). Les nouveaux moves doivent donc documenter leurs coûts et gains en précisant clairement ces types.
+
+Les **CharacterData** disposent en complément d'un champ `awakeHarmonicThreshold` (ancien `resonancePoint`) et d'un `baseHarmonicCharge`. Le premier indique la quantité à atteindre pour s'éveiller, tandis que le second fixe la réserve initiale en début de combat. Cette valeur de base pourra être modifiée dynamiquement par d'autres systèmes (objets, événements de narration, etc.).
+
+Cette précision rend l'apprentissage intuitif pour les débutants tout en révélant aux stratèges aguerris des fenêtres de combos alignées avec la légende de Symphonie.

--- a/Assets/Documentation/TypageHarmoniques.md.meta
+++ b/Assets/Documentation/TypageHarmoniques.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c8c0f7ca36eb472d84dec0f62b65ae89
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Documentation/VolumetricRays.md
+++ b/Assets/Documentation/VolumetricRays.md
@@ -1,0 +1,54 @@
+# Configuration des rayons volumétriques (HDRP)
+
+Ce document reprend la **recette "2 minutes"** utilisée pour faire apparaître des rayons de lumière visibles dans la forêt.
+Il peut servir de mémo rapide lors de la mise en place de nouvelles scènes.
+
+## Pré‑requis
+- Projet configuré avec le **High Definition Render Pipeline**.
+- HDRP Asset : `Volumetrics` activé en qualité **Medium** ou **High**.
+
+## Caméra
+- Dans les *Frame Settings Overrides* :
+  - `Volumetrics` **ON**
+  - `Shadows` **ON**
+  - `Atmospheric Scattering` **ON**
+
+## Lumière directionnelle (soleil)
+- Intensité : **60 000 – 100 000 Lux** (80 000 par défaut).
+- `Volumetrics` activé, **Multiplier** entre **1.3** et **2.0**.
+- `Shadow Dimmer` : **1** avec une résolution d'ombre ≥ **2048**.
+- Oriente le soleil bas (10–20°) et regarde vers lui avec la caméra pour profiter du *forward scattering*.
+
+## Volume global > Fog
+- `State` : **Enabled**
+- `Fog Attenuation Distance` : **70–120** (90 recommandé).
+- `Volumetric Fog` : **ON**
+- `Albedo` : très sombre (`#111` – `#222`).
+- `Anisotropy` : **0.85 – 0.9**
+- `Directional Lights Only` : **ON**
+- `Denoising` : **Gaussian**
+
+## Volume local de brume (clé)
+- Ajouter un **GameObject > Volume > Local Volumetric Fog** entre le soleil et le sol.
+- `Size` : environ **(10, 20, 10)** mètres.
+- `Volumetric Fog Distance` : **10 – 15**
+- `Anisotropy` : **0.9 – 0.95**
+- `Blend Distance` : **2 – 4**
+- Possibilité d'utiliser un *mask* 3D rayé pour des faisceaux plus nets.
+
+## Feuillage et ombres
+- Les matériaux de feuilles doivent **caster des ombres**.
+- Si un shader est `Transparent`, cocher `Transparent Receives Shadows` et activer `Alpha Clipping`.
+- Idéalement, utiliser un shader `Opaque + Alpha Clip` pour une découpe nette des rayons.
+
+## Exposure
+- Volume > `Exposure` : `Automatic` ou `Fixed` entre `0` et `+1 EV`.
+- Si l'image semble voilée, réduire l'`Exposure` ou augmenter le `Fog Attenuation Distance`.
+
+## Valeurs de départ qui fonctionnent
+- **Fog global** : `Attenuation 90`, `Anisotropy 0.85`
+- **Soleil** : `80 000 Lux`, `Volumetric Multiplier 1.5`, `Shadows 2048`
+- **2x Local Volumetric Fog** : `Size (10,20,10)`, `Distance 12`, `Anisotropy 0.9`, `Blend 3`
+- **Arbres** : `Alpha Clipping ON`, `Cast Shadows ON`, `Transparent Receives Shadows ON`
+
+Ce guide s'appuie sur l'histoire et l'ambiance de *Symphonie* : une forêt dense où la lumière matinale perce la canopée. Ajustez les valeurs selon les besoins des niveaux tout en conservant une ambiance accueillante pour les débutants et riche en possibilités pour les joueurs expérimentés.

--- a/Assets/Documentation/VolumetricRays.md.meta
+++ b/Assets/Documentation/VolumetricRays.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 34da87fe27d248188e2f40eea88414d8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- copy the existing markdown documentation into a new `Assets/Documentation` folder so that it is available inside Unity
- add Unity `.meta` files for the folder and each document

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915bcefdc548325859f410dc2417143)