### PR TITLE
Cache ConcentrationSystem lookup in CharacterUnit

### DIFF
--- a/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
+++ b/Assets/Scripts/MonoBehavioursUsed/CharacterUnit.cs
@@ -36,6 +36,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     private SpriteRenderer spriteRenderer;
     private AudioSource audioSource;
     [HideInInspector] public Animator animator;
+    private ConcentrationSystem concentrationSystem;
     // Indicateur évitant les multiples avertissements lorsque l'Animator enfant est introuvable.
     private bool hasLoggedMissingChildAnimator;
     // Indicateur évitant de répéter les avertissements lorsqu'on détecte plusieurs Animator valides chez les enfants.
@@ -838,6 +839,14 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         // Les timelines sont déclenchées manuellement, on désactive donc toute
         // lecture automatique pour éviter une répétition non désirée en scène.
         battleDirector.playOnAwake = false;
+
+        CacheConcentrationSystem();
+    }
+
+    private void CacheConcentrationSystem()
+    {
+        if (concentrationSystem == null)
+            TryGetComponent(out concentrationSystem);
     }
 
     public CharacterType characterType => Data.characterType;
@@ -1021,6 +1030,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         animator = GetCasterAnimator(forceRefresh: true);
         awakeState = GetComponent<AwakeState>();
         isIdleActive = false; // L'unité n'est pas encore en Idle : permet de jouer le son d'entrée lors du premier appel.
+        CacheConcentrationSystem();
 
         // Setup graphique
         if (spriteRenderer != null && Data.portrait != null)
@@ -1032,7 +1042,7 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
 
         if (customBar != null)
         {
-            var concentration = GetComponent<ConcentrationSystem>();
+            var concentration = concentrationSystem;
             if (concentration != null)
             {
                 customBar.SetMaxValue(concentration.maxConcentration);
@@ -1372,7 +1382,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
     {
         if (customBar != null)
         {
-            var concentration = GetComponent<ConcentrationSystem>();
+            CacheConcentrationSystem();
+            var concentration = concentrationSystem;
             if (concentration != null)
                 customBar.SetValue(concentration.currentConcentration);
             else
@@ -1471,7 +1482,8 @@ public class CharacterUnit : MonoBehaviour, IDamageable, IHealable, IBuffable, I
         // Lance l'animation de blessure adaptée à la direction de l'attaquant
         PlayHurtAnimation(attacker);
         GetComponent<SleepStatus>()?.OnDamageTaken();
-        GetComponent<ConcentrationSystem>()?.OnDamageTaken(amount);
+        CacheConcentrationSystem();
+        concentrationSystem?.OnDamageTaken(amount);
         if (Data != null && Data.gameplayType == GameplayType.Rage)
         {
             GetComponent<RageSystem>()?.AddRage(amount);


### PR DESCRIPTION
### Motivation
- Reduce per-frame cost caused by repeated `GetComponent<ConcentrationSystem>()` calls in `CharacterUnit` update paths.
- Improve runtime performance on scenes with many units by caching frequently accessed components.
- Make `CustomBar` updates and damage handling lower-overhead without changing visible behavior.
- Align with existing project optimizations that prefer cached references and `TryGetComponent` usage.

### Description
- Added a private `ConcentrationSystem concentrationSystem` field and a `CacheConcentrationSystem()` helper to `CharacterUnit`.
- Populate the cache in `Awake()` and during initialization using `TryGetComponent` to avoid costly lookups.
- Replaced direct `GetComponent<ConcentrationSystem>()` calls in `Initialize`, `HandleCustomBarValue`, and `TakeDamage` with the cached reference.
- Changes preserve behavior when the component is absent by falling back to existing logic (no public API or serialized field changes).

### Testing
- No automated tests were run for this change.
- Recommend running `unity -projectPath . -runTests -testPlatform editmode` and `unity -projectPath . -runTests -testPlatform playmode` before merging.
- Please perform a short manual playthrough of combat scenarios to verify `CustomBar` updates and damage reactions remain correct.
- The code falls back gracefully when `ConcentrationSystem` is not present, so behavior should remain unchanged in that case.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a7a5d4e88325a16bd5a236884cd5)