### PR TITLE
Ajoute un répertoire des cités angéliques

### DIFF
--- a/Docs/CitesAngeliques.md
+++ b/Docs/CitesAngeliques.md
@@ -1,0 +1,20 @@
+# Répertoire des cités angéliques
+
+Ce document recense des cités liées aux fragments façonnés par Azazel ou aux enclaves restées fidèles au Rêve. Chaque lieu reprend une racine angélique pour souligner l'influence de l'iconographie céleste sur l'architecture et les mythes locaux.
+
+## Tableau des cités
+
+| Nom | État | Description | Rôle narratif |
+|-----|------|-------------|---------------|
+| **Amnistiel** | En ruines | Cité suspendue au-dessus d'un gouffre, dont les arches fracturées diffusent encore une lumière d'absolution. | Lucian y découvre les premiers fragments d'âmes sauvées par Azazel mais incapables de se souvenir de leur existence passée. |
+| **Monstiel** | Vivante | Métropole sanctuaire, éclairée par des vitraux mouvants qui projettent des visions du Rêve. | Point de rencontre avec des Séraphins hésitants, partageant leurs doutes sur la légitimité du plan d'Azazel. |
+| **Solastiel** | En ruines | Ancienne cité-jardin, minée par un chœur figé qui résonne en boucle. | Munin y perçoit l'échec du premier essai de Convocation, soulignant le danger de répéter les erreurs du passé. |
+| **Veilstiel** | Vivante | Ville-labyrinthe protégée par des illusions mélodiques que seuls les harmonistes peuvent dissiper. | Sert de terrain d'entraînement pour maîtriser les harmoniques croisées entre Lucian et ses alliés. |
+| **Abyssiel** | En ruines | Capitale submergée dont les cloches englouties émettent des basses presque inaudibles. | Les résonances y dévoilent comment Azazel tente de stabiliser les âmes en les enchaînant au fond des eaux. |
+| **Seraphiel** | Vivante | Cité-pilier connectant les branches du rêve de Munin aux mémoires du monde réel. | Dernier bastion loyal au Rêve ; Lucian doit y négocier un accès vers la Source sans déclencher la purge. |
+
+## Utilisation dans le jeu
+
+- Ces cités peuvent servir de chapitres ou de hubs secondaires, chacun introduisant une harmonique dominante et des variations de gameplay adaptées (hauteur, illusions, tempo).
+- Les ruines offrent des occasions de révéler les conséquences des expériences d'Azazel, tandis que les cités encore vivantes questionnent la frontière entre loyauté au Rêve et empathie pour les âmes perdues.
+- Intégrer ces noms et leurs atmosphères dans les dialogues et descriptions environnementales permettra de renforcer la cohérence avec l'histoire principale détaillée dans `HistoireSymphonie.md`.

--- a/Docs/IndexDocumentation.md
+++ b/Docs/IndexDocumentation.md
@@ -6,6 +6,7 @@ Ce document décrit l'organisation thématique des fichiers de `Docs/` afin de r
 - `HistoireSymphonie.md` : chronologie détaillée des arcs principaux.
 - `AngePleureur.md` : découpage du combat contre l’Ange Pleureur.
 - `Quotes.md` : citations clés à réutiliser dans les dialogues.
+- `CitesAngeliques.md` : répertoire des cités emblématiques aux racines angéliques.
 
 ## Thèmes gameplay
 - `LimitesUtilisationActions.md` : paramétrage des limites d'utilisation pour les MusicalMoves et Items.


### PR DESCRIPTION
## Résumé
- documente un ensemble de cités angéliques, en ruines ou encore habitées, et leur rôle narratif
- référence le nouveau document dans l’index de la documentation

## Tests
- aucun test nécessaire (mise à jour documentaire)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a512b9d48325a26dfb6cdadd2e99)